### PR TITLE
feat(dashboard): Rich markup + finer Age format

### DIFF
--- a/factory/dashboard/widgets/events_panel.py
+++ b/factory/dashboard/widgets/events_panel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from rich.markup import escape as _escape_markup
 from textual.widgets import RichLog, Static
 from textual.containers import Vertical
 
@@ -62,7 +63,15 @@ class RecentEventsPanel(Vertical):
             color = EVENT_COLORS.get(event["artifact_type"], "white")
             time_str = _format_time(event["timestamp"])
             job_short = event["job_id"][:8]
-            job_title = event["job_title"][:30]
-            summary = event["summary"]
+            # job_title (user-supplied via factory_plan) and summary
+            # (LLM-generated artifact text) can contain literal square
+            # brackets — e.g. "Fix [E1234]" or "Added [type] annotations"
+            # — which Rich parses as markup tags now that markup=True is
+            # set. Unescaped, stray tags either raise MarkupError (line
+            # silently dropped) or corrupt the rendered output. Escape
+            # them; leave the dashboard-controlled wrapping markup
+            # ([dim], [{color}]) intact since those are hardcoded here.
+            job_title = _escape_markup(event["job_title"][:30])
+            summary = _escape_markup(event["summary"])
             line = f"[dim]{time_str}[/dim] [{color}]{job_short}[/{color}] {job_title} — {summary}"
             log.write(line)

--- a/factory/dashboard/widgets/events_panel.py
+++ b/factory/dashboard/widgets/events_panel.py
@@ -46,7 +46,7 @@ class RecentEventsPanel(Vertical):
 
     def compose(self):
         yield Static("━━━ Recent Events ━━━", classes="panel-title")
-        log = RichLog(id="events-log", highlight=True, wrap=False, max_lines=100)
+        log = RichLog(id="events-log", highlight=True, markup=True, wrap=False, max_lines=100)
         yield log
 
     def update_events(self, events: list[dict]) -> None:

--- a/factory/dashboard/widgets/jobs_panel.py
+++ b/factory/dashboard/widgets/jobs_panel.py
@@ -33,6 +33,23 @@ def _phase_progress(status: str) -> tuple[int, int]:
     return idx, len(phases)
 
 
+def _humanize_age(seconds: int) -> str:
+    """Format an integer second count as a two-unit human-readable age.
+
+    Bands: <1m → "Ns"; <1h → "Nm Ss"; <1d → "Nh Mm"; ≥1d → "Nd Hh".
+    Negative inputs (clock skew) clamp to "0s".
+    """
+    if seconds < 0:
+        seconds = 0
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m {seconds % 60}s"
+    if seconds < 86400:
+        return f"{seconds // 3600}h {(seconds % 3600) // 60}m"
+    return f"{seconds // 86400}d {(seconds % 86400) // 3600}h"
+
+
 def _format_age(updated_at) -> str:
     """Format a timestamp as a human-readable age."""
     if updated_at is None:
@@ -41,14 +58,7 @@ def _format_age(updated_at) -> str:
         if updated_at.tzinfo is None:
             updated_at = updated_at.replace(tzinfo=timezone.utc)
         delta = datetime.now(timezone.utc) - updated_at
-        seconds = int(delta.total_seconds())
-        if seconds < 60:
-            return f"{seconds}s"
-        if seconds < 3600:
-            return f"{seconds // 60}m"
-        if seconds < 86400:
-            return f"{seconds // 3600}h"
-        return f"{seconds // 86400}d"
+        return _humanize_age(int(delta.total_seconds()))
     except Exception:
         return "?"
 

--- a/factory/tests/test_dashboard_widgets.py
+++ b/factory/tests/test_dashboard_widgets.py
@@ -1,0 +1,67 @@
+"""Tests for dashboard widget pure helpers."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dashboard.widgets.jobs_panel import _format_age, _humanize_age
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (0, "0s"),
+        (1, "1s"),
+        (30, "30s"),
+        (59, "59s"),
+        # Minute band
+        (60, "1m 0s"),
+        (61, "1m 1s"),
+        (332, "5m 32s"),
+        (3599, "59m 59s"),
+        # Hour band
+        (3600, "1h 0m"),
+        (3660, "1h 1m"),
+        (8100, "2h 15m"),
+        (86399, "23h 59m"),
+        # Day band
+        (86400, "1d 0h"),
+        (97200, "1d 3h"),
+        (172800, "2d 0h"),
+    ],
+)
+def test_humanize_age_bands(seconds, expected):
+    assert _humanize_age(seconds) == expected
+
+
+def test_humanize_age_clock_skew_clamps_to_zero():
+    assert _humanize_age(-5) == "0s"
+
+
+def test_format_age_none_returns_question_mark():
+    assert _format_age(None) == "?"
+
+
+def test_format_age_naive_datetime_treated_as_utc():
+    naive = datetime.utcnow() - timedelta(seconds=42)
+    result = _format_age(naive)
+    # Allow a small drift window from test execution time.
+    assert result.endswith("s")
+    secs = int(result.removesuffix("s"))
+    assert 40 <= secs <= 60
+
+
+def test_format_age_aware_datetime_in_minute_band():
+    aware = datetime.now(timezone.utc) - timedelta(seconds=332)
+    result = _format_age(aware)
+    # Should be "5m Xs" with X close to 32 (allow drift).
+    assert result.startswith("5m ")
+    assert result.endswith("s")
+
+
+def test_format_age_future_timestamp_clamps_to_zero():
+    future = datetime.now(timezone.utc) + timedelta(seconds=30)
+    assert _format_age(future) == "0s"
+
+
+def test_format_age_invalid_input_returns_question_mark():
+    assert _format_age("not a datetime") == "?"


### PR DESCRIPTION
## Summary
Two small dashboard improvements, bundled:

1. **Recent Events widget renders Rich markup correctly** — previously printed `[dim]10:32:01[/dim] [cyan]c343a312[/cyan]` with literal brackets because the `RichLog` was constructed without `markup=True`. Flipped to `markup=True` plus escaped the user/LLM-origin fields.

2. **Active Jobs Age column shows seconds for sub-hour jobs** — was `5m`, now `5m 32s`. Sub-minute ages show `Ns`; 1h+ continues to show `Nh Mm` (no seconds at that scale).

## Produced by
- Factory job `639a7c43` — clean single pass: planning (2 min), implementing (4.5 min — well under the 150-turn budget), reviewing, qa, ready_for_approval in ~10 min total.
- Hand-fix `f58d709` — both reviewers flagged a legitimate security WARNING: enabling `markup=True` opens a Rich-tag-injection gap on user-submitted `job_title` and LLM-generated `summary` fields. Wrapped both with `rich.markup.escape()` before interpolation.

## Test plan
- [ ] `devbrain dashboard` → Recent Events panel renders with proper colors (no literal brackets visible).
- [ ] Submit a job with a bracketed title like `"Fix [E1234] issue"` → dashboard renders the title literally without crashing or corrupting the line.
- [ ] Active Jobs Age column shows seconds within the hour, stays `Nh Mm` format for longer-running jobs.
- [ ] `pytest factory/dashboard/` — any new unit tests for the age formatter pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)