### PR TITLE
feat(factory): add optional `branch` parameter to factory_plan

### DIFF
--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -244,6 +244,81 @@ class FactoryOrchestrator:
         except Exception as exc:
             logger.warning("readiness-block notification failed (non-blocking): %s", exc)
 
+    def _setup_implementation_branch(
+        self, job: FactoryJob, project_root: str
+    ) -> tuple[str | None, str | None]:
+        """Resolve the git branch implementation should run on.
+
+        If ``job.branch_name`` is set:
+          - main/master (case-insensitive) → return ``(None, fail_msg)`` so the
+            caller can transition the job to FAILED. Factory jobs must operate
+            on feature branches; running them on shared trunk is unsafe.
+          - existing branch → ``git checkout`` it. Dirty tree is warned but not
+            blocking — the user opted in by naming the branch explicitly.
+          - missing branch → log a warning and fall through to auto-create.
+
+        Otherwise auto-create ``factory/<job-id>/<slug>`` (the original
+        no-branch behavior).
+
+        Returns ``(branch_name, fail_msg)`` where exactly one is non-None on
+        the failure path; on success ``fail_msg`` is None and ``branch_name``
+        may still be None if git invocation failed (matching prior behavior —
+        the implementation phase proceeds on the current branch).
+        """
+        if job.branch_name:
+            name = job.branch_name.strip()
+            if name.lower() in ("main", "master"):
+                return (
+                    None,
+                    f"Refusing to run factory job on '{name}' — factory jobs "
+                    "operate on feature branches only.",
+                )
+
+            checkout = None
+            try:
+                checkout = subprocess.run(
+                    ["git", "checkout", name],
+                    cwd=project_root, capture_output=True, text=True, timeout=10,
+                )
+            except Exception as e:
+                logger.warning(
+                    "git checkout %s raised (%s) — falling back to auto-create",
+                    name, e,
+                )
+
+            if checkout is not None and checkout.returncode == 0:
+                try:
+                    status = subprocess.run(
+                        ["git", "status", "--porcelain"],
+                        cwd=project_root, capture_output=True, text=True, timeout=10,
+                    )
+                    if status.returncode == 0 and status.stdout.strip():
+                        logger.warning(
+                            "Branch '%s' has uncommitted changes — proceeding anyway",
+                            name,
+                        )
+                except Exception:
+                    pass
+                return (name, None)
+
+            stderr = (checkout.stderr if checkout is not None else "").strip()
+            logger.warning(
+                "Branch '%s' does not exist (%s) — falling back to auto-generated branch",
+                name, stderr[:200],
+            )
+
+        slug = re.sub(r'[^a-z0-9-]', '-', job.title.lower())[:40].strip('-')
+        branch = f"factory/{job.id[:8]}/{slug}"
+        try:
+            subprocess.run(
+                ["git", "checkout", "-b", branch],
+                cwd=project_root, capture_output=True, timeout=10,
+            )
+        except Exception as e:
+            logger.warning("Branch creation failed: %s", e)
+            branch = None
+        return (branch, None)
+
     def _get_cli(self, phase: str, job: FactoryJob) -> str:
         """Get the CLI to use for a phase."""
         return job.assigned_cli or DEFAULT_CLI_ASSIGNMENTS.get(phase, "claude")
@@ -439,18 +514,13 @@ Store the final plan in DevBrain using the store tool with type="decision"."""
 
                 return blocked_job
 
-            # No conflicts — create branch and proceed
-            slug = re.sub(r'[^a-z0-9-]', '-', job.title.lower())[:40].strip('-')
-            branch = f"factory/{job.id[:8]}/{slug}"
-            try:
-                subprocess.run(
-                    ["git", "checkout", "-b", branch],
-                    cwd=project_root, capture_output=True, timeout=10,
+            # No conflicts — set up branch (auto-create or use job.branch_name)
+            branch, fail_msg = self._setup_implementation_branch(job, project_root)
+            if fail_msg:
+                return self.db.transition(
+                    job.id, JobStatus.FAILED,
+                    metadata={"failure": fail_msg},
                 )
-            except Exception as e:
-                logger.warning("Branch creation failed: %s", e)
-                branch = None
-
             return self.db.transition(job.id, JobStatus.IMPLEMENTING, branch_name=branch)
         else:
             return self.db.transition(job.id, JobStatus.FAILED,
@@ -552,18 +622,14 @@ Store the final plan in DevBrain using the store tool with type="decision"."""
             )
             conn.commit()
 
-        # Create branch (same logic as _run_planning success path)
+        # Set up branch (auto-create or use job.branch_name)
         project_root = self._get_project_root(job)
-        slug = re.sub(r'[^a-z0-9-]', '-', job.title.lower())[:40].strip('-')
-        branch = f"factory/{job.id[:8]}/{slug}"
-        try:
-            subprocess.run(
-                ["git", "checkout", "-b", branch],
-                cwd=project_root, capture_output=True, timeout=10,
+        branch, fail_msg = self._setup_implementation_branch(job, project_root)
+        if fail_msg:
+            return self.db.transition(
+                job.id, JobStatus.FAILED,
+                metadata={"failure": fail_msg},
             )
-        except Exception as e:
-            logger.warning("Branch creation failed: %s", e)
-            branch = None
 
         # Fire unblocked notification
         self._fire_unblocked_notification(job)

--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -41,6 +41,39 @@ Search DevBrain BEFORE assuming anything about architecture, past decisions, or 
 """
 
 
+# Branch-name safety regex. Mirrors SAFE_BRANCH_RE in
+# mcp-server/src/index.ts — defense in depth for the case where
+# job.branch_name was set outside the MCP tool's zod validator
+# (direct SQL writes, migrations, API bypasses). Rejects shapes
+# that would let a crafted value reach git as an option flag
+# (leading "-"), a refspec (contains ":"), or shell metachars.
+SAFE_BRANCH_RE = re.compile(r'^[A-Za-z0-9_][A-Za-z0-9_./-]{0,254}$')
+
+
+def _validate_branch_name(name: str) -> str | None:
+    """Return None if the branch name is safe to pass to git subprocess
+    calls, else a human-readable failure message describing why.
+
+    Runs the same checks the MCP factory_plan tool applies at submission
+    time (see SAFE_BRANCH_RE), plus the main/master guard. Keep the two
+    validators in sync when updating either.
+    """
+    stripped = name.strip()
+    if not stripped:
+        return "branch name is empty or whitespace"
+    if not SAFE_BRANCH_RE.match(stripped):
+        return (
+            f"branch name has unsafe characters: {name!r} — only "
+            "[A-Za-z0-9_./-] allowed, cannot start with '-' or '.'"
+        )
+    if stripped.lower() in ("main", "master"):
+        return (
+            f"Refusing to run factory job on '{stripped}' — factory jobs "
+            "operate on feature branches only."
+        )
+    return None
+
+
 def _count_blocking(text: str) -> int:
     """Count actual BLOCKING findings — look for the marker at start of line or list item."""
     # Match patterns like "BLOCKING:", "**BLOCKING**", "1. BLOCKING:", "- BLOCKING:"
@@ -266,13 +299,15 @@ class FactoryOrchestrator:
         the implementation phase proceeds on the current branch).
         """
         if job.branch_name:
+            # Fail-closed validation before anything reaches git. The MCP
+            # tool validates on submission, but direct DB writes or
+            # migrations could set an unsafe value; this second check
+            # ensures the orchestrator never passes attacker-controlled
+            # input to `git checkout`/`git push` as an unquoted positional.
+            fail = _validate_branch_name(job.branch_name)
+            if fail:
+                return (None, fail)
             name = job.branch_name.strip()
-            if name.lower() in ("main", "master"):
-                return (
-                    None,
-                    f"Refusing to run factory job on '{name}' — factory jobs "
-                    "operate on feature branches only.",
-                )
 
             checkout = None
             try:

--- a/factory/tests/test_orchestrator_branch_setup.py
+++ b/factory/tests/test_orchestrator_branch_setup.py
@@ -1,0 +1,190 @@
+"""Tests for FactoryOrchestrator._setup_implementation_branch.
+
+Covers the four documented branch-resolution paths:
+    1. branch_name unset → auto-create factory/<id>/<slug> (regression)
+    2. branch_name set, branch exists → checkout + return name
+    3. branch_name set, branch missing → warn + fall back to auto-create
+    4. branch_name in {main, master} (case-insensitive) → return fail_msg
+
+The helper invokes ``orchestrator.subprocess.run`` directly, so we
+monkeypatch it on the imported module to avoid touching git.
+"""
+import logging
+
+import pytest
+
+import orchestrator as orchestrator_module
+from config import DATABASE_URL
+from orchestrator import FactoryOrchestrator
+from state_machine import FactoryDB
+
+TEST_TITLE_PREFIX = "fbranch_setup_"
+
+
+@pytest.fixture
+def db():
+    return FactoryDB(DATABASE_URL)
+
+
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            (f"{TEST_TITLE_PREFIX}%",),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_cleanup_reports WHERE job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts WHERE job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)",
+                (ids,),
+            )
+        conn.commit()
+
+
+@pytest.fixture
+def orch():
+    return FactoryOrchestrator(DATABASE_URL)
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _make_job(db: FactoryDB, title: str, branch_name: str | None = None):
+    job_id = db.create_job(project_slug="devbrain", title=title, spec="test")
+    if branch_name is not None:
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "UPDATE devbrain.factory_jobs SET branch_name = %s WHERE id = %s",
+                (branch_name, job_id),
+            )
+            conn.commit()
+    return db.get_job(job_id)
+
+
+def test_no_branch_set_auto_creates_factory_branch(orch, db, monkeypatch):
+    """Regression: branch_name unset → auto-create factory/<id>/<slug>."""
+    job = _make_job(db, f"{TEST_TITLE_PREFIX}auto_create")
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(orchestrator_module.subprocess, "run", fake_run)
+
+    branch, fail_msg = orch._setup_implementation_branch(job, "/tmp")
+
+    assert fail_msg is None
+    assert branch is not None
+    assert branch.startswith(f"factory/{job.id[:8]}/")
+    assert calls == [["git", "checkout", "-b", branch]]
+
+
+def test_existing_branch_is_checked_out(orch, db, monkeypatch):
+    """branch_name set + branch exists → checkout it, return its name."""
+    job = _make_job(
+        db, f"{TEST_TITLE_PREFIX}existing", branch_name="feature/existing-x"
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        # checkout succeeds; status reports clean working tree
+        return _FakeCompleted(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(orchestrator_module.subprocess, "run", fake_run)
+
+    branch, fail_msg = orch._setup_implementation_branch(job, "/tmp")
+
+    assert fail_msg is None
+    assert branch == "feature/existing-x"
+    # First invocation checks out the requested branch (no -b).
+    assert calls[0] == ["git", "checkout", "feature/existing-x"]
+    # No auto-create fallback should have fired.
+    assert not any("-b" in c for c in calls)
+
+
+def test_missing_branch_falls_back_with_warning(orch, db, monkeypatch, caplog):
+    """branch_name set + branch missing → warn, fall back to auto-create."""
+    job = _make_job(
+        db, f"{TEST_TITLE_PREFIX}missing", branch_name="feature/does-not-exist"
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == ["git", "checkout", "feature/does-not-exist"]:
+            return _FakeCompleted(
+                returncode=1,
+                stderr=(
+                    "error: pathspec 'feature/does-not-exist' did not match "
+                    "any file(s) known to git"
+                ),
+            )
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(orchestrator_module.subprocess, "run", fake_run)
+
+    with caplog.at_level(logging.WARNING, logger=orchestrator_module.__name__):
+        branch, fail_msg = orch._setup_implementation_branch(job, "/tmp")
+
+    assert fail_msg is None
+    assert branch is not None
+    assert branch.startswith(f"factory/{job.id[:8]}/")
+    # Both the failed checkout and the auto-create should have happened.
+    assert ["git", "checkout", "feature/does-not-exist"] in calls
+    assert any(c[:3] == ["git", "checkout", "-b"] for c in calls)
+    assert any("does not exist" in m for m in caplog.messages)
+
+
+def test_main_branch_is_refused(orch, db, monkeypatch):
+    """branch_name = 'main' → return fail_msg, do not invoke git."""
+    job = _make_job(db, f"{TEST_TITLE_PREFIX}main", branch_name="main")
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(orchestrator_module.subprocess, "run", fake_run)
+
+    branch, fail_msg = orch._setup_implementation_branch(job, "/tmp")
+
+    assert branch is None
+    assert fail_msg is not None
+    assert "main" in fail_msg
+    assert "feature branches" in fail_msg
+    assert calls == []
+
+
+def test_master_branch_is_refused_case_insensitive(orch, db, monkeypatch):
+    """branch_name = 'MASTER' → also refused; check happens case-insensitively."""
+    job = _make_job(db, f"{TEST_TITLE_PREFIX}master", branch_name="MASTER")
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(orchestrator_module.subprocess, "run", fake_run)
+
+    branch, fail_msg = orch._setup_implementation_branch(job, "/tmp")
+
+    assert branch is None
+    assert fail_msg is not None
+    assert "MASTER" in fail_msg
+    assert calls == []

--- a/factory/tests/test_orchestrator_branch_setup.py
+++ b/factory/tests/test_orchestrator_branch_setup.py
@@ -188,3 +188,85 @@ def test_master_branch_is_refused_case_insensitive(orch, db, monkeypatch):
     assert fail_msg is not None
     assert "MASTER" in fail_msg
     assert calls == []
+
+
+# ─── Injection-shape guards ────────────────────────────────────────────────
+# The following cases cover branch names that would be parsed by git as
+# flags or refspecs if passed through without validation. Each must
+# fail-closed BEFORE any subprocess call — the assertion on `calls == []`
+# is the real security check.
+
+@pytest.mark.parametrize(
+    "name,reason",
+    [
+        ("--help", "leading '-' → git flag"),
+        ("--receive-pack=echo", "leading '-' with = → RCE on push"),
+        ("-feature", "single leading '-'"),
+        ("feature:refs/heads/main", "refspec form → main bypass"),
+        ("feat with space", "whitespace → shell metachar"),
+        ("feat~1", "git refspec shorthand"),
+        ("feat^", "git refspec shorthand"),
+        ("..escape", "leading dots"),
+        (".hidden", "leading dot"),
+        ("feat\\back", "backslash"),
+        ("feat[glob", "brackets"),
+        ("feat*star", "glob"),
+        ("   ", "whitespace only"),
+        # Note: branch_name == "" falls through `if job.branch_name:` as
+        # falsy, taking the auto-create path — that's the "no branch
+        # provided" case, not an injection attempt. Empty is handled by
+        # the existing no-branch test, not here.
+    ],
+)
+def test_unsafe_branch_names_refused_without_running_git(
+    orch, db, monkeypatch, name, reason
+):
+    """Every unsafe branch shape must fail validation BEFORE any
+    subprocess call — the zod layer catches fresh submissions, this
+    protects the orchestrator from direct-DB bypasses."""
+    job = _make_job(
+        db, f"{TEST_TITLE_PREFIX}unsafe_{hash(name) & 0xffffff:x}",
+        branch_name=name,
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(orchestrator_module.subprocess, "run", fake_run)
+
+    branch, fail_msg = orch._setup_implementation_branch(job, "/tmp")
+
+    assert branch is None, f"expected refusal for {name!r} ({reason})"
+    assert fail_msg is not None
+    # Critical: no git invocation should have fired for any of these.
+    assert calls == [], f"git was called with unsafe branch {name!r}: {calls}"
+
+
+def test_safe_branch_names_pass_validation(orch, db, monkeypatch):
+    """Sanity check: ordinary branch names still work post-hardening."""
+    safe_names = [
+        "feature/my-work",
+        "factory/abc12345/some-title",
+        "user_fix_123",
+        "release-1.2.3",
+        "fix/ABC-42",
+    ]
+    for name in safe_names:
+        job = _make_job(
+            db, f"{TEST_TITLE_PREFIX}safe_{hash(name) & 0xffffff:x}",
+            branch_name=name,
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            return _FakeCompleted(returncode=0)
+
+        monkeypatch.setattr(orchestrator_module.subprocess, "run", fake_run)
+
+        branch, fail_msg = orch._setup_implementation_branch(job, "/tmp")
+        assert fail_msg is None, f"rejected valid name {name!r}: {fail_msg}"
+        assert branch == name
+        assert calls and calls[0][:2] == ["git", "checkout"]

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -405,6 +405,48 @@ server.tool(
 
 // ─── Tool: factory_plan ──────────────────────────────────────────────────────
 
+// Branch-name validation.
+//
+// A user-supplied branch string eventually reaches `git checkout <name>` and
+// `git push -u origin <name>` inside the orchestrator. Without validation
+// two concrete attacks work:
+//
+// 1. Leading "-" → git parses as flag.
+//    `branch: "--help"` turns `git checkout -- help` effectively no-op;
+//    worse, `branch: "--receive-pack=<cmd>"` on a later push invokes the
+//    attacker's command on the remote (genuine RCE on servers that honor
+//    the flag). Valid git refnames never begin with `-`.
+//
+// 2. Refspec form → bypasses main/master guard.
+//    `branch: "feature:refs/heads/main"` is a valid git refspec. A naive
+//    `name.toLowerCase() in {"main","master"}` check doesn't match, but
+//    `git push origin feature:refs/heads/main` happily pushes onto main.
+//    Safe refnames don't contain `:`.
+//
+// The regex below matches plain git refnames only: starts with an
+// alphanumeric or underscore (so "-" and "." are excluded up front),
+// then safe chars only. This is stricter than git's own `check-ref-format`
+// but deliberately so — we'd rather reject an exotic-but-valid name than
+// accept any of the attack shapes above.
+const SAFE_BRANCH_RE = /^[A-Za-z0-9_][A-Za-z0-9_./-]{0,254}$/
+const branchSchema = z
+  .string()
+  .trim()
+  .min(1, 'branch must not be empty or whitespace-only')
+  .max(255)
+  .regex(
+    SAFE_BRANCH_RE,
+    'branch has unsafe characters — only [A-Za-z0-9_./-] allowed, cannot start with "-" or "."',
+  )
+  .refine(
+    (v) => v.toLowerCase() !== 'main' && v.toLowerCase() !== 'master',
+    { message: 'branch must not be main or master — factory operates on feature branches only' },
+  )
+  .optional()
+  .describe(
+    'Optional existing branch to continue work on. If unset, factory creates factory/<id>/<slug>. Refuses main/master and unsafe refnames synchronously; falls back to auto-create with a warning if the (validated) branch does not exist.',
+  )
+
 server.tool(
   'factory_plan',
   'Submit a feature to the dev factory for autonomous implementation. Creates a job that will be planned, implemented, reviewed, QA tested, and staged for your approval.',
@@ -415,7 +457,7 @@ server.tool(
     priority: z.number().optional().default(0).describe('Priority (higher = more urgent)'),
     assigned_cli: z.string().optional().describe('CLI to use: claude, codex, gemini (default: claude)'),
     submitted_by: z.string().optional().describe('Dev identifier (SSH user) who submitted this job'),
-    branch: z.string().optional().describe('Optional existing branch to continue work on. If unset, factory creates factory/<id>/<slug>. Refuses main/master; falls back to auto-create with a warning if the branch does not exist.'),
+    branch: branchSchema,
   },
   async ({ project, title, spec, priority, assigned_cli, submitted_by, branch }) => {
     const projectId = await resolveProjectId(project)

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -415,8 +415,9 @@ server.tool(
     priority: z.number().optional().default(0).describe('Priority (higher = more urgent)'),
     assigned_cli: z.string().optional().describe('CLI to use: claude, codex, gemini (default: claude)'),
     submitted_by: z.string().optional().describe('Dev identifier (SSH user) who submitted this job'),
+    branch: z.string().optional().describe('Optional existing branch to continue work on. If unset, factory creates factory/<id>/<slug>. Refuses main/master; falls back to auto-create with a warning if the branch does not exist.'),
   },
-  async ({ project, title, spec, priority, assigned_cli, submitted_by }) => {
+  async ({ project, title, spec, priority, assigned_cli, submitted_by, branch }) => {
     const projectId = await resolveProjectId(project)
     if (!projectId) {
       return { content: [{ type: 'text', text: `Project "${project}" not found.` }] }
@@ -424,10 +425,10 @@ server.tool(
 
     const result = await query<{ id: string }>(
       `INSERT INTO devbrain.factory_jobs
-          (project_id, title, spec, status, priority, current_phase, assigned_cli, max_retries, submitted_by)
-       VALUES ($1, $2, $3, 'queued', $4, 'queued', $5, 5, $6)
+          (project_id, title, spec, status, priority, current_phase, assigned_cli, max_retries, submitted_by, branch_name)
+       VALUES ($1, $2, $3, 'queued', $4, 'queued', $5, 5, $6, $7)
        RETURNING id`,
-      [projectId, title, spec, priority, assigned_cli ?? 'claude', submitted_by ?? process.env.USER ?? null],
+      [projectId, title, spec, priority, assigned_cli ?? 'claude', submitted_by ?? process.env.USER ?? null, branch ?? null],
     )
 
     const jobId = result.rows[0].id


### PR DESCRIPTION
## Summary
- Adds optional `branch` parameter to `mcp__devbrain__factory_plan` so follow-up jobs can continue work on an existing factory branch instead of always creating a new one.
- Extracts `_setup_implementation_branch()` helper to dedupe branch-resolution logic across the planning and resume paths.
- Hardens the branch-name input against git option-injection (CVE-class issues caught in security review).

Produced by the DevBrain factory in two passes:
- Job `c3c06db8` — initial implementation (first successful run under the new per-phase max-turns budget; implementing took 15 min under the 150-turn ceiling after three prior specs hit the old 50-turn wall).
- Hand-fix `02cc477` — addressed 2 BLOCKING findings from the security review: leading-`-` flag injection (e.g. `--receive-pack=<cmd>` → RCE on push) and refspec-form bypass (`feature:refs/heads/main` sneaking around the main/master guard).

## Behavior
- `branch` omitted → original behavior: auto-create `factory/<id>/<slug>`.
- `branch` is a valid feature branch that exists → checkout it, skip auto-create.
- `branch` does not exist → log a warning, fall back to auto-create.
- `branch` = main/master (case-insensitive) → refuse synchronously at the MCP layer.
- `branch` has unsafe characters (leading `-`, `:`, whitespace, shell metachars) → refuse at the MCP zod layer AND at the orchestrator's validation (defense-in-depth for direct-DB writes).

## Validation
`SAFE_BRANCH_RE = /^[A-Za-z0-9_][A-Za-z0-9_./-]{0,254}$/` — same rule applied at both layers. Stricter than git's `check-ref-format` intentionally; rather reject exotic-but-valid names than accept anything that could be parsed as a flag or refspec.

## Test plan
- [ ] `pytest factory/tests/test_orchestrator_branch_setup.py` — 19 tests (5 behavioral + 13 unsafe-name parametrized + 1 safe-name regression).
- [ ] Submit a factory_plan with `branch="feature/existing"` and verify orchestrator checks it out.
- [ ] Submit a factory_plan with `branch="--receive-pack=id"` and verify MCP rejects synchronously with no planning run.
- [ ] Submit a factory_plan with `branch="feature:refs/heads/main"` and verify same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)