### PR TITLE
feat(cli): add `devbrain version` subcommand

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1093,7 +1093,9 @@ def version() -> None:
         tree_str = "git not available"
     else:
         commit_str = commit
-        branch_str = branch if branch is not None else "git not available"
+        # `--abbrev-ref HEAD` returns the literal "HEAD" in detached state
+        # (e.g. CI checkouts by SHA). Surface that as "(detached)".
+        branch_str = "(detached)" if branch in (None, "HEAD") else branch
         tree_str = "clean" if porcelain == "" else "dirty"
 
     click.echo(f"commit: {commit_str}")

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1062,6 +1062,46 @@ def devdoctor(as_json: bool, fix: bool) -> None:
             click.echo("✅ All checks passed.")
 
 
+@cli.command(name="version")
+def version() -> None:
+    """Print DevBrain version info: git commit, branch, working tree, DEVBRAIN_HOME."""
+    import subprocess
+    from config import DEVBRAIN_HOME
+
+    def _git(args: list[str]) -> str | None:
+        try:
+            result = subprocess.run(
+                ["git", *args],
+                cwd=str(DEVBRAIN_HOME),
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (FileNotFoundError, subprocess.SubprocessError):
+            return None
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip()
+
+    commit = _git(["rev-parse", "--short", "HEAD"])
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"])
+    porcelain = _git(["status", "--porcelain"])
+
+    if commit is None:
+        commit_str = "git not available"
+        branch_str = "git not available"
+        tree_str = "git not available"
+    else:
+        commit_str = commit
+        branch_str = branch if branch is not None else "git not available"
+        tree_str = "clean" if porcelain == "" else "dirty"
+
+    click.echo(f"commit: {commit_str}")
+    click.echo(f"branch: {branch_str}")
+    click.echo(f"working tree: {tree_str}")
+    click.echo(f"DEVBRAIN_HOME: {DEVBRAIN_HOME}")
+
+
 @cli.command(name="doctor", hidden=True)
 @click.option("--json", "as_json", is_flag=True, help="Emit JSON instead of text")
 @click.option("--fix", is_flag=True, help="Interactively remediate WARN/FAIL items")

--- a/factory/tests/test_cli.py
+++ b/factory/tests/test_cli.py
@@ -98,6 +98,9 @@ def test_version_command(runner):
     assert "branch:" in result.output
     assert "working tree:" in result.output
     assert "DEVBRAIN_HOME:" in result.output
+    # Guard against silent field drops: each label appears exactly once.
+    for label in ("commit:", "branch:", "working tree:", "DEVBRAIN_HOME:"):
+        assert result.output.count(label) == 1, f"{label} should appear once"
 
 
 def test_version_help(runner):

--- a/factory/tests/test_cli.py
+++ b/factory/tests/test_cli.py
@@ -88,3 +88,19 @@ def test_dashboard_command_exists(runner):
     result = runner.invoke(cli, ["dashboard", "--help"])
     assert result.exit_code == 0
     assert "dashboard" in result.output.lower()
+
+
+def test_version_command(runner):
+    """devbrain version runs without error and prints all four fields."""
+    result = runner.invoke(cli, ["version"])
+    assert result.exit_code == 0
+    assert "commit:" in result.output
+    assert "branch:" in result.output
+    assert "working tree:" in result.output
+    assert "DEVBRAIN_HOME:" in result.output
+
+
+def test_version_help(runner):
+    """devbrain version --help works."""
+    result = runner.invoke(cli, ["version", "--help"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- Adds `devbrain version` subcommand printing commit SHA, branch, working-tree status, and `DEVBRAIN_HOME`.
- Gracefully handles the "git not on PATH" and "not a git repo" cases.
- Detached-HEAD state renders as `branch: (detached)` instead of the literal `HEAD`.

Produced by the DevBrain factory in two autonomous passes:
- Job `81f58667` — initial implementation + tests
- Job `05877d68` — refinement per review findings (1 WARNING + 3 NITs)

Both passes ran through planning → implementing → reviewing (arch + security) → QA → ready_for_approval with zero fix-loop iterations required.

## Test plan
- [ ] `devbrain version` prints all four fields
- [ ] `devbrain version --help` works
- [ ] `pytest factory/tests/test_cli.py::test_version_command factory/tests/test_cli.py::test_version_help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)