### PR TITLE
feat(factory): fix-loop triggers on WARNING findings when configured

### DIFF
--- a/config/devbrain.yaml.example
+++ b/config/devbrain.yaml.example
@@ -144,6 +144,14 @@ factory:
     auto_archive_after_hours: 24  # Archive completed jobs after 24h in context
     branch_cleanup: true          # Delete branches for failed/rejected jobs
 
+  # Fix-loop trigger tier. When true (default as of 2026-04-23), reviewer
+  # WARNING findings also route a job through FIX_LOOP alongside BLOCKING
+  # findings. Set false to restore the pre-2026-04-23 BLOCKING-only gate
+  # — useful if reviewer calibration leans too cautious on a given project.
+  # max_fix_loop_retries still caps total fix attempts either way.
+  fix_loop:
+    warnings_trigger_retry: true
+
   # What factory-spawned claude subprocesses are allowed to do.
   #   1 — Read-only audit: file reads, git log/diff/status only. Factory
   #       can observe but not modify anything. Use for dry runs, untrusted

--- a/factory/config.py
+++ b/factory/config.py
@@ -37,6 +37,9 @@ _DEFAULTS: dict = {
     "factory": {
         "max_concurrent_jobs": 2,
         "max_fix_loop_retries": 5,
+        "fix_loop": {
+            "warnings_trigger_retry": True,
+        },
         "default_review_passes": ["architecture", "security_hipaa"],
         "cli_preferences": {},
         "cleanup": {
@@ -140,6 +143,14 @@ FACTORY_PERMISSIONS_EXTRA_TOOLS = list(
 )
 FACTORY_TIER_2_SUBCATEGORIES = dict(
     FACTORY_CONFIG.get("permissions_tier_2_subcategories", {})
+)
+
+# Fix-loop trigger tier. When True (default as of 2026-04-23), reviewer
+# WARNING findings also route a job through FIX_LOOP; when False the
+# pre-2026-04-23 behavior (BLOCKING-only) is preserved.
+_FIX_LOOP_CONFIG = FACTORY_CONFIG.get("fix_loop", {})
+FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY = bool(
+    _FIX_LOOP_CONFIG.get("warnings_trigger_retry", True)
 )
 
 # Per-phase --max-turns ceiling for claude subprocesses. Tuned empirically:

--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -438,18 +438,6 @@ class FactoryOrchestrator:
                 prior.extend(items)
         return prior
 
-    def _get_prior_warning_findings(
-        self, job: FactoryJob, artifact_type: str
-    ) -> list[str]:
-        """Get WARNING findings from previous review rounds for fix context."""
-        artifacts = self.db.get_artifacts(job.id, phase="review")
-        prior = []
-        for art in artifacts:
-            if art["artifact_type"] == artifact_type and art["warning_count"] > 0:
-                items = _extract_warning_items(art["content"])
-                prior.extend(items)
-        return prior
-
     def _get_fix_history(self, job: FactoryJob) -> str:
         """Get summary of what was fixed in prior fix loops."""
         fix_artifacts = self.db.get_artifacts(job.id, phase="fix")

--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from state_machine import FactoryDB, FactoryJob, JobStatus
 from cli_executor import run_cli, notify_desktop, DEFAULT_CLI_ASSIGNMENTS
+from config import FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY
 from learning import extract_lessons, get_review_lessons
 from cleanup_agent import CleanupAgent
 from file_registry import FileRegistry
@@ -434,6 +435,18 @@ class FactoryOrchestrator:
         for art in artifacts:
             if art["artifact_type"] == artifact_type and art["blocking_count"] > 0:
                 items = _extract_blocking_items(art["content"])
+                prior.extend(items)
+        return prior
+
+    def _get_prior_warning_findings(
+        self, job: FactoryJob, artifact_type: str
+    ) -> list[str]:
+        """Get WARNING findings from previous review rounds for fix context."""
+        artifacts = self.db.get_artifacts(job.id, phase="review")
+        prior = []
+        for art in artifacts:
+            if art["artifact_type"] == artifact_type and art["warning_count"] > 0:
+                items = _extract_warning_items(art["content"])
                 prior.extend(items)
         return prior
 
@@ -1020,9 +1033,20 @@ Store any security issues found in DevBrain with type="issue" and category="secu
         )
 
         total_blocking = blocking_count + sec_blocking
-        if total_blocking > 0:
-            return self.db.transition(job.id, JobStatus.FIX_LOOP,
-                                      metadata={"blocking_findings": total_blocking})
+        total_warning = warning_count + sec_warning
+        warnings_trigger = (
+            FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY and total_warning > 0
+        )
+        if total_blocking > 0 or warnings_trigger:
+            return self.db.transition(
+                job.id,
+                JobStatus.FIX_LOOP,
+                metadata={
+                    "blocking_findings": total_blocking,
+                    "warning_findings": total_warning,
+                    "trigger_reason": "blocking" if total_blocking > 0 else "warning",
+                },
+            )
         else:
             return self.db.transition(job.id, JobStatus.QA)
 
@@ -1108,21 +1132,44 @@ Store any security issues found in DevBrain with type="issue" and category="secu
         # Get ONLY the most recent review artifacts (not all historical ones)
         all_artifacts = self.db.get_artifacts(job.id)
         latest_blocking = []
+        latest_warning = []
         for art in reversed(all_artifacts):
             if art["phase"] == "review" and art["blocking_count"] > 0:
                 items = _extract_blocking_items(art["content"])
                 latest_blocking.extend(items)
+            if (
+                FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY
+                and art["phase"] == "review"
+                and art["warning_count"] > 0
+            ):
+                items = _extract_warning_items(art["content"])
+                latest_warning.extend(items)
             # Stop once we've passed the most recent review round
             if art["phase"] == "fix":
                 break
 
-        if not latest_blocking:
+        if not latest_blocking and not latest_warning:
             # QA failures instead of review findings
             qa_artifacts = [a for a in all_artifacts if a["phase"] == "qa" and a["blocking_count"] > 0]
             if qa_artifacts:
                 latest_blocking.append(qa_artifacts[-1]["content"])
 
-        fix_prompt = f"""You are fixing blocking issues found during code review. You are part of an autonomous dev factory pipeline — fix ONLY what is listed below, nothing else.
+        blocking_section = (
+            chr(10).join(
+                f"{i+1}. {finding}" for i, finding in enumerate(latest_blocking)
+            )
+            if latest_blocking
+            else "(none in the most recent review round)"
+        )
+        warning_section = (
+            chr(10).join(
+                f"{i+1}. {finding}" for i, finding in enumerate(latest_warning)
+            )
+            if latest_warning
+            else "(none)"
+        )
+
+        fix_prompt = f"""You are fixing review findings from the most recent review round. You are part of an autonomous dev factory pipeline — fix ONLY what is listed below, nothing else.
 
 PROJECT: {job.project_slug}
 FEATURE: {job.title}
@@ -1131,7 +1178,11 @@ FIX ATTEMPT: {job.error_count + 1}/{job.max_retries}
 
 ## BLOCKING FINDINGS TO FIX
 
-{chr(10).join(f"{i+1}. {finding}" for i, finding in enumerate(latest_blocking))}
+{blocking_section}
+
+## Prior WARNING findings to address
+
+{warning_section}
 
 {DEVBRAIN_INSTRUCTIONS}
 

--- a/factory/tests/test_warning_fix_loop.py
+++ b/factory/tests/test_warning_fix_loop.py
@@ -177,51 +177,26 @@ def test_warning_skipped_when_flag_false(orch, db, monkeypatch):
     assert result.status == JobStatus.QA
 
 
-def test_prior_warning_findings_extracted(orch, db):
-    """_get_prior_warning_findings skips artifacts with warning_count=0
-    and extracts items from those with warning_count>0, mirroring the
-    BLOCKING helper's behavior."""
-    job_id = db.create_job(
-        project_slug="devbrain",
-        title=f"{TEST_TITLE_PREFIX}helper_extracts_warnings",
-        spec="test",
-    )
-    db.transition(job_id, JobStatus.PLANNING)
-    job = db.get_job(job_id)
+def test_extract_warning_items_from_review_content(orch, db):
+    """_extract_warning_items extracts individual WARNING items from
+    review-artifact content. This exercises the same extraction path
+    _run_fix uses inline when collecting prior warning findings for
+    the fix prompt (see orchestrator.py _run_fix around the
+    `latest_warning` loop).
+    """
+    from orchestrator import _extract_warning_items
 
-    db.store_artifact(
-        job_id=job.id,
-        phase="review",
-        artifact_type="arch_review",
-        content="(no issues)",
-        blocking_count=0,
-        warning_count=0,
+    text = (
+        "1. WARNING: first warning at a.py:1\n"
+        "2. WARNING: second warning at b.py:2\n"
+        "3. BLOCKING: some blocking issue at c.py:3\n"
     )
-    db.store_artifact(
-        job_id=job.id,
-        phase="review",
-        artifact_type="arch_review",
-        content=(
-            "1. WARNING: first warning at a.py:1\n"
-            "2. WARNING: second warning at b.py:2\n"
-        ),
-        blocking_count=0,
-        warning_count=2,
-    )
-    db.store_artifact(
-        job_id=job.id,
-        phase="review",
-        artifact_type="security_review",
-        content="1. WARNING: security warning at c.py:3",
-        blocking_count=0,
-        warning_count=1,
-    )
+    items = _extract_warning_items(text)
+    assert len(items) == 2
+    assert "first warning" in items[0]
+    assert "second warning" in items[1]
 
-    arch_items = orch._get_prior_warning_findings(job, "arch_review")
-    sec_items = orch._get_prior_warning_findings(job, "security_review")
-
-    assert len(arch_items) == 2
-    assert "first warning" in arch_items[0]
-    assert "second warning" in arch_items[1]
+    sec_text = "1. WARNING: security warning at c.py:3"
+    sec_items = _extract_warning_items(sec_text)
     assert len(sec_items) == 1
     assert "security warning" in sec_items[0]

--- a/factory/tests/test_warning_fix_loop.py
+++ b/factory/tests/test_warning_fix_loop.py
@@ -1,0 +1,227 @@
+"""Tests for the WARNING-triggered fix-loop gate.
+
+Covers the 2026-04-23 change where reviewer WARNING findings can also
+route a job through FIX_LOOP when the new
+`factory.fix_loop.warnings_trigger_retry` tier is on (default True).
+
+The gate itself lives at the end of `_run_review` in orchestrator.py.
+We exercise it end-to-end by stubbing `run_cli` (no actual claude call)
+and `subprocess.run` (no `git diff main...HEAD`) and reading back the
+post-review job status.
+"""
+import pytest
+
+import orchestrator as orch_mod
+from orchestrator import FactoryOrchestrator
+from state_machine import FactoryDB, JobStatus
+from config import DATABASE_URL
+
+TEST_TITLE_PREFIX = "warning_fix_loop_test_"
+
+
+@pytest.fixture
+def db():
+    return FactoryDB(DATABASE_URL)
+
+
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            (f"{TEST_TITLE_PREFIX}%",),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_cleanup_reports "
+                "WHERE job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts "
+                "WHERE job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "UPDATE devbrain.factory_jobs SET blocked_by_job_id = NULL "
+                "WHERE blocked_by_job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)",
+                (ids,),
+            )
+        conn.commit()
+
+
+@pytest.fixture
+def orch():
+    return FactoryOrchestrator(DATABASE_URL)
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _FakeCLIResult:
+    """Shape-compatible with cli_executor.CLIResult for what _run_review reads."""
+
+    def __init__(self, stdout: str):
+        self.cli = "claude"
+        self.exit_code = 0
+        self.stdout = stdout
+        self.stderr = ""
+        self.success = True
+
+
+def _make_implementing_job(db: FactoryDB, title: str):
+    """Create a job and walk it QUEUED → PLANNING → IMPLEMENTING so the
+    gate under test sees the transition-to-REVIEWING _run_review performs."""
+    job_id = db.create_job(project_slug="devbrain", title=title, spec="test")
+    db.transition(job_id, JobStatus.PLANNING)
+    db.transition(job_id, JobStatus.IMPLEMENTING)
+    return db.get_job(job_id)
+
+
+def _stub_review_env(monkeypatch, *, arch_stdout: str, sec_stdout: str):
+    """Stub run_cli (both arch + security reviews) and subprocess.run
+    (git diff) so _run_review exercises the gate without touching CLIs
+    or git. run_cli returns arch_stdout then sec_stdout in order."""
+    responses = iter([_FakeCLIResult(arch_stdout), _FakeCLIResult(sec_stdout)])
+
+    def fake_run_cli(*args, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(orch_mod, "run_cli", fake_run_cli)
+    monkeypatch.setattr(
+        orch_mod.subprocess, "run",
+        lambda *a, **k: _FakeCompleted(stdout="diff --git a/x b/x\n"),
+    )
+
+
+def test_blocking_triggers_fix_loop_regardless_of_config(orch, db, monkeypatch):
+    """BLOCKING findings always route to FIX_LOOP, even when the WARNING
+    trigger tier is disabled — BLOCKING is not gated by the flag."""
+    monkeypatch.setattr(
+        orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", False
+    )
+    job = _make_implementing_job(
+        db, f"{TEST_TITLE_PREFIX}blocking_always_fixes"
+    )
+
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout="1. BLOCKING: missing null check at x.py:42",
+        sec_stdout="(no findings)",
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.FIX_LOOP
+    assert result.metadata.get("blocking_findings") == 1
+    assert result.metadata.get("trigger_reason") == "blocking"
+
+
+def test_warning_triggers_fix_loop_when_flag_true(orch, db, monkeypatch):
+    """WARNING-only findings route to FIX_LOOP when the flag is on."""
+    monkeypatch.setattr(
+        orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", True
+    )
+    job = _make_implementing_job(
+        db, f"{TEST_TITLE_PREFIX}warning_flag_on"
+    )
+
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout=(
+            "1. WARNING: suboptimal pattern at a.py:10\n"
+            "2. WARNING: missing docstring at b.py:5\n"
+        ),
+        sec_stdout="(no findings)",
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.FIX_LOOP
+    assert result.metadata.get("blocking_findings") == 0
+    assert result.metadata.get("warning_findings") == 2
+    assert result.metadata.get("trigger_reason") == "warning"
+
+
+def test_warning_skipped_when_flag_false(orch, db, monkeypatch):
+    """WARNING-only findings fall through to QA when the flag is off —
+    preserves the pre-2026-04-23 BLOCKING-only gate behavior."""
+    monkeypatch.setattr(
+        orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", False
+    )
+    job = _make_implementing_job(
+        db, f"{TEST_TITLE_PREFIX}warning_flag_off"
+    )
+
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout=(
+            "1. WARNING: suboptimal pattern at a.py:10\n"
+            "2. WARNING: missing docstring at b.py:5\n"
+        ),
+        sec_stdout="(no findings)",
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.QA
+
+
+def test_prior_warning_findings_extracted(orch, db):
+    """_get_prior_warning_findings skips artifacts with warning_count=0
+    and extracts items from those with warning_count>0, mirroring the
+    BLOCKING helper's behavior."""
+    job_id = db.create_job(
+        project_slug="devbrain",
+        title=f"{TEST_TITLE_PREFIX}helper_extracts_warnings",
+        spec="test",
+    )
+    db.transition(job_id, JobStatus.PLANNING)
+    job = db.get_job(job_id)
+
+    db.store_artifact(
+        job_id=job.id,
+        phase="review",
+        artifact_type="arch_review",
+        content="(no issues)",
+        blocking_count=0,
+        warning_count=0,
+    )
+    db.store_artifact(
+        job_id=job.id,
+        phase="review",
+        artifact_type="arch_review",
+        content=(
+            "1. WARNING: first warning at a.py:1\n"
+            "2. WARNING: second warning at b.py:2\n"
+        ),
+        blocking_count=0,
+        warning_count=2,
+    )
+    db.store_artifact(
+        job_id=job.id,
+        phase="review",
+        artifact_type="security_review",
+        content="1. WARNING: security warning at c.py:3",
+        blocking_count=0,
+        warning_count=1,
+    )
+
+    arch_items = orch._get_prior_warning_findings(job, "arch_review")
+    sec_items = orch._get_prior_warning_findings(job, "security_review")
+
+    assert len(arch_items) == 2
+    assert "first warning" in arch_items[0]
+    assert "second warning" in arch_items[1]
+    assert len(sec_items) == 1
+    assert "security warning" in sec_items[0]


### PR DESCRIPTION
## Summary
Extends the fix-loop trigger gate so reviewer WARNING findings can route jobs back through `_run_fix`, not just BLOCKING. WARNING is the tier for real correctness/UX concerns that would bother a human reviewer — iterating on them raises code quality at the cost of extra implementer turns.

## Changes
- **`factory/config.py`** — new `FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY` constant loaded from `factory.fix_loop.warnings_trigger_retry` yaml key, defaulting to `true`.
- **`config/devbrain.yaml.example`** — documents the toggle alongside the existing factory config block.
- **`factory/orchestrator.py`** — imports the flag; fix-loop gate at `_run_review` now checks `total_blocking > 0 OR (flag AND total_warning > 0)`; `_run_fix` pulls prior WARNING findings inline alongside BLOCKING in a single iteration pass over review artifacts, feeding both into the fix prompt under separate sections.
- **`factory/tests/test_warning_fix_loop.py`** (new, 4 tests): blocking-only (regression), warning-triggers-when-flag-true, warning-skipped-when-flag-false, `_extract_warning_items` direct extraction.

## Produced by
Factory job `6e7bb7af` — clean single pass (planning 2m, implementing 11m, reviewing 8m, qa instant). 0 BLOCKING on both reviews. 1 WARNING in arch (dead `_get_prior_warning_findings` helper — implementer added it per spec but inlined the logic in `_run_fix`, making the helper unused) — hand-fix `e062122` removed the helper, `33d9830` replaced the obsolete helper-test with a direct test of `_extract_warning_items`.

## Notes
- Deferred to **2b-prime** (separate follow-up): reviewer prompt calibration block explaining when to use BLOCKING vs WARNING vs NIT. Reviewers classify correctly today; this would just tighten the definitions.
- Deferred to **2c** (separate follow-up): oscillation guardrail — if the same WARNING persists across two fix rounds, escalate to `needs_human` instead of looping.
- **Worktree sync hiccup discovered during approval**: Mac Studio's worktree held the old branch tip after I pushed hand-fix commits from MacBook. `factory_approve`'s push got rejected (non-fast-forward) until I `cd` into the worktree and pulled. Worth a small follow-up to make `approve_job` auto-pull before push, or document the hand-edit-on-worktree constraint.

## Test plan
- [ ] `pytest factory/tests/test_warning_fix_loop.py` — 4 pass.
- [ ] With flag default (true), submit a factory job where the reviewer will flag a WARNING — verify fix-loop fires and resolves it.
- [ ] Set `factory.fix_loop.warnings_trigger_retry: false` in yaml, repeat — verify same job proceeds to `ready_for_approval` with WARNING reported but unfixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)