### PR TITLE
feat(factory): reviewer severity calibration — cost-aware classification

### DIFF
--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -933,14 +933,18 @@ If you find relevant past findings, check whether those same issues appear in th
 4. Error handling completeness
 5. Performance considerations
 
-## Output Format
+## Severity
 
-Output findings as a numbered list with severity:
-- **BLOCKING**: Must fix before merge — only for genuine bugs, broken functionality, or missing critical behavior
-- **WARNING**: Should fix but not blocking — code smell, missing edge case handling, suboptimal pattern
-- **NIT**: Style/preference suggestions
+Classify each finding. **Severity drives behavior**:
+- BLOCKING → must fix before merge, routes back to fix loop
+- WARNING  → fix-loop iterates on these automatically (each flag costs one implementer round); flag only when a human reviewer would genuinely push back
+- NIT      → reported but never iterated on; reserve for pure style / micro-optimizations / "considered alternatives"
 
-Be precise: include file paths and line numbers. Only use BLOCKING for issues that would cause runtime errors, data corruption, or security vulnerabilities. Architectural preferences are WARNING, not BLOCKING.
+Err toward NIT when the concern is stylistic or subjective.
+Err toward WARNING only when the code works but would annoy a careful reviewer (surprising behavior, missing edge case, silent error paths, etc.).
+Reserve BLOCKING for runtime bugs, data corruption, missing critical functionality — not architectural preferences.
+
+Be precise: include file paths and line numbers.
 
 If this is a re-review round, explicitly state which prior findings are RESOLVED vs still BLOCKING."""
 
@@ -989,14 +993,17 @@ If you find relevant past findings, check whether those same issues appear in th
 5. FERPA compliance (student data protection)
 6. Audit trail completeness for access control changes
 
-## Output Format
+## Severity
 
-Output findings as a numbered list with severity:
-- **BLOCKING**: Security/compliance issue that MUST be fixed — actual vulnerability, PHI exposure, missing auth check
-- **WARNING**: Potential concern that should be addressed — defense-in-depth suggestion, missing validation
-- **NIT**: Best practice suggestion
+Classify each finding. **Severity drives behavior**:
+- BLOCKING → actual vulnerability, PHI exposure, missing auth check; must fix before merge
+- WARNING  → defense-in-depth suggestion, narrow input validation gap, weak-but-not-absent auth — fix-loop iterates automatically (each flag costs one implementer round)
+- NIT      → best-practice suggestion with no concrete threat model; reported but not iterated on
 
-Be precise: include file paths and line numbers. Only use BLOCKING for actual security vulnerabilities or compliance violations, not theoretical concerns or defense-in-depth suggestions (those are WARNING).
+Err toward NIT for theoretical/defense-in-depth without a realistic attack path.
+Reserve BLOCKING for actual exploits or compliance violations (HIPAA, FERPA), not hypotheticals.
+
+Be precise: include file paths and line numbers.
 
 If this is a re-review round, explicitly state which prior findings are RESOLVED vs still BLOCKING.
 

--- a/factory/tests/test_review_prompt_calibration.py
+++ b/factory/tests/test_review_prompt_calibration.py
@@ -1,0 +1,118 @@
+"""Tests that reviewer prompts (arch + security) carry calibrated
+severity guidance after PR #29 made WARNING findings trigger a fix
+round. Captures the prompts via a fake run_cli (option (c) from the
+2b-prime spec — the prompts are built inline in _run_review, so this
+is the least invasive way to read them)."""
+import pytest
+
+import orchestrator as orch_mod
+from orchestrator import FactoryOrchestrator
+from state_machine import FactoryDB, JobStatus
+from config import DATABASE_URL
+
+TEST_TITLE_PREFIX = "review_prompt_calibration_test_"
+
+
+@pytest.fixture
+def db():
+    return FactoryDB(DATABASE_URL)
+
+
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            (f"{TEST_TITLE_PREFIX}%",),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts "
+                "WHERE job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)",
+                (ids,),
+            )
+        conn.commit()
+
+
+@pytest.fixture
+def orch():
+    return FactoryOrchestrator(DATABASE_URL)
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _FakeCLIResult:
+    """Shape-compatible with cli_executor.CLIResult."""
+    def __init__(self, stdout: str = ""):
+        self.cli = "claude"
+        self.exit_code = 0
+        self.stdout = stdout
+        self.stderr = ""
+        self.success = True
+
+
+def _make_reviewing_job(db: FactoryDB, title: str):
+    job_id = db.create_job(project_slug="devbrain", title=title, spec="test")
+    db.transition(job_id, JobStatus.PLANNING)
+    db.transition(job_id, JobStatus.IMPLEMENTING)
+    return db.get_job(job_id)
+
+
+def _capture_prompts(monkeypatch):
+    """Stub run_cli + subprocess.run. The returned list is appended
+    to on every run_cli call — captured[0] is arch_prompt, captured[1]
+    is sec_prompt."""
+    captured = []
+
+    def fake_run_cli(cli, prompt, *args, **kwargs):
+        captured.append(prompt)
+        return _FakeCLIResult(stdout="(no findings)")
+
+    monkeypatch.setattr(orch_mod, "run_cli", fake_run_cli)
+    monkeypatch.setattr(
+        orch_mod.subprocess, "run",
+        lambda *a, **k: _FakeCompleted(stdout="diff --git a/x b/x\n"),
+    )
+    return captured
+
+
+def test_arch_prompt_contains_severity_cost_guidance(orch, db, monkeypatch):
+    captured = _capture_prompts(monkeypatch)
+    job = _make_reviewing_job(db, f"{TEST_TITLE_PREFIX}arch")
+
+    orch._run_review(job)
+
+    assert len(captured) >= 1, "run_cli was not called for arch review"
+    arch_prompt = captured[0]
+    assert "Severity drives behavior" in arch_prompt
+    assert "fix-loop iterates" in arch_prompt
+    assert "each flag costs one implementer round" in arch_prompt
+    assert "Err toward NIT" in arch_prompt
+    assert "RESOLVED vs still BLOCKING" in arch_prompt
+
+
+def test_security_prompt_contains_severity_cost_guidance(orch, db, monkeypatch):
+    captured = _capture_prompts(monkeypatch)
+    job = _make_reviewing_job(db, f"{TEST_TITLE_PREFIX}sec")
+
+    orch._run_review(job)
+
+    assert len(captured) >= 2, "run_cli was not called for security review"
+    sec_prompt = captured[1]
+    assert "Severity drives behavior" in sec_prompt
+    assert "fix-loop iterates" in sec_prompt
+    assert "each flag costs one implementer round" in sec_prompt
+    assert "Err toward NIT" in sec_prompt
+    assert "defense-in-depth" in sec_prompt
+    assert "RESOLVED vs still BLOCKING" in sec_prompt


### PR DESCRIPTION
## Summary
Tightens the severity definitions in both reviewer prompts (architecture + security) now that WARNING carries real cost — PR #29 made WARNING findings trigger the fix-loop. Every WARNING the reviewer flags costs one implementer round; the prompts now communicate that asymmetry so reviewers err toward NIT for stylistic/preference concerns and reserve WARNING for issues a careful human reviewer would push back on.

## Changes
- `factory/orchestrator.py` — replaces the `## Output Format` severity blocks in both `_run_review` prompts (arch ~line 936, security ~line 993) with a new `## Severity` block:
  - Leads with "**Severity drives behavior**" to connect classification to downstream cost
  - States explicitly that WARNING triggers automatic fix-loop iteration
  - Adds "Err toward NIT / reserve WARNING for / reserve BLOCKING for" calibration sentences
- `factory/tests/test_review_prompt_calibration.py` (new, 2 tests) — string-assertion regression on the new guidance phrases ("Severity drives behavior", "fix-loop iterates", "each flag costs one implementer round", "Err toward NIT", plus security-specific "defense-in-depth").

## Produced by
Factory job `9ad0df9b` — single clean pass (~10 min total, implementing 7 min). 0 BLOCKING, 0 WARNING on both reviews. Two stylistic NITs, no hand-fix.

## Test plan
- [ ] `pytest factory/tests/test_review_prompt_calibration.py` — 2 pass.
- [ ] Submit a factory job whose change is subjective/stylistic; verify reviewers more often flag as NIT now rather than WARNING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)