### PR TITLE
feat(factory): plumb warning_count into factory_artifacts

### DIFF
--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -62,6 +62,24 @@ def _extract_blocking_items(text: str) -> list[str]:
     return items
 
 
+def _count_warning(text: str) -> int:
+    """Count actual WARNING findings — look for the marker at start of line or list item."""
+    pattern = r'(?:^|\n)\s*(?:\d+\.\s*|\*\*?|-\s*)?WARNING\b'
+    return len(re.findall(pattern, text, re.IGNORECASE))
+
+
+def _extract_warning_items(text: str) -> list[str]:
+    """Extract individual WARNING finding texts."""
+    items = []
+    parts = re.split(r'(?:^|\n)\s*(?:\d+\.\s*|\*\*?|-\s*)?WARNING[:\s]*', text, flags=re.IGNORECASE)
+    for part in parts[1:]:
+        end = re.search(r'\n\s*(?:\d+\.\s*|\*\*?|-\s*)?(?:BLOCKING|NIT|WARNING)\b', part, re.IGNORECASE)
+        item = part[:end.start()].strip() if end else part.strip()
+        if item:
+            items.append(item)
+    return items
+
+
 class FactoryOrchestrator:
     """Orchestrates the dev factory pipeline."""
 
@@ -775,6 +793,7 @@ If this is a re-review round, explicitly state which prior findings are RESOLVED
                               phase="review_arch")
 
         blocking_count = _count_blocking(arch_result.stdout)
+        warning_count = _count_warning(arch_result.stdout)
         self.db.store_artifact(
             job_id=job.id,
             phase="review",
@@ -783,6 +802,7 @@ If this is a re-review round, explicitly state which prior findings are RESOLVED
             model_used=arch_cli,
             findings_count=arch_result.stdout.count("\n- ") + arch_result.stdout.count("\n1."),
             blocking_count=blocking_count,
+            warning_count=warning_count,
         )
 
         # Security/HIPAA review
@@ -831,6 +851,7 @@ Store any security issues found in DevBrain with type="issue" and category="secu
                              phase="review_security")
 
         sec_blocking = _count_blocking(sec_result.stdout)
+        sec_warning = _count_warning(sec_result.stdout)
         self.db.store_artifact(
             job_id=job.id,
             phase="review",
@@ -839,6 +860,7 @@ Store any security issues found in DevBrain with type="issue" and category="secu
             model_used=sec_cli,
             findings_count=sec_result.stdout.count("\n- ") + sec_result.stdout.count("\n1."),
             blocking_count=sec_blocking,
+            warning_count=sec_warning,
         )
 
         total_blocking = blocking_count + sec_blocking

--- a/factory/state_machine.py
+++ b/factory/state_machine.py
@@ -301,6 +301,7 @@ class FactoryDB:
         model_used: str | None = None,
         findings_count: int = 0,
         blocking_count: int = 0,
+        warning_count: int = 0,
         metadata: dict | None = None,
     ) -> str:
         """Store a factory artifact (plan, diff, review, QA report)."""
@@ -309,13 +310,13 @@ class FactoryDB:
                 """
                 INSERT INTO devbrain.factory_artifacts
                     (job_id, phase, artifact_type, content, model_used,
-                     findings_count, blocking_count, metadata)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                     findings_count, blocking_count, warning_count, metadata)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                 RETURNING id
                 """,
                 (
                     job_id, phase, artifact_type, content, model_used,
-                    findings_count, blocking_count,
+                    findings_count, blocking_count, warning_count,
                     json.dumps(metadata or {}),
                 ),
             )
@@ -335,7 +336,8 @@ class FactoryDB:
             cur.execute(
                 f"""
                 SELECT id, phase, artifact_type, content, model_used,
-                       findings_count, blocking_count, metadata, created_at
+                       findings_count, blocking_count, warning_count,
+                       metadata, created_at
                 FROM devbrain.factory_artifacts
                 WHERE {' AND '.join(conditions)}
                 ORDER BY created_at ASC
@@ -347,7 +349,8 @@ class FactoryDB:
                     "id": str(r[0]), "phase": r[1], "artifact_type": r[2],
                     "content": r[3], "model_used": r[4],
                     "findings_count": r[5], "blocking_count": r[6],
-                    "metadata": r[7] or {}, "created_at": str(r[8]),
+                    "warning_count": r[7],
+                    "metadata": r[8] or {}, "created_at": str(r[9]),
                 }
                 for r in cur.fetchall()
             ]

--- a/factory/tests/test_orchestrator_warning_count.py
+++ b/factory/tests/test_orchestrator_warning_count.py
@@ -12,6 +12,37 @@ def db():
     return FactoryDB(DATABASE_URL)
 
 
+# Autouse cleanup: every integration test in this directory that creates
+# factory_jobs rows should pair with a teardown that deletes them by
+# title prefix, or each CI run accumulates dozens of stale rows in the
+# dev DB (observed 2026-04-23 — this test file's own pre-cleanup version
+# contributed to a 90-row pollution cleanup). Mirrors the pattern already
+# used in test_orchestrator_branch_setup.py / test_cleanup_agent.py /
+# test_blocked_resolution_flow.py.
+_TEST_TITLE_PREFIX = "warning_count plumbing test"
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_test_rows(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            (f"{_TEST_TITLE_PREFIX}%",),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts WHERE job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)",
+                (ids,),
+            )
+        conn.commit()
+
+
 def test_count_warning_matches_common_markers():
     """_count_warning detects the same list/markdown shapes as its BLOCKING twin."""
     text = """

--- a/factory/tests/test_orchestrator_warning_count.py
+++ b/factory/tests/test_orchestrator_warning_count.py
@@ -1,0 +1,91 @@
+"""Tests for warning_count plumbing in factory_artifacts."""
+import pytest
+
+from state_machine import FactoryDB, JobStatus
+from orchestrator import _count_warning, _extract_warning_items
+
+from config import DATABASE_URL
+
+
+@pytest.fixture
+def db():
+    return FactoryDB(DATABASE_URL)
+
+
+def test_count_warning_matches_common_markers():
+    """_count_warning detects the same list/markdown shapes as its BLOCKING twin."""
+    text = """
+1. WARNING: missing docstring
+- WARNING: consider caching result
+**WARNING**: shadowed variable
+warning: lower-case still counts
+"""
+    assert _count_warning(text) == 4
+
+
+def test_extract_warning_items_splits_on_markers_and_stops_at_next_severity():
+    """Each WARNING item should be its own string, truncated at the next severity marker."""
+    text = """
+1. WARNING: first warning item with detail
+   spans a second line
+2. BLOCKING: a blocking issue
+3. WARNING: second warning
+4. NIT: style nitpick
+"""
+    items = _extract_warning_items(text)
+    assert len(items) == 2
+    assert "first warning item" in items[0]
+    assert "spans a second line" in items[0]
+    assert "BLOCKING" not in items[0]
+    assert "second warning" in items[1]
+    assert "NIT" not in items[1]
+
+
+def test_store_artifact_persists_warning_count(db):
+    """store_artifact accepts warning_count and round-trips it via get_artifacts."""
+    job_id = db.create_job(
+        project_slug="devbrain",
+        title="warning_count plumbing test (store)",
+        spec="Test warning_count persists on insert and read-back.",
+    )
+    db.transition(job_id, JobStatus.PLANNING)
+    db.store_artifact(
+        job_id=job_id,
+        phase="review",
+        artifact_type="arch_review",
+        content="WARNING: x\nWARNING: y\nBLOCKING: z",
+        findings_count=3,
+        blocking_count=1,
+        warning_count=2,
+    )
+
+    artifacts = db.get_artifacts(job_id, phase="review")
+    assert len(artifacts) == 1
+    art = artifacts[0]
+    assert art["warning_count"] == 2
+    assert art["blocking_count"] == 1
+    assert art["findings_count"] == 3
+    # Other fields still deserialize correctly after index shift
+    assert art["artifact_type"] == "arch_review"
+    assert art["metadata"] == {}
+    assert art["created_at"] is not None
+
+
+def test_warning_count_defaults_to_zero_when_omitted(db):
+    """Callers that don't pass warning_count (QA, fix sites) still work and get 0."""
+    job_id = db.create_job(
+        project_slug="devbrain",
+        title="warning_count plumbing test (default)",
+        spec="Test warning_count defaults to 0 when caller omits it.",
+    )
+    db.transition(job_id, JobStatus.PLANNING)
+    db.store_artifact(
+        job_id=job_id,
+        phase="planning",
+        artifact_type="plan",
+        content="a plan",
+    )
+
+    artifacts = db.get_artifacts(job_id, phase="planning")
+    assert len(artifacts) == 1
+    assert artifacts[0]["warning_count"] == 0

--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -184,6 +184,7 @@ CREATE TABLE devbrain.factory_artifacts (
     status          VARCHAR(50) DEFAULT 'created',
     findings_count  INT DEFAULT 0,
     blocking_count  INT DEFAULT 0,
+    warning_count   INT DEFAULT 0,
     metadata        JSONB DEFAULT '{}',
     created_at      TIMESTAMPTZ DEFAULT now()
 );

--- a/migrations/008_artifact_warning_count.sql
+++ b/migrations/008_artifact_warning_count.sql
@@ -1,0 +1,14 @@
+-- Migration 008: Add warning_count to factory_artifacts.
+-- ============================================================================
+--
+-- Plumbing-only addition. Review phases already count BLOCKING findings via
+-- blocking_count; warning_count adds the mirror counter for WARNING-severity
+-- findings so downstream surfaces can display both counts without re-parsing
+-- artifact content. No behavior change — counts are stored but not yet acted
+-- on by transition logic.
+--
+-- Usage:
+--   docker exec -i devbrain-db psql -U devbrain -d devbrain < migrations/008_artifact_warning_count.sql
+
+ALTER TABLE devbrain.factory_artifacts
+    ADD COLUMN IF NOT EXISTS warning_count INT DEFAULT 0;


### PR DESCRIPTION
## Summary
Data-layer plumbing only — adds `warning_count INT DEFAULT 0` to `factory_artifacts`, populates it alongside the existing `blocking_count` on every review artifact, and exposes it via `state_machine.store_artifact()` / `get_artifacts()`.

No behavior change. Fix-loop gate, reviewer prompts, oscillation guardrail are follow-up jobs (2b + 2c) that'll consume the new column.

## Motivation
The factory reviewer classifies findings as BLOCKING, WARNING, or NIT. Only BLOCKING is counted today, so the fix-loop fires only on strictly-blocking issues. Real UX/correctness concerns flagged as WARNING get reported but never acted on. Before we can change that gate, the `warning_count` data needs to exist on reviewed artifacts. This PR ships only that data layer, so it can be deployed and verified before any logic references it (avoids the "column doesn't exist" cascade seen on 2026-04-22).

## Changes
- `migrations/008_artifact_warning_count.sql` — `ALTER TABLE ... ADD COLUMN IF NOT EXISTS warning_count INT DEFAULT 0`. Idempotent.
- `migrations/001_initial_schema.sql` — adds the column for fresh installs.
- `factory/state_machine.py` — `store_artifact()` gains `warning_count=0` kwarg; `get_artifacts()` SELECT + row-to-dict projection updated.
- `factory/orchestrator.py` — new `_count_warning()` + `_extract_warning_items()` mirroring the BLOCKING helpers; both review-store sites now populate the column.
- `factory/tests/test_orchestrator_warning_count.py` — new tests for `_count_warning`, `_extract_warning_items`, persistence round-trip, and default-zero behavior.

## Produced by
- Factory job `9e3ea252` — single pass, first-try clean under the new 150-turn `implementing` budget (the prior 50-turn ceiling caused three consecutive max-turns failures on related specs).
- Hand-fix `2e450ea` — added the autouse cleanup fixture the architecture review flagged as WARNING. This very review is doing the job the not-yet-built fix-loop-on-WARNING would automate.

## Test plan
- [ ] `pytest factory/tests/test_orchestrator_warning_count.py` — 4 tests pass, 0 leftover DB rows.
- [ ] Apply `migrations/008_artifact_warning_count.sql` on a live DB; existing rows get `warning_count = 0` via the DEFAULT.
- [ ] Submit a new factory job and verify the review artifacts have non-null `warning_count` values matching the reviewer's flagged items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)