### PR TITLE
test(factory): rename generic test-fixture job titles to per-file prefixes

### DIFF
--- a/factory/tests/test_cleanup_agent.py
+++ b/factory/tests/test_cleanup_agent.py
@@ -16,14 +16,8 @@ def cleanup(db):
     yield
     with db._conn() as conn, conn.cursor() as cur:
         cur.execute(
-            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
-            ([
-                "Test approved job",
-                "Test failed job",
-                "Recovery test job",
-                "Lock release test task6",
-                "No locks task6",
-            ],),
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            ("cleanup_agent_test_%",),
         )
         ids = [r[0] for r in cur.fetchall()]
         if ids:
@@ -55,7 +49,7 @@ def approved_job(db):
     """Simulate a job that went through the full happy path to APPROVED."""
     job_id = db.create_job(
         project_slug="devbrain",
-        title="Test approved job",
+        title="cleanup_agent_test_approved_job",
         spec="Implement widget feature",
     )
     # Walk through the pipeline
@@ -77,7 +71,7 @@ def failed_job(db):
     """Simulate a job that hit blocking review findings and eventually failed."""
     job_id = db.create_job(
         project_slug="devbrain",
-        title="Test failed job",
+        title="cleanup_agent_test_failed_job",
         spec="Implement broken feature",
         metadata={"branch": "factory/broken-feature"},
     )
@@ -175,7 +169,7 @@ class TestAttemptRecovery:
         """attempt_recovery returns a CleanupReport dataclass."""
         job_id = db.create_job(
             project_slug="devbrain",
-            title="Recovery test job",
+            title="cleanup_agent_test_recovery_job",
             spec="Test spec for recovery",
         )
         db.transition(job_id, JobStatus.PLANNING)
@@ -205,7 +199,7 @@ def test_post_cleanup_releases_file_locks(db, agent):
     registry = FileRegistry(db)
 
     # Create a failed job
-    job_id = db.create_job(project_slug="devbrain", title="Lock release test task6", spec="Test")
+    job_id = db.create_job(project_slug="devbrain", title="cleanup_agent_test_lock_release_task6", spec="Test")
     db.transition(job_id, JobStatus.PLANNING)
     db.transition(job_id, JobStatus.FAILED)
 
@@ -229,7 +223,7 @@ def test_post_cleanup_releases_file_locks(db, agent):
 
 def test_cleanup_handles_jobs_with_no_locks(db, agent):
     """Cleanup agent handles jobs that don't have any locks (no crash)."""
-    job_id = db.create_job(project_slug="devbrain", title="No locks task6", spec="Test")
+    job_id = db.create_job(project_slug="devbrain", title="cleanup_agent_test_no_locks_task6", spec="Test")
     db.transition(job_id, JobStatus.PLANNING)
     db.transition(job_id, JobStatus.FAILED)
 

--- a/factory/tests/test_file_registry.py
+++ b/factory/tests/test_file_registry.py
@@ -14,11 +14,8 @@ def cleanup(db):
     yield
     with db._conn() as conn, conn.cursor() as cur:
         cur.execute(
-            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
-            ([
-                "Test job 1",
-                "Test job 2",
-            ],),
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            ("file_registry_test_%",),
         )
         ids = [r[0] for r in cur.fetchall()]
         if ids:
@@ -45,12 +42,12 @@ def registry(db):
 
 @pytest.fixture
 def job1(db):
-    job_id = db.create_job(project_slug="devbrain", title="Test job 1", spec="Test")
+    job_id = db.create_job(project_slug="devbrain", title="file_registry_test_job_1", spec="Test")
     return db.get_job(job_id)
 
 @pytest.fixture
 def job2(db):
-    job_id = db.create_job(project_slug="devbrain", title="Test job 2", spec="Test")
+    job_id = db.create_job(project_slug="devbrain", title="file_registry_test_job_2", spec="Test")
     return db.get_job(job_id)
 
 def test_acquire_locks_no_conflicts(registry, job1):

--- a/factory/tests/test_multi_dev_integration.py
+++ b/factory/tests/test_multi_dev_integration.py
@@ -17,19 +17,8 @@ def cleanup(db):
     yield
     with db._conn() as conn, conn.cursor() as cur:
         cur.execute(
-            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
-            ([
-                "Independent A integ",
-                "Independent B integ",
-                "Shared A integ",
-                "Shared B integ",
-                "Release test A integ",
-                "Release test B integ",
-                "Crashed job integ",
-                "New job integ",
-                "Blocker A integ",
-                "Blocked B integ",
-            ],),
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            ("multi_dev_test_%",),
         )
         ids = [r[0] for r in cur.fetchall()]
         if ids:
@@ -55,8 +44,8 @@ def test_two_jobs_independent_files_both_proceed(db):
     """Two jobs with no file overlap both acquire locks successfully."""
     registry = FileRegistry(db)
 
-    job_a = db.get_job(db.create_job(project_slug="devbrain", title="Independent A integ", spec="Test"))
-    job_b = db.get_job(db.create_job(project_slug="devbrain", title="Independent B integ", spec="Test"))
+    job_a = db.get_job(db.create_job(project_slug="devbrain", title="multi_dev_test_independent_a_integ", spec="Test"))
+    job_b = db.get_job(db.create_job(project_slug="devbrain", title="multi_dev_test_independent_b_integ", spec="Test"))
 
     result_a = registry.acquire_locks(
         job_a.id, job_a.project_id,
@@ -81,8 +70,8 @@ def test_two_jobs_shared_file_second_blocks(db):
     """Two jobs touching the same file: first wins, second blocks."""
     registry = FileRegistry(db)
 
-    job_a = db.get_job(db.create_job(project_slug="devbrain", title="Shared A integ", spec="Test"))
-    job_b = db.get_job(db.create_job(project_slug="devbrain", title="Shared B integ", spec="Test"))
+    job_a = db.get_job(db.create_job(project_slug="devbrain", title="multi_dev_test_shared_a_integ", spec="Test"))
+    job_b = db.get_job(db.create_job(project_slug="devbrain", title="multi_dev_test_shared_b_integ", spec="Test"))
 
     result_a = registry.acquire_locks(
         job_a.id, job_a.project_id,
@@ -110,7 +99,7 @@ def test_cleanup_releases_then_blocked_job_proceeds(db):
     cleanup = CleanupAgent(db)
 
     # Job A acquires lock on shared file
-    job_a_id = db.create_job(project_slug="devbrain", title="Release test A integ", spec="Test")
+    job_a_id = db.create_job(project_slug="devbrain", title="multi_dev_test_release_test_a_integ", spec="Test")
     db.transition(job_a_id, JobStatus.PLANNING)
     job_a = db.get_job(job_a_id)
     registry.acquire_locks(
@@ -120,7 +109,7 @@ def test_cleanup_releases_then_blocked_job_proceeds(db):
     )
 
     # Job B tries same file — blocked
-    job_b_id = db.create_job(project_slug="devbrain", title="Release test B integ", spec="Test")
+    job_b_id = db.create_job(project_slug="devbrain", title="multi_dev_test_release_test_b_integ", spec="Test")
     job_b = db.get_job(job_b_id)
     result = registry.acquire_locks(
         job_b.id, job_b.project_id,
@@ -152,7 +141,7 @@ def test_expired_locks_get_cleaned_up_automatically(db):
     registry = FileRegistry(db)
 
     # Simulate a crashed job by acquiring and manually expiring the lock
-    crashed_job_id = db.create_job(project_slug="devbrain", title="Crashed job integ", spec="Test")
+    crashed_job_id = db.create_job(project_slug="devbrain", title="multi_dev_test_crashed_job_integ", spec="Test")
     crashed_job = db.get_job(crashed_job_id)
     registry.acquire_locks(
         crashed_job.id, crashed_job.project_id,
@@ -168,7 +157,7 @@ def test_expired_locks_get_cleaned_up_automatically(db):
         conn.commit()
 
     # New job should be able to acquire the same file (expired locks auto-cleaned in acquire_locks)
-    new_job_id = db.create_job(project_slug="devbrain", title="New job integ", spec="Test")
+    new_job_id = db.create_job(project_slug="devbrain", title="multi_dev_test_new_job_integ", spec="Test")
     new_job = db.get_job(new_job_id)
     result = registry.acquire_locks(
         new_job.id, new_job.project_id,
@@ -184,14 +173,14 @@ def test_blocked_job_has_blocked_by_set(db):
     """A job transitioned to BLOCKED has blocked_by_job_id populated."""
     registry = FileRegistry(db)
 
-    job_a = db.get_job(db.create_job(project_slug="devbrain", title="Blocker A integ", spec="Test"))
+    job_a = db.get_job(db.create_job(project_slug="devbrain", title="multi_dev_test_blocker_a_integ", spec="Test"))
     registry.acquire_locks(
         job_a.id, job_a.project_id,
         ["src/integ_blocker.py"],
         dev_id="alice",
     )
 
-    job_b_id = db.create_job(project_slug="devbrain", title="Blocked B integ", spec="Test")
+    job_b_id = db.create_job(project_slug="devbrain", title="multi_dev_test_blocked_b_integ", spec="Test")
     result = registry.acquire_locks(
         job_b_id, job_a.project_id,
         ["src/integ_blocker.py"],

--- a/factory/tests/test_orchestrator_cleanup.py
+++ b/factory/tests/test_orchestrator_cleanup.py
@@ -16,13 +16,8 @@ def cleanup(db):
     yield
     with db._conn() as conn, conn.cursor() as cur:
         cur.execute(
-            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
-            ([
-                "Recovery API test",
-                "Orchestrator cleanup integration test",
-                "Orchestrator cleanup approved test",
-                "Recovery store test",
-            ],),
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            ("orchestrator_cleanup_test_%",),
         )
         ids = [r[0] for r in cur.fetchall()]
         if ids:
@@ -75,7 +70,7 @@ class TestCleanupAgentMethods:
         """attempt_recovery should return a CleanupReport dataclass."""
         job_id = db.create_job(
             project_slug="devbrain",
-            title="Recovery API test",
+            title="orchestrator_cleanup_test_recovery_api",
             spec="Test spec",
         )
         db.transition(job_id, JobStatus.PLANNING)
@@ -102,7 +97,7 @@ class TestOrchestratorCleanupIntegration:
     def test_post_cleanup_creates_report_for_failed_job(self, db, agent):
         job_id = db.create_job(
             project_slug="devbrain",
-            title="Orchestrator cleanup integration test",
+            title="orchestrator_cleanup_test_integration",
             spec="Test that post-cleanup stores a report",
         )
         # Walk to FAILED
@@ -132,7 +127,7 @@ class TestOrchestratorCleanupIntegration:
     def test_post_cleanup_creates_report_for_approved_job(self, db, agent):
         job_id = db.create_job(
             project_slug="devbrain",
-            title="Orchestrator cleanup approved test",
+            title="orchestrator_cleanup_test_approved",
             spec="Test that post-cleanup stores a report for success",
         )
         # Walk to APPROVED
@@ -165,7 +160,7 @@ class TestOrchestratorCleanupIntegration:
         """Simulate what orchestrator does: call attempt_recovery, store the report."""
         job_id = db.create_job(
             project_slug="devbrain",
-            title="Recovery store test",
+            title="orchestrator_cleanup_test_recovery_store",
             spec="Test that recovery reports are persisted",
         )
         db.transition(job_id, JobStatus.PLANNING)

--- a/factory/tests/test_state_machine_blocked.py
+++ b/factory/tests/test_state_machine_blocked.py
@@ -15,13 +15,8 @@ def cleanup(db):
     yield
     with db._conn() as conn, conn.cursor() as cur:
         cur.execute(
-            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
-            ([
-                "Test BLOCKED transition",
-                "Resolution field test",
-                "Set/clear resolution test",
-                "Invalid resolution test",
-            ],),
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            ("state_machine_blocked_test_%",),
         )
         ids = [r[0] for r in cur.fetchall()]
         if ids:
@@ -75,7 +70,7 @@ def test_blocked_can_fail_as_safety_net():
 
 
 def test_transition_planning_to_blocked(db):
-    job_id = db.create_job(project_slug="devbrain", title="Test BLOCKED transition", spec="Test")
+    job_id = db.create_job(project_slug="devbrain", title="state_machine_blocked_test_blocked_transition", spec="Test")
     db.transition(job_id, JobStatus.PLANNING)
     job = db.transition(job_id, JobStatus.BLOCKED)
     assert job.status == JobStatus.BLOCKED
@@ -83,14 +78,14 @@ def test_transition_planning_to_blocked(db):
 
 def test_factory_job_has_blocked_resolution_field(db):
     """FactoryJob has blocked_resolution field, defaults to None."""
-    job_id = db.create_job(project_slug="devbrain", title="Resolution field test", spec="Test")
+    job_id = db.create_job(project_slug="devbrain", title="state_machine_blocked_test_resolution_field", spec="Test")
     job = db.get_job(job_id)
     assert hasattr(job, "blocked_resolution")
     assert job.blocked_resolution is None
 
 
 def test_set_and_clear_blocked_resolution(db):
-    job_id = db.create_job(project_slug="devbrain", title="Set/clear resolution test", spec="Test")
+    job_id = db.create_job(project_slug="devbrain", title="state_machine_blocked_test_set_clear_resolution", spec="Test")
     db.set_blocked_resolution(job_id, "proceed")
     job = db.get_job(job_id)
     assert job.blocked_resolution == "proceed"
@@ -100,6 +95,6 @@ def test_set_and_clear_blocked_resolution(db):
 
 
 def test_set_invalid_resolution_raises(db):
-    job_id = db.create_job(project_slug="devbrain", title="Invalid resolution test", spec="Test")
+    job_id = db.create_job(project_slug="devbrain", title="state_machine_blocked_test_invalid_resolution", spec="Test")
     with pytest.raises(ValueError, match="Invalid resolution"):
         db.set_blocked_resolution(job_id, "bogus")

--- a/factory/tests/test_state_machine_cleanup.py
+++ b/factory/tests/test_state_machine_cleanup.py
@@ -16,11 +16,8 @@ def cleanup(db):
     yield
     with db._conn() as conn, conn.cursor() as cur:
         cur.execute(
-            "SELECT id FROM devbrain.factory_jobs WHERE title = ANY(%s)",
-            ([
-                "Test cleanup job",
-                "Test active job",
-            ],),
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            ("state_machine_cleanup_test_%",),
         )
         ids = [r[0] for r in cur.fetchall()]
         if ids:
@@ -45,7 +42,7 @@ def cleanup(db):
 @pytest.fixture
 def test_job(db):
     """Create a test job in FAILED state for cleanup testing."""
-    job_id = db.create_job(project_slug="devbrain", title="Test cleanup job", spec="Test spec")
+    job_id = db.create_job(project_slug="devbrain", title="state_machine_cleanup_test_job", spec="Test spec")
     db.transition(job_id, JobStatus.PLANNING)
     db.transition(job_id, JobStatus.FAILED)
     return job_id
@@ -61,7 +58,7 @@ def test_archive_job(db, test_job):
 
 def test_archive_non_terminal_job_raises(db):
     """Cannot archive a job that isn't in a terminal state."""
-    job_id = db.create_job(project_slug="devbrain", title="Test active job", spec="Test spec")
+    job_id = db.create_job(project_slug="devbrain", title="state_machine_cleanup_test_active_job", spec="Test spec")
     with pytest.raises(ValueError, match="Cannot archive"):
         db.archive_job(job_id)
 


### PR DESCRIPTION
## Summary
Follow-up to PR #25 architecture review. Renames 27 hardcoded job titles across 6 test files from generic names like `"Test job 1"`, `"New job integ"`, `"Test active job"` to per-file prefixes. Also upgrades the cleanup fixtures from exact-match `title = ANY(%s)` lists to `title LIKE 'prefix_%'` pattern matches — cleaner, more resilient to new tests being added to the file.

Prefix per file:
- `test_cleanup_agent.py` → `cleanup_agent_test_*`
- `test_file_registry.py` → `file_registry_test_*`
- `test_multi_dev_integration.py` → `multi_dev_test_*`
- `test_orchestrator_cleanup.py` → `orchestrator_cleanup_test_*`
- `test_state_machine_blocked.py` → `state_machine_blocked_test_*`
- `test_state_machine_cleanup.py` → `state_machine_cleanup_test_*`

## Produced by
Factory job `3aa356d6` — single clean pass (planning 2m, implementing 7m, reviewing 3m, qa instant). 0 BLOCKING, 0 WARNING on both reviews.

## Test plan
- [ ] `pytest factory/tests/` — all tests pass, 0 leaked rows.
- [ ] Grep `factory/tests/` for any remaining generic titles (`"Test job 1"`, etc.) — should return 0 hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)