### PR TITLE
test(factory): retrofit autouse cleanup fixtures to stop DB row leaks

### DIFF
--- a/factory/tests/test_cleanup_agent.py
+++ b/factory/tests/test_cleanup_agent.py
@@ -11,6 +11,40 @@ def db():
     return FactoryDB(DATABASE_URL)
 
 
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
+            ([
+                "Test approved job",
+                "Test failed job",
+                "Recovery test job",
+                "Lock release test task6",
+                "No locks task6",
+            ],),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_cleanup_reports "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "UPDATE devbrain.factory_jobs SET blocked_by_job_id = NULL "
+                "WHERE blocked_by_job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)", (ids,),
+            )
+        conn.commit()
+
+
 @pytest.fixture
 def agent(db):
     return CleanupAgent(db)

--- a/factory/tests/test_file_registry.py
+++ b/factory/tests/test_file_registry.py
@@ -9,6 +9,36 @@ from config import DATABASE_URL
 def db():
     return FactoryDB(DATABASE_URL)
 
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
+            ([
+                "Test job 1",
+                "Test job 2",
+            ],),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_cleanup_reports "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "UPDATE devbrain.factory_jobs SET blocked_by_job_id = NULL "
+                "WHERE blocked_by_job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)", (ids,),
+            )
+        conn.commit()
+
 @pytest.fixture
 def registry(db):
     return FileRegistry(db)

--- a/factory/tests/test_multi_dev_integration.py
+++ b/factory/tests/test_multi_dev_integration.py
@@ -12,6 +12,45 @@ def db():
     return FactoryDB(DATABASE_URL)
 
 
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
+            ([
+                "Independent A integ",
+                "Independent B integ",
+                "Shared A integ",
+                "Shared B integ",
+                "Release test A integ",
+                "Release test B integ",
+                "Crashed job integ",
+                "New job integ",
+                "Blocker A integ",
+                "Blocked B integ",
+            ],),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_cleanup_reports "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "UPDATE devbrain.factory_jobs SET blocked_by_job_id = NULL "
+                "WHERE blocked_by_job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)", (ids,),
+            )
+        conn.commit()
+
+
 def test_two_jobs_independent_files_both_proceed(db):
     """Two jobs with no file overlap both acquire locks successfully."""
     registry = FileRegistry(db)

--- a/factory/tests/test_orchestrator_cleanup.py
+++ b/factory/tests/test_orchestrator_cleanup.py
@@ -11,6 +11,39 @@ def db():
     return FactoryDB(DATABASE_URL)
 
 
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
+            ([
+                "Recovery API test",
+                "Orchestrator cleanup integration test",
+                "Orchestrator cleanup approved test",
+                "Recovery store test",
+            ],),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_cleanup_reports "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "UPDATE devbrain.factory_jobs SET blocked_by_job_id = NULL "
+                "WHERE blocked_by_job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)", (ids,),
+            )
+        conn.commit()
+
+
 @pytest.fixture
 def agent(db):
     return CleanupAgent(db)

--- a/factory/tests/test_state_machine_blocked.py
+++ b/factory/tests/test_state_machine_blocked.py
@@ -10,6 +10,39 @@ def db():
     return FactoryDB(DATABASE_URL)
 
 
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
+            ([
+                "Test BLOCKED transition",
+                "Resolution field test",
+                "Set/clear resolution test",
+                "Invalid resolution test",
+            ],),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_cleanup_reports "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "UPDATE devbrain.factory_jobs SET blocked_by_job_id = NULL "
+                "WHERE blocked_by_job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)", (ids,),
+            )
+        conn.commit()
+
+
 def test_blocked_status_exists():
     assert JobStatus.BLOCKED == "blocked"
 

--- a/factory/tests/test_state_machine_cleanup.py
+++ b/factory/tests/test_state_machine_cleanup.py
@@ -11,6 +11,37 @@ def db():
     return FactoryDB(DATABASE_URL)
 
 
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
+            ([
+                "Test cleanup job",
+                "Test active job",
+            ],),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_cleanup_reports "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts "
+                "WHERE job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "UPDATE devbrain.factory_jobs SET blocked_by_job_id = NULL "
+                "WHERE blocked_by_job_id = ANY(%s)", (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)", (ids,),
+            )
+        conn.commit()
+
+
 @pytest.fixture
 def test_job(db):
     """Create a test job in FAILED state for cleanup testing."""


### PR DESCRIPTION
## Summary
Adds autouse cleanup fixtures to the 6 test files under `factory/tests/` that were calling `db.create_job(...)` without teardown. Every CI run was leaking 1-5 rows per file into `factory_jobs`, accumulating until someone noticed (observed 2026-04-23 — required a 90-row manual cleanup to unclutter the dashboard).

Files retrofitted:
- `test_cleanup_agent.py`
- `test_file_registry.py`
- `test_multi_dev_integration.py`
- `test_orchestrator_cleanup.py`
- `test_state_machine_blocked.py`
- `test_state_machine_cleanup.py`

Pattern mirrors the 6 files that already had cleanup (`test_blocked_resolution_flow.py` etc.) — autouse fixture DELETEs rows by exact-title match, FK-safe ordering (artifacts → cleanup_reports → blocked_by_job_id NULL → jobs).

No test-logic changes; fixtures are additive only.

## Produced by
Factory job `c343a312` — single pass, clean pipeline: planning (2 min) → implementing (14 min) → reviewing (5 min) → qa (instant) → ready_for_approval. 0 BLOCKING, 0 WARNING on security review.

## Follow-up
Architecture review flagged generic titles like `"Test job 1"` as collision-prone vs the prior-art pattern (`bflow_*`, `blockinv_*`). That's spec-level — I explicitly asked for no-renames to keep this diff small. Will address in a follow-up to standardize title prefixes across all test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)