### PR TITLE
feat(factory): WARNING oscillation guardrail — escalate when findings persist (2c)

### DIFF
--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -143,15 +143,30 @@ def _finding_signature(text: str) -> str:
 
 
 def _findings_overlap(current: list[str], prior: list[str]) -> list[str]:
-    """Return the sorted intersection of normalized finding signatures.
+    """Return current-round finding texts whose normalized signatures
+    also appear in the prior round.
 
     Used by the WARNING oscillation guardrail: if any signature shows
     up in both the most recent review round and the round before it,
-    the fix loop is not converging on those items.
+    the fix loop is not converging on those items. Signatures (see
+    `_finding_signature`) are used for matching because reviewers
+    paraphrase tail context round-to-round, but the ORIGINAL current-
+    round text flows out to metadata and human notifications — a
+    lowercased-truncated signature is the wrong thing to show a human.
+
+    Duplicate current-round findings with the same signature fold to
+    the first occurrence so the output order is stable and echoes the
+    reviewer's own ordering.
     """
-    current_sigs = {_finding_signature(t) for t in current}
     prior_sigs = {_finding_signature(t) for t in prior}
-    return sorted(current_sigs & prior_sigs)
+    repeating: list[str] = []
+    seen: set[str] = set()
+    for item in current:
+        sig = _finding_signature(item)
+        if sig in prior_sigs and sig not in seen:
+            seen.add(sig)
+            repeating.append(item)
+    return repeating
 
 
 class FactoryOrchestrator:

--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -129,6 +129,31 @@ def _extract_warning_items(text: str) -> list[str]:
     return items
 
 
+def _finding_signature(text: str) -> str:
+    """Normalize a finding for cross-round comparison.
+
+    Lowercases, collapses runs of whitespace to single spaces, and
+    truncates to the first 80 chars. The truncation is intentional —
+    reviewers paraphrase tail context (paragraph wording, suggested
+    fix) round to round even when the underlying issue is identical,
+    so equality on the full string under-counts repeats.
+    """
+    collapsed = re.sub(r'\s+', ' ', text.strip().lower())
+    return collapsed[:80]
+
+
+def _findings_overlap(current: list[str], prior: list[str]) -> list[str]:
+    """Return the sorted intersection of normalized finding signatures.
+
+    Used by the WARNING oscillation guardrail: if any signature shows
+    up in both the most recent review round and the round before it,
+    the fix loop is not converging on those items.
+    """
+    current_sigs = {_finding_signature(t) for t in current}
+    prior_sigs = {_finding_signature(t) for t in prior}
+    return sorted(current_sigs & prior_sigs)
+
+
 class FactoryOrchestrator:
     """Orchestrates the dev factory pipeline."""
 
@@ -330,6 +355,46 @@ class FactoryOrchestrator:
         except Exception as exc:
             logger.warning("readiness-block notification failed (non-blocking): %s", exc)
 
+    def _notify_warning_oscillation(
+        self, job: FactoryJob, repeating: list[str]
+    ) -> None:
+        """Fire a needs_human notification when the WARNING fix-loop fails
+        to converge — same WARNING signatures appeared in two
+        consecutive review rounds. Wrapped in try/except so a
+        notification failure cannot break the FAILED transition the
+        caller has already committed.
+        """
+        try:
+            from notifications.router import NotificationRouter, NotificationEvent
+            if not job.submitted_by:
+                return
+            router = NotificationRouter(self.db)
+            body_lines = [
+                f"Factory job FAILED after {job.error_count} fix round(s) — "
+                "the same WARNING findings keep coming back round after round.",
+                "",
+                "Repeating findings:",
+            ]
+            body_lines.extend(f"  - {r}" for r in repeating)
+            body_lines.extend([
+                "",
+                "Inspect the fix output and review artifacts to decide whether "
+                "to tighten the fix prompt, downgrade these to NIT, or split "
+                "the work into a follow-up job.",
+            ])
+            router.send(NotificationEvent(
+                event_type="needs_human",
+                recipient_dev_id=job.submitted_by,
+                title=f"⚠ Factory oscillation — job FAILED: {job.title}",
+                body="\n".join(body_lines),
+                job_id=job.id,
+                metadata={"repeating_warnings": list(repeating)},
+            ))
+        except Exception as exc:
+            logger.warning(
+                "warning-oscillation notification failed (non-blocking): %s", exc
+            )
+
     def _setup_implementation_branch(
         self, job: FactoryJob, project_root: str
     ) -> tuple[str | None, str | None]:
@@ -437,6 +502,28 @@ class FactoryOrchestrator:
                 items = _extract_blocking_items(art["content"])
                 prior.extend(items)
         return prior
+
+    def _get_last_round_warnings(self, job: FactoryJob) -> list[str]:
+        """Return WARNING items from the review round immediately before
+        the current one — input to the oscillation guardrail.
+
+        Each round produces two review artifacts (arch + security), so
+        the most recent round is `[-2:]` and the prior round is
+        `[-4:-2]`. The current round's artifacts are already persisted
+        by the time the post-review gate runs (store_artifact is called
+        synchronously after each reviewer completes), so we read prior
+        from the DB rather than threading state through call sites.
+
+        Returns `[]` when there are fewer than 4 review artifacts —
+        i.e., this is the first round and there is no prior to compare.
+        """
+        artifacts = self.db.get_artifacts(job.id, phase="review")
+        if len(artifacts) < 4:
+            return []
+        items: list[str] = []
+        for art in artifacts[-4:-2]:
+            items.extend(_extract_warning_items(art["content"]))
+        return items
 
     def _get_fix_history(self, job: FactoryJob) -> str:
         """Get summary of what was fixed in prior fix loops."""
@@ -1032,18 +1119,45 @@ Store any security issues found in DevBrain with type="issue" and category="secu
         warnings_trigger = (
             FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY and total_warning > 0
         )
-        if total_blocking > 0 or warnings_trigger:
-            return self.db.transition(
-                job.id,
-                JobStatus.FIX_LOOP,
-                metadata={
-                    "blocking_findings": total_blocking,
-                    "warning_findings": total_warning,
-                    "trigger_reason": "blocking" if total_blocking > 0 else "warning",
-                },
-            )
-        else:
+        should_fix = total_blocking > 0 or warnings_trigger
+        if not should_fix:
             return self.db.transition(job.id, JobStatus.QA)
+
+        # Oscillation guardrail: if BLOCKINGs are gone but WARNINGs are
+        # the same ones we already tried to fix in the prior round, the
+        # fix loop is not converging — escalate to a human instead of
+        # spending more rounds on findings the implementer keeps
+        # missing. BLOCKINGs always win: if a real bug is also present
+        # we stay in the loop.
+        if total_blocking == 0 and warnings_trigger and job.error_count >= 1:
+            current_warnings = (
+                _extract_warning_items(arch_result.stdout)
+                + _extract_warning_items(sec_result.stdout)
+            )
+            prior_warnings = self._get_last_round_warnings(job)
+            repeating = _findings_overlap(current_warnings, prior_warnings)
+            if repeating:
+                failed = self.db.transition(
+                    job.id,
+                    JobStatus.FAILED,
+                    metadata={
+                        "failure": "warning_oscillation",
+                        "repeating_warnings": repeating,
+                        "error_count_at_escalation": job.error_count,
+                    },
+                )
+                self._notify_warning_oscillation(failed, repeating)
+                return failed
+
+        return self.db.transition(
+            job.id,
+            JobStatus.FIX_LOOP,
+            metadata={
+                "blocking_findings": total_blocking,
+                "warning_findings": total_warning,
+                "trigger_reason": "blocking" if total_blocking > 0 else "warning",
+            },
+        )
 
     # ─── QA Phase ──────────────────────────────────────────────────────────
 

--- a/factory/tests/test_oscillation_guardrail.py
+++ b/factory/tests/test_oscillation_guardrail.py
@@ -140,26 +140,36 @@ def _make_job_in_fix_cycle(
 
 # ─── Unit test ────────────────────────────────────────────────────────────
 
-def test_findings_overlap_normalizes_case_and_whitespace():
-    """`_findings_overlap` is signature-based: case and runs of whitespace
-    do not affect equality, but truly different findings do not match."""
-    # Same finding, different case + whitespace → matches
+def test_findings_overlap_matches_on_signature_returns_original():
+    """`_findings_overlap` matches on normalized signatures (case-
+    insensitive, whitespace-collapsed, prefix-truncated) but returns
+    the original current-round text — never the signature — so that
+    humans read the reviewer's own words in the notification and
+    job metadata, not a lowercased stub."""
+    # Same finding, different case + whitespace → returns current original
     current = ["WARNING: missing null check at x.py:42"]
     prior = ["warning:   missing  null check  at x.py:42"]
     assert _findings_overlap(current, prior) == [
-        "warning: missing null check at x.py:42"
+        "WARNING: missing null check at x.py:42"
     ]
 
     # Different findings → empty intersection
     assert _findings_overlap(["foo"], ["bar"]) == []
 
-    # Truncation at 80 chars — same prefix matches even when suffixes diverge
+    # Truncation at 80 chars — same prefix matches even when suffixes
+    # diverge; the returned text is the full original current item.
     long_prefix = "warning: identical first eighty chars of finding text padding xxxxxxxxxxxxxxxxxxxxxx"
     assert len(long_prefix) >= 80
+    current_item = long_prefix + " distinct suffix one"
     assert _findings_overlap(
-        [long_prefix + " distinct suffix one"],
+        [current_item],
         [long_prefix + " entirely different suffix two"],
-    )
+    ) == [current_item]
+
+    # Duplicate current-round findings with the same signature fold to
+    # the first occurrence — stable, reviewer-ordered output.
+    dup = "WARNING: same thing at z.py:1"
+    assert _findings_overlap([dup, dup], [dup]) == [dup]
 
 
 # ─── Gate behavior ────────────────────────────────────────────────────────
@@ -270,3 +280,104 @@ def test_first_round_no_prior_state_does_not_escalate(orch, db, monkeypatch):
     assert result.status == JobStatus.FIX_LOOP
     assert result.metadata.get("trigger_reason") == "warning"
     assert "failure" not in result.metadata
+
+
+# ─── Notification side-effect ────────────────────────────────────────────
+# `_notify_warning_oscillation` is wrapped in a silently-swallowing
+# try/except so a body-format bug (wrong field name, KeyError) would
+# never surface in prod. These two tests are the only thing that would
+# catch that rot — they stub NotificationRouter at its import site and
+# assert on the captured event.
+
+class _FakeRouter:
+    """Captures NotificationEvent instances sent via .send(). One
+    instance per test — reset via the `sent_events` class attribute
+    inside each test."""
+    sent_events: list = []
+
+    def __init__(self, db, *args, **kwargs):
+        pass
+
+    def send(self, event):
+        type(self).sent_events.append(event)
+
+
+def _stub_notification_router(monkeypatch):
+    """Patch NotificationRouter at its source module. The orchestrator
+    imports it lazily inside `_notify_warning_oscillation`, so we patch
+    where it is defined — `factory.notifications.router` — not where
+    it is referenced."""
+    from notifications import router as router_module
+
+    _FakeRouter.sent_events = []
+    monkeypatch.setattr(router_module, "NotificationRouter", _FakeRouter)
+
+
+def test_oscillation_notification_fires_with_correct_payload(orch, db, monkeypatch):
+    """The FAILED transition's side-effect notification fires with
+    event_type=needs_human, carries the job id and repeating findings
+    in metadata, and renders the original reviewer text (not a
+    lowercased signature) into the body."""
+    monkeypatch.setattr(orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", True)
+    _stub_notification_router(monkeypatch)
+
+    job = _make_job_in_fix_cycle(
+        db,
+        f"{TEST_TITLE_PREFIX}notify_fires",
+        prior_arch_text="1. WARNING: Missing Null Check at X.py:42",
+    )
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.factory_jobs SET submitted_by = %s WHERE id = %s",
+            ("test-dev", job.id),
+        )
+        conn.commit()
+    job = db.get_job(job.id)
+
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout="1. WARNING: Missing Null Check at X.py:42",
+        sec_stdout="(no findings)",
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.FAILED
+    assert len(_FakeRouter.sent_events) == 1
+    event = _FakeRouter.sent_events[0]
+    assert event.event_type == "needs_human"
+    assert event.recipient_dev_id == "test-dev"
+    assert event.job_id == job.id
+    assert event.metadata.get("repeating_warnings")
+    # Original reviewer text — preserves case — reaches metadata + body.
+    assert any(
+        "Missing Null Check" in r for r in event.metadata["repeating_warnings"]
+    )
+    assert "Missing Null Check" in event.body
+
+
+def test_oscillation_notification_skips_when_no_submitted_by(orch, db, monkeypatch):
+    """When job.submitted_by is None there is nobody to notify — the
+    early-return branch fires before any NotificationEvent is built.
+    The FAILED transition itself still commits."""
+    monkeypatch.setattr(orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", True)
+    _stub_notification_router(monkeypatch)
+
+    # _make_job_in_fix_cycle leaves submitted_by=NULL by default.
+    job = _make_job_in_fix_cycle(
+        db,
+        f"{TEST_TITLE_PREFIX}notify_no_submitter",
+        prior_arch_text="1. WARNING: same issue at w.py:1",
+    )
+    assert job.submitted_by is None
+
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout="1. WARNING: same issue at w.py:1",
+        sec_stdout="(no findings)",
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.FAILED
+    assert _FakeRouter.sent_events == []

--- a/factory/tests/test_oscillation_guardrail.py
+++ b/factory/tests/test_oscillation_guardrail.py
@@ -1,0 +1,272 @@
+"""Tests for the WARNING oscillation guardrail.
+
+Covers the 2026-04-23 escalation that fires when the same WARNING
+findings persist across consecutive review rounds. The fix loop
+otherwise spends an implementer pass per round on findings the
+implementer apparently can't or won't fix — escalating instead to
+a human is the bounded-cost option.
+
+The guardrail itself lives at the end of `_run_review` in
+orchestrator.py, fired after the should_fix check and before the
+normal FIX_LOOP transition. We exercise it end-to-end by stubbing
+`run_cli` (no actual claude call) and `subprocess.run` (no
+`git diff main...HEAD`) and reading back the post-review job
+status + metadata.
+"""
+import pytest
+
+import orchestrator as orch_mod
+from orchestrator import (
+    FactoryOrchestrator,
+    _findings_overlap,
+)
+from state_machine import FactoryDB, JobStatus
+from config import DATABASE_URL
+
+TEST_TITLE_PREFIX = "oscillation_test_"
+
+
+@pytest.fixture
+def db():
+    return FactoryDB(DATABASE_URL)
+
+
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            (f"{TEST_TITLE_PREFIX}%",),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_cleanup_reports "
+                "WHERE job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts "
+                "WHERE job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "UPDATE devbrain.factory_jobs SET blocked_by_job_id = NULL "
+                "WHERE blocked_by_job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)",
+                (ids,),
+            )
+        conn.commit()
+
+
+@pytest.fixture
+def orch():
+    return FactoryOrchestrator(DATABASE_URL)
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _FakeCLIResult:
+    """Shape-compatible with cli_executor.CLIResult for what _run_review reads."""
+
+    def __init__(self, stdout: str):
+        self.cli = "claude"
+        self.exit_code = 0
+        self.stdout = stdout
+        self.stderr = ""
+        self.success = True
+
+
+def _stub_review_env(monkeypatch, *, arch_stdout: str, sec_stdout: str):
+    """Stub run_cli (both arch + security reviews) and subprocess.run
+    (git diff) so _run_review exercises the gate without touching CLIs
+    or git. run_cli returns arch_stdout then sec_stdout in order."""
+    responses = iter([_FakeCLIResult(arch_stdout), _FakeCLIResult(sec_stdout)])
+
+    def fake_run_cli(*args, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(orch_mod, "run_cli", fake_run_cli)
+    monkeypatch.setattr(
+        orch_mod.subprocess, "run",
+        lambda *a, **k: _FakeCompleted(stdout="diff --git a/x b/x\n"),
+    )
+
+
+def _make_job_in_fix_cycle(
+    db: FactoryDB,
+    title: str,
+    *,
+    prior_arch_text: str = "1. WARNING: same warning at file.py:10",
+    prior_sec_text: str = "(no findings)",
+):
+    """Create a job, seed it with one prior round of WARNING-only review
+    artifacts, and walk it QUEUED → PLANNING → IMPLEMENTING → REVIEWING
+    → FIX_LOOP → IMPLEMENTING. Returns the job in IMPLEMENTING state
+    with error_count=1 — i.e., ready for _run_review to fire round 2's
+    gate against the seeded prior round.
+
+    The two seeded review artifacts represent round 1's arch + security
+    review. _run_review will add round 2's pair when called, giving
+    `_get_last_round_warnings` exactly the [-4:-2] slice it expects.
+    """
+    job_id = db.create_job(project_slug="devbrain", title=title, spec="test")
+    db.transition(job_id, JobStatus.PLANNING)
+    db.transition(job_id, JobStatus.IMPLEMENTING)
+    db.transition(job_id, JobStatus.REVIEWING)
+    db.store_artifact(
+        job_id=job_id, phase="review", artifact_type="arch_review",
+        content=prior_arch_text,
+        warning_count=prior_arch_text.upper().count("WARNING"),
+    )
+    db.store_artifact(
+        job_id=job_id, phase="review", artifact_type="security_review",
+        content=prior_sec_text,
+        warning_count=prior_sec_text.upper().count("WARNING"),
+    )
+    db.transition(job_id, JobStatus.FIX_LOOP, metadata={"warning_findings": 1})
+    db.transition(job_id, JobStatus.IMPLEMENTING)
+    return db.get_job(job_id)
+
+
+# ─── Unit test ────────────────────────────────────────────────────────────
+
+def test_findings_overlap_normalizes_case_and_whitespace():
+    """`_findings_overlap` is signature-based: case and runs of whitespace
+    do not affect equality, but truly different findings do not match."""
+    # Same finding, different case + whitespace → matches
+    current = ["WARNING: missing null check at x.py:42"]
+    prior = ["warning:   missing  null check  at x.py:42"]
+    assert _findings_overlap(current, prior) == [
+        "warning: missing null check at x.py:42"
+    ]
+
+    # Different findings → empty intersection
+    assert _findings_overlap(["foo"], ["bar"]) == []
+
+    # Truncation at 80 chars — same prefix matches even when suffixes diverge
+    long_prefix = "warning: identical first eighty chars of finding text padding xxxxxxxxxxxxxxxxxxxxxx"
+    assert len(long_prefix) >= 80
+    assert _findings_overlap(
+        [long_prefix + " distinct suffix one"],
+        [long_prefix + " entirely different suffix two"],
+    )
+
+
+# ─── Gate behavior ────────────────────────────────────────────────────────
+
+def test_repeating_warnings_escalate_to_failed(orch, db, monkeypatch):
+    """When the same WARNING appears in two consecutive rounds with no
+    blockers, the gate transitions REVIEWING → FAILED with structured
+    metadata instead of bouncing through FIX_LOOP again."""
+    monkeypatch.setattr(orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", True)
+    job = _make_job_in_fix_cycle(
+        db,
+        f"{TEST_TITLE_PREFIX}escalate",
+        prior_arch_text="1. WARNING: missing null check at x.py:42",
+    )
+
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout="1. WARNING: missing null check at x.py:42",
+        sec_stdout="(no findings)",
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.FAILED
+    assert result.metadata.get("failure") == "warning_oscillation"
+    assert result.metadata.get("error_count_at_escalation") == 1
+    repeating = result.metadata.get("repeating_warnings", [])
+    assert repeating, "expected at least one repeating warning signature"
+    assert any("missing null check" in r for r in repeating)
+
+
+def test_blocking_findings_bypass_oscillation_guardrail(orch, db, monkeypatch):
+    """BLOCKING always wins: even if WARNINGs are repeating round to
+    round, the presence of a real BLOCKING finding routes the job
+    back to FIX_LOOP. We don't want to give up on a real bug."""
+    monkeypatch.setattr(orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", True)
+    job = _make_job_in_fix_cycle(
+        db,
+        f"{TEST_TITLE_PREFIX}blocking_wins",
+        prior_arch_text="1. WARNING: same warning persisting at y.py:1",
+    )
+
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout=(
+            "1. WARNING: same warning persisting at y.py:1\n"
+            "2. BLOCKING: actual exploit at y.py:5\n"
+        ),
+        sec_stdout="(no findings)",
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.FIX_LOOP
+    assert result.metadata.get("trigger_reason") == "blocking"
+    assert result.metadata.get("blocking_findings") == 1
+
+
+def test_different_warnings_do_not_escalate(orch, db, monkeypatch):
+    """If round 2's WARNINGs do not overlap round 1's, the loop is
+    making progress on something — guardrail does not fire and the
+    job goes back through FIX_LOOP normally."""
+    monkeypatch.setattr(orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", True)
+    job = _make_job_in_fix_cycle(
+        db,
+        f"{TEST_TITLE_PREFIX}different",
+        prior_arch_text="1. WARNING: old warning at a.py:1",
+    )
+
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout="1. WARNING: brand new completely different warning at b.py:2",
+        sec_stdout="(no findings)",
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.FIX_LOOP
+    assert result.metadata.get("trigger_reason") == "warning"
+
+
+def test_first_round_no_prior_state_does_not_escalate(orch, db, monkeypatch):
+    """Round 1 (error_count=0) cannot trigger the guardrail — there is
+    no prior round to compare against. The job follows the normal
+    WARNING → FIX_LOOP path even when the same string would have
+    matched, because the guard only inspects history that exists."""
+    monkeypatch.setattr(orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", True)
+
+    # Bare job — no prior review artifacts seeded, error_count=0.
+    job_id = db.create_job(
+        project_slug="devbrain",
+        title=f"{TEST_TITLE_PREFIX}first_round",
+        spec="test",
+    )
+    db.transition(job_id, JobStatus.PLANNING)
+    db.transition(job_id, JobStatus.IMPLEMENTING)
+    job = db.get_job(job_id)
+    assert job.error_count == 0
+
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout="1. WARNING: any warning at a.py:1",
+        sec_stdout="(no findings)",
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.FIX_LOOP
+    assert result.metadata.get("trigger_reason") == "warning"
+    assert "failure" not in result.metadata


### PR DESCRIPTION
## Summary
Adds a fix-loop escape hatch: when reviewer WARNINGs persist across two consecutive review rounds, the factory now transitions REVIEWING → FAILED with `failure: warning_oscillation` instead of burning another implementer round on findings the implementer apparently can't or won't fix. A needs_human notification fires with the repeating findings so the dev can decide whether to tighten the fix prompt, downgrade to NIT, or split the work.

## Design
- `_finding_signature(text)` — normalizes a WARNING for cross-round comparison (lowercase + collapsed whitespace + 80-char prefix). Truncation is deliberate; reviewers paraphrase tail context round-to-round.
- `_findings_overlap(current, prior)` — returns current-round finding **texts** whose signatures also appear in the prior round. Signatures are the matching key but the original text is what flows to metadata + notifications.
- `_get_last_round_warnings(job)` — reads review artifacts `[-4:-2]` (prior round's arch + sec), returns `[]` when fewer than 4 exist.
- `_notify_warning_oscillation(job, repeating)` — fires a `needs_human` notification with the repeating findings. Wrapped in try/except so a mail failure can't roll back the FAILED transition.
- Gate at end of `_run_review`: `total_blocking == 0 AND warnings_trigger AND error_count >= 1 AND overlap != []` → FAILED. BLOCKING always wins.

## Produced by
Factory job `42e6a70a` — single clean pass (planning 6m, implementing 14m, reviewing 4m, qa instant). 0 BLOCKING on both reviews. **0 warning_count reported in the stored artifact row**, but the arch reviewer's body actually flagged 2 WARNINGs — see Deferred below.

## Hand-fix on top of factory output
Commit `7c824fd` addresses the two arch-review WARNINGs (caught on manual inspection, missed by the pipeline counter):

1. **`repeating_warnings` now carries original text, not lowercased signatures.** The reviewer flagged that human-facing surfaces (notification body, `job.metadata`) were getting internal matching tokens like `warning: missing null check at x.py:4` — lowercased, truncated mid-word. Fix: `_findings_overlap` returns originals; signatures stay an internal detail.
2. **Notification-side-effect tests.** `_notify_warning_oscillation` wraps its whole body in a silently-swallowing try/except, so a body-format bug (wrong field, KeyError) would never surface. Two new tests stub `NotificationRouter` at its source module and assert on captured events: the happy path (event_type=needs_human, recipient, job_id, metadata, original text in body) and the `submitted_by=None` short-circuit.

## Deferred
**`_count_warning` / `_count_blocking` miss bolded-markdown numbered lists** like `**1. WARNING —**`. The arch review for this very job had `warning_count=0` in its `factory_artifacts` row despite having 2 numbered WARNINGs in the body. That's why fix-loop didn't trigger on those — and why hand-review caught what the pipeline couldn't. This is a pipeline-wide invisibility bug affecting every job under the new WARNING-fix-loop gate (PR #29). Tracking as a separate task — not a 2c concern.

## Test plan
- [ ] `pytest factory/tests/test_oscillation_guardrail.py` — 7 tests pass (5 gate + 2 notification)
- [ ] Full factory suite: `pytest factory/tests/` — 240 pass (verified locally both before and after the hand-fix commit)
- [ ] Submit a factory job where the reviewer will flag a repeating WARNING across two rounds — verify FAILED transition, needs_human email body contains original reviewer text (not a lowercased signature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)