### PR TITLE
fix(factory): count stacked severity prefixes (**1. WARNING)

### DIFF
--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -92,8 +92,11 @@ def _worktree_path_for_job(job) -> str:
 
 def _count_blocking(text: str) -> int:
     """Count actual BLOCKING findings — look for the marker at start of line or list item."""
-    # Match patterns like "BLOCKING:", "**BLOCKING**", "1. BLOCKING:", "- BLOCKING:"
-    pattern = r'(?:^|\n)\s*(?:\d+\.\s*|\*\*?|-\s*)?BLOCKING\b'
+    # Match patterns like "BLOCKING:", "**BLOCKING**", "1. BLOCKING:", "- BLOCKING:",
+    # and stacked combos like "**1. BLOCKING" or "- **BLOCKING**" that reviewers
+    # produce when nesting bold/list/number prefixes. {0,4} is bounded — each
+    # alternative consumes ≥1 char so there is no catastrophic backtracking.
+    pattern = r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}BLOCKING\b'
     return len(re.findall(pattern, text, re.IGNORECASE))
 
 
@@ -101,10 +104,10 @@ def _extract_blocking_items(text: str) -> list[str]:
     """Extract individual BLOCKING finding texts."""
     items = []
     # Split on BLOCKING markers and capture the text after each
-    parts = re.split(r'(?:^|\n)\s*(?:\d+\.\s*|\*\*?|-\s*)?BLOCKING[:\s]*', text, flags=re.IGNORECASE)
+    parts = re.split(r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}BLOCKING[:\s]*', text, flags=re.IGNORECASE)
     for part in parts[1:]:  # Skip text before first BLOCKING
         # Take text until next severity marker or end
-        end = re.search(r'\n\s*(?:\d+\.\s*|\*\*?|-\s*)?(?:WARNING|NIT|BLOCKING)\b', part, re.IGNORECASE)
+        end = re.search(r'\n\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}(?:WARNING|NIT|BLOCKING)\b', part, re.IGNORECASE)
         item = part[:end.start()].strip() if end else part.strip()
         if item:
             items.append(item)
@@ -113,16 +116,16 @@ def _extract_blocking_items(text: str) -> list[str]:
 
 def _count_warning(text: str) -> int:
     """Count actual WARNING findings — look for the marker at start of line or list item."""
-    pattern = r'(?:^|\n)\s*(?:\d+\.\s*|\*\*?|-\s*)?WARNING\b'
+    pattern = r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}WARNING\b'
     return len(re.findall(pattern, text, re.IGNORECASE))
 
 
 def _extract_warning_items(text: str) -> list[str]:
     """Extract individual WARNING finding texts."""
     items = []
-    parts = re.split(r'(?:^|\n)\s*(?:\d+\.\s*|\*\*?|-\s*)?WARNING[:\s]*', text, flags=re.IGNORECASE)
+    parts = re.split(r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}WARNING[:\s]*', text, flags=re.IGNORECASE)
     for part in parts[1:]:
-        end = re.search(r'\n\s*(?:\d+\.\s*|\*\*?|-\s*)?(?:BLOCKING|NIT|WARNING)\b', part, re.IGNORECASE)
+        end = re.search(r'\n\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}(?:BLOCKING|NIT|WARNING)\b', part, re.IGNORECASE)
         item = part[:end.start()].strip() if end else part.strip()
         if item:
             items.append(item)

--- a/factory/tests/test_severity_marker_regex.py
+++ b/factory/tests/test_severity_marker_regex.py
@@ -1,0 +1,141 @@
+"""Tests for stacked-prefix severity markers in _count_*/_extract_* helpers.
+
+The four helpers in orchestrator.py
+(_count_blocking, _count_warning, _extract_blocking_items,
+_extract_warning_items) used to use a prefix group that matched AT MOST
+ONE of {number, bold, dash}. Reviewers naturally produce stacked
+prefixes like ``**1. WARNING — text**`` or ``- **WARNING:** body``,
+which the old regex silently missed — leaving warning_count at 0 on
+real findings and skipping the WARNING fix-loop gate.
+
+These are pure-function tests (no DB fixture); they exercise the regex
+behavior directly. The autouse cleanup fixture used elsewhere in this
+directory is unnecessary here because no factory_jobs rows are created.
+"""
+from orchestrator import (
+    _count_blocking,
+    _count_warning,
+    _extract_blocking_items,
+    _extract_warning_items,
+)
+
+
+def test_stacked_bold_number_warning_regression():
+    """``**1. WARNING — text**`` was the original miss that motivated the fix."""
+    text = "**1. WARNING — missing null check at x.py:42**"
+    assert _count_warning(text) == 1
+
+
+def test_stacked_bold_number_blocking_and_warning_mixed():
+    """Mixed bold-number stacked forms: 1 BLOCKING + 1 WARNING."""
+    text = (
+        "**2. BLOCKING — null deref at a.py:10**\n"
+        "**3. WARNING — suboptimal pattern at b.py:5**\n"
+    )
+    assert _count_blocking(text) == 1
+    assert _count_warning(text) == 1
+
+
+def test_number_then_bold_warning():
+    """``1. **WARNING:** body`` — number first, then bold."""
+    text = "1. **WARNING:** missing docstring"
+    assert _count_warning(text) == 1
+
+
+def test_dash_then_bold_warning():
+    """``- **WARNING:** body`` — dash first, then bold."""
+    text = "- **WARNING:** consider caching result"
+    assert _count_warning(text) == 1
+
+
+def test_plain_forms_regression_guard():
+    """Bare / numbered / bolded / dashed forms must still be detected.
+
+    Locks in the original behavior so the {0,4} change doesn't regress
+    the simple cases the prior regex already handled.
+    """
+    text = (
+        "WARNING: bare form\n"
+        "1. WARNING: numbered\n"
+        "**WARNING**: bolded\n"
+        "- WARNING: dashed\n"
+    )
+    assert _count_warning(text) == 4
+
+    btext = (
+        "BLOCKING: bare\n"
+        "1. BLOCKING: numbered\n"
+        "**BLOCKING**: bolded\n"
+        "- BLOCKING: dashed\n"
+    )
+    assert _count_blocking(btext) == 4
+
+
+def test_prose_word_warning_does_not_match():
+    """A prose mention like ``warning sign`` must not be counted.
+
+    The start-of-line/list anchor is what keeps mid-sentence words out.
+    """
+    text = "There was a warning sign on the wall."
+    assert _count_warning(text) == 0
+
+
+def test_realistic_review_body_mixed_styles():
+    """A realistic reviewer body with 2 BLOCKING + 3 WARNING + 1 NIT.
+
+    Mixes plain numbered, bold-stacked, and dash-stacked styles so the
+    helpers exercise the full prefix permutation set in one body.
+    Verifies both counts AND that extracted bodies stop at the next
+    severity boundary.
+    """
+    text = (
+        "## Review\n"
+        "1. BLOCKING: missing auth check at handler.py:88\n"
+        "**2. WARNING — suboptimal query plan at db.py:120**\n"
+        "- **WARNING:** docstring missing for public API foo()\n"
+        "3. WARNING: hardcoded timeout at worker.py:45\n"
+        "**4. BLOCKING — race condition at cache.py:200**\n"
+        "5. NIT: prefer f-strings\n"
+    )
+    assert _count_blocking(text) == 2
+    assert _count_warning(text) == 3
+
+    blockings = _extract_blocking_items(text)
+    assert len(blockings) == 2
+    assert "missing auth check" in blockings[0]
+    # First blocking body must stop before the next WARNING
+    assert "suboptimal query plan" not in blockings[0]
+    assert "race condition" in blockings[1]
+
+    warnings = _extract_warning_items(text)
+    assert len(warnings) == 3
+    assert "suboptimal query plan" in warnings[0]
+    assert "docstring missing" in warnings[1]
+    assert "hardcoded timeout" in warnings[2]
+    # Last warning body must not bleed into the BLOCKING that follows
+    assert "race condition" not in warnings[2]
+
+
+def test_extract_warning_stops_at_stacked_blocking_boundary():
+    """End-boundary regex must also tolerate stacked prefixes.
+
+    ``"1. WARNING: foo\\n\\n**2. BLOCKING: bar**"`` — the warning body
+    should stop before the bold-stacked BLOCKING, otherwise the
+    extracted text leaks into the next finding.
+    """
+    text = "1. WARNING: foo\n\n**2. BLOCKING: bar**"
+    warnings = _extract_warning_items(text)
+    assert len(warnings) == 1
+    assert "foo" in warnings[0]
+    assert "BLOCKING" not in warnings[0]
+    assert "bar" not in warnings[0]
+
+
+def test_bound_check_six_dashes_does_not_match():
+    """Locks the {0,4} cap — beyond 4 stacked prefixes we deliberately
+    don't match. This guards against a future change that loosens the
+    bound and re-introduces the catastrophic-backtracking risk that {0,4}
+    was chosen to avoid.
+    """
+    text = ("- " * 6) + "WARNING: body"
+    assert _count_warning(text) == 0


### PR DESCRIPTION
## Summary
`_count_warning`, `_count_blocking`, and the two `_extract_*` helpers in `factory/orchestrator.py` were silently dropping real findings when reviewers used stacked markdown prefixes like `**1. WARNING —`. The old regex `(?:\d+\.\s*|\*\*?|-\s*)?` was a single-choice optional group — it matched `**WARNING`, `1. WARNING`, or `- WARNING`, but never combinations.

## The bug in practice
Factory job `42e6a70a` (PR #31, oscillation guardrail) produced an arch review with two numbered bolded WARNINGs. The artifact row stored `warning_count=0`. Consequence: PR #29's WARNING fix-loop gate (`total_warning > 0`) didn't fire — the job coasted to `ready_for_approval` on a single pass despite real findings. The WARNINGs were caught only by hand-inspection; PR #31 commit `7c824fd` addressed them. This change makes the pipeline see what the reviewer actually wrote.

## Fix
Swap the single-choice optional group for a bounded stacked group in all 6 regex sites (4 helpers, 2 with inner end-boundary regex):
```python
# Old:  (?:\d+\.\s*|\*\*?|-\s*)?
# New:  (?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}
```
The `{0,4}` cap is bounded ReDoS-safe: every alternative consumes ≥1 non-whitespace char, so 4 stacked prefixes can consume at most ~20 chars before the regex gives up. Polynomial worst case, not catastrophic.

## Produced by
Factory job `32e20829` — single clean pass (planning 3m, implementing 9m, arch review 4m, security review 2m, qa instant). 0 BLOCKING + 0 WARNING on both reviews. Security reviewer notes this change **tightens** the fix-loop gate since the old regex silently let real findings reach approval.

## Tests
- `factory/tests/test_severity_marker_regex.py` (new, 9 pure-function tests):
  - Stacked-bold-number regression case (`**1. WARNING — text**`)
  - Mixed BLOCKING+WARNING with stacked bold-number prefixes
  - Number-then-bold (`1. **WARNING:**`)
  - Dash-then-bold (`- **WARNING:**`)
  - Plain-form regression guard (all pre-existing shapes still count)
  - Prose-word negative (`"warning sign"` → 0 false positive via `\b`)
  - Realistic mixed-style review body: counts + extracted body bodies + boundary behavior
  - `_extract_*` end-boundary with a stacked-BLOCKING follower (extraction stops before it)
  - Bound check: `{0,4}` cap is deliberate and asserted (6 dashes does not match)

All 9 new tests pass locally (pure-function, no DB needed).

## Follow-ups (not blocking)
Reviewer NITs worth noting but not blocking merge:
- Add a short "don't add zero-width alternatives" comment above the regex sites — the `{0,4}` bound only holds while every alternative consumes ≥1 char.
- Consider asserting both 4-stack-matches AND 5-stack-doesn't in the cap test so a future `{0,5}` bump fails fast.
- Existing pre-refactor behavior: `**WARNING**: body` leaves the trailing `**:` in the extracted body because `WARNING[:\s]*` doesn't strip `*`. Not changed here.

## Test plan
- [ ] `pytest factory/tests/test_severity_marker_regex.py` — 9 pass
- [ ] Full factory suite on a machine with working Postgres — should remain green (change is pure-function, only affects string parsing)
- [ ] Post-merge sanity: pass factory job `42e6a70a`'s stored arch_review body through the updated `_count_warning` — should return 2 (currently returns 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)