### PR TITLE
feat(factory): ff-only sync before push in factory_approve (task #13)

### DIFF
--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -1376,35 +1376,47 @@ IMPORTANT: Fix ONLY the listed findings. Do not expand scope. Do not "improve" s
 
             if fetch_result is not None and fetch_result.returncode == 0:
                 # Fetch succeeded — origin has the branch. Try to ff-merge.
-                merge_result = None
+                # Both branches below funnel into `merge_error` so the
+                # subprocess-raised case (TimeoutExpired, OSError) also
+                # bails out instead of silently falling through to push
+                # from a worktree fetch already told us is behind origin.
+                merge_error: str | None = None
                 try:
                     merge_result = subprocess.run(
                         ["git", "merge", "--ff-only",
                          f"origin/{job.branch_name}"],
                         cwd=project_root, capture_output=True, timeout=30,
                     )
+                    if merge_result.returncode != 0:
+                        combined = (
+                            (merge_result.stderr or b"")
+                            + (merge_result.stdout or b"")
+                        )
+                        merge_error = (
+                            combined.decode("utf-8", errors="replace").strip()
+                        )[-2048:] or "(no git output)"
                 except Exception as e:
-                    logger.warning("Pre-push ff-merge failed to spawn: %s", e)
-
-                if merge_result is not None and merge_result.returncode != 0:
-                    # Divergent history — refuse to advance. Record the
-                    # git output so the human can see exactly what went
-                    # wrong, leave status at READY_FOR_APPROVAL, and bail.
-                    combined = (
-                        (merge_result.stderr or b"")
-                        + (merge_result.stdout or b"")
+                    # Fetch already confirmed origin is ahead; pushing
+                    # from this worktree now would silently advance to
+                    # stale tips. Record and bail — same contract as the
+                    # non-zero returncode branch above.
+                    merge_error = f"merge subprocess failed: {e}"
+                    logger.warning(
+                        "Pre-push ff-merge failed to spawn: %s", e
                     )
-                    error_detail = (
-                        combined.decode("utf-8", errors="replace").strip()
-                    )[-2048:] or "(no git output)"
+
+                if merge_error is not None:
+                    # Divergent history OR merge subprocess died — either
+                    # way, leave status at READY_FOR_APPROVAL so a human
+                    # can inspect and decide.
                     self.db.update_metadata(
                         job.id,
-                        {"approve_sync_error": error_detail},
+                        {"approve_sync_error": merge_error},
                     )
                     logger.warning(
                         "Approve-sync ff-only failed for job %s: %s",
                         job.id[:8],
-                        error_detail.splitlines()[0] if error_detail else "",
+                        merge_error.splitlines()[0],
                     )
                     return self.db.get_job(job.id)
             # Else: fetch failed (origin has no branch yet, network, auth

--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -1345,17 +1345,76 @@ IMPORTANT: Fix ONLY the listed findings. Do not expand scope. Do not "improve" s
     # ─── Approval ──────────────────────────────────────────────────────────
 
     def approve_job(self, job_id: str, notes: str | None = None) -> FactoryJob:
-        """Approve a job — pushes the branch."""
+        """Approve a job — syncs the worktree with origin, then pushes."""
         job = self.db.get_job(job_id)
         if not job or job.status != JobStatus.READY_FOR_APPROVAL:
-            raise ValueError(f"Job {job_id} is not ready for approval (status: {job.status.value if job else 'not found'})")
+            raise ValueError(
+                f"Job {job_id} is not ready for approval "
+                f"(status: {job.status.value if job else 'not found'})"
+            )
 
         # Push from the job's worktree. The branch ref lives in the
         # shared .git dir so the push still updates origin correctly.
         project_root = self._get_job_cwd(job)
 
-        # Push the branch
         if job.branch_name:
+            # Sync the worktree with origin BEFORE pushing. If a human
+            # pushed hand-fix commits to this branch from another machine
+            # between factory completion and approval, our worktree is
+            # behind origin — an unsynced push gets rejected as
+            # non-fast-forward. Fetch + ff-only merge catches that case
+            # silently, and fails loud on genuine history divergence.
+            fetch_result = None
+            try:
+                fetch_result = subprocess.run(
+                    ["git", "fetch", "origin", job.branch_name],
+                    cwd=project_root, capture_output=True, timeout=30,
+                )
+            except Exception as e:
+                # spawn/timeout — treat as a missed fetch; proceed to push.
+                logger.warning("Pre-push fetch failed: %s", e)
+
+            if fetch_result is not None and fetch_result.returncode == 0:
+                # Fetch succeeded — origin has the branch. Try to ff-merge.
+                merge_result = None
+                try:
+                    merge_result = subprocess.run(
+                        ["git", "merge", "--ff-only",
+                         f"origin/{job.branch_name}"],
+                        cwd=project_root, capture_output=True, timeout=30,
+                    )
+                except Exception as e:
+                    logger.warning("Pre-push ff-merge failed to spawn: %s", e)
+
+                if merge_result is not None and merge_result.returncode != 0:
+                    # Divergent history — refuse to advance. Record the
+                    # git output so the human can see exactly what went
+                    # wrong, leave status at READY_FOR_APPROVAL, and bail.
+                    combined = (
+                        (merge_result.stderr or b"")
+                        + (merge_result.stdout or b"")
+                    )
+                    error_detail = (
+                        combined.decode("utf-8", errors="replace").strip()
+                    )[-2048:] or "(no git output)"
+                    self.db.update_metadata(
+                        job.id,
+                        {"approve_sync_error": error_detail},
+                    )
+                    logger.warning(
+                        "Approve-sync ff-only failed for job %s: %s",
+                        job.id[:8],
+                        error_detail.splitlines()[0] if error_detail else "",
+                    )
+                    return self.db.get_job(job.id)
+            # Else: fetch failed (origin has no branch yet, network, auth
+            # on fetch) — swallow silently and let the push surface any
+            # real problem. This is the "first push" case where origin
+            # doesn't have the branch yet; fetch of a nonexistent ref is
+            # the only non-error signal for that state.
+
+            # Push. Keeps the existing behavior (non-zero exit is logged
+            # but swallowed; only spawn/timeout raises).
             try:
                 subprocess.run(
                     ["git", "push", "-u", "origin", job.branch_name],
@@ -1364,8 +1423,10 @@ IMPORTANT: Fix ONLY the listed findings. Do not expand scope. Do not "improve" s
             except Exception as e:
                 logger.warning("Push failed: %s", e)
 
-        job = self.db.transition(job.id, JobStatus.APPROVED,
-                                 metadata={"approved_at": "now", "notes": notes or ""})
+        job = self.db.transition(
+            job.id, JobStatus.APPROVED,
+            metadata={"approved_at": "now", "notes": notes or ""},
+        )
         notify_desktop("DevBrain Factory", f"Approved: {job.title}")
         return job
 

--- a/factory/state_machine.py
+++ b/factory/state_machine.py
@@ -269,6 +269,19 @@ class FactoryDB:
         logger.info("Job %s: %s → %s", job_id[:8], job.status.value, new_status.value)
         return self.get_job(job_id)
 
+    def update_metadata(self, job_id: str, metadata: dict) -> None:
+        """Merge the given dict into a job's metadata JSONB without
+        changing status. Used when we need to attach diagnostic info
+        (e.g., approve_sync_error) but the state must not advance."""
+        with self._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "UPDATE devbrain.factory_jobs "
+                "SET metadata = metadata || %s::jsonb, updated_at = now() "
+                "WHERE id = %s",
+                (json.dumps(metadata), job_id),
+            )
+            conn.commit()
+
     def set_blocked_resolution(self, job_id: str, resolution: str) -> None:
         """Set the dev's resolution for a blocked job.
 

--- a/factory/tests/test_factory_approve_sync.py
+++ b/factory/tests/test_factory_approve_sync.py
@@ -1,0 +1,263 @@
+"""Tests for factory_approve's git sync step before push.
+
+Covers the change where approve_job runs
+
+    git fetch origin <branch>
+    git merge --ff-only origin/<branch>
+
+in the worktree cwd before `git push -u origin <branch>`, so a
+worktree whose branch tip is behind origin catches up silently
+instead of pushing a non-fast-forward that git rejects.
+
+Spec: worktree sync at approval boundary only — not per-phase.
+Stubs `orchestrator.subprocess.run` to avoid touching git and
+`orchestrator.notify_desktop` to avoid `osascript` calls.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import orchestrator as orch_mod
+from orchestrator import FactoryOrchestrator
+from state_machine import FactoryDB, JobStatus
+from config import DATABASE_URL
+
+TEST_TITLE_PREFIX = "approve_sync_test_"
+
+
+@pytest.fixture
+def db():
+    return FactoryDB(DATABASE_URL)
+
+
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.factory_jobs WHERE title LIKE %s",
+            (f"{TEST_TITLE_PREFIX}%",),
+        )
+        ids = [r[0] for r in cur.fetchall()]
+        if ids:
+            cur.execute(
+                "DELETE FROM devbrain.factory_cleanup_reports "
+                "WHERE job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts "
+                "WHERE job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "UPDATE devbrain.factory_jobs SET blocked_by_job_id = NULL "
+                "WHERE blocked_by_job_id = ANY(%s)",
+                (ids,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)",
+                (ids,),
+            )
+        conn.commit()
+
+
+@pytest.fixture
+def orch():
+    return FactoryOrchestrator(DATABASE_URL)
+
+
+@pytest.fixture
+def silence_notify(monkeypatch):
+    """Suppress notify_desktop's osascript call on success paths."""
+    monkeypatch.setattr(orch_mod, "notify_desktop", lambda *a, **k: None)
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int = 0, stdout: bytes = b"", stderr: bytes = b""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _walk_to_ready(
+    db: FactoryDB, title: str, branch_name: str,
+):
+    """Walk a fresh job QUEUED → ... → READY_FOR_APPROVAL with branch_name
+    set. Mirrors the pattern used in test_orchestrator_cleanup.py."""
+    job_id = db.create_job(
+        project_slug="devbrain", title=title, spec="test",
+    )
+    db.transition(job_id, JobStatus.PLANNING)
+    db.store_artifact(job_id, "planning", "plan", "plan body")
+    db.transition(
+        job_id, JobStatus.IMPLEMENTING, branch_name=branch_name,
+    )
+    db.store_artifact(job_id, "implementing", "diff", "diff body")
+    db.transition(job_id, JobStatus.REVIEWING)
+    db.store_artifact(
+        job_id, "reviewing", "review", "LGTM",
+        findings_count=0, blocking_count=0,
+    )
+    db.transition(job_id, JobStatus.QA)
+    db.store_artifact(
+        job_id, "qa", "qa_report", "All pass",
+        findings_count=0, blocking_count=0,
+    )
+    db.transition(job_id, JobStatus.READY_FOR_APPROVAL)
+    return db.get_job(job_id)
+
+
+# ─── 1. Normal case: origin ahead, sync + push all succeed ──────────────
+
+def test_fetch_merge_push_happy_path(orch, db, monkeypatch, silence_notify):
+    """Worktree is behind origin: fetch succeeds, ff-only merge succeeds,
+    push succeeds → status becomes APPROVED. Assert the call sequence is
+    [fetch, merge --ff-only, push] in that order."""
+    branch = "feature/approve-sync-happy"
+    job = _walk_to_ready(db, f"{TEST_TITLE_PREFIX}happy", branch_name=branch)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(orch_mod.subprocess, "run", fake_run)
+
+    result = orch.approve_job(job.id)
+
+    assert result.status == JobStatus.APPROVED
+    git_calls = [c for c in calls if c and c[0] == "git"]
+    assert len(git_calls) == 3, f"expected fetch+merge+push, got: {git_calls}"
+    assert git_calls[0][:3] == ["git", "fetch", "origin"]
+    assert git_calls[0][-1] == branch
+    assert git_calls[1][:3] == ["git", "merge", "--ff-only"]
+    assert git_calls[1][-1] == f"origin/{branch}"
+    assert git_calls[2][:3] == ["git", "push", "-u"]
+    assert branch in git_calls[2]
+
+
+# ─── 2. First push: origin has no branch yet → fetch miss, proceed ──────
+
+def test_first_push_fetch_miss_does_not_block(
+    orch, db, monkeypatch, silence_notify,
+):
+    """Origin doesn't have the branch yet (first push): fetch returns
+    non-zero, merge is NOT attempted, push proceeds → APPROVED.
+    Key assertion: the job does NOT stay at READY_FOR_APPROVAL on
+    fetch miss — that's the signal for a first push, not an error."""
+    branch = "feature/approve-sync-first-push"
+    job = _walk_to_ready(db, f"{TEST_TITLE_PREFIX}first", branch_name=branch)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:2] == ["git", "fetch"]:
+            return _FakeCompleted(
+                returncode=128,
+                stderr=b"fatal: couldn't find remote ref "
+                       b"refs/heads/" + branch.encode(),
+            )
+        # push succeeds
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(orch_mod.subprocess, "run", fake_run)
+
+    result = orch.approve_job(job.id)
+
+    assert result.status == JobStatus.APPROVED, (
+        f"fetch miss must not block approval; status was {result.status}"
+    )
+    assert "approve_sync_error" not in result.metadata
+    # Merge must NOT have been called when fetch missed.
+    merge_calls = [c for c in calls if c[:3] == ["git", "merge", "--ff-only"]]
+    assert merge_calls == [], (
+        f"ff-only merge must not run on fetch miss; got: {merge_calls}"
+    )
+    # Push must have been called.
+    push_calls = [c for c in calls if c[:3] == ["git", "push", "-u"]]
+    assert len(push_calls) == 1
+
+
+# ─── 3. Divergent history: ff-only fails → revert + approve_sync_error ──
+
+def test_divergent_history_reverts_and_records_error(orch, db, monkeypatch):
+    """Fetch succeeds but ff-only merge fails (divergent history).
+    Push must NOT be attempted; job stays at READY_FOR_APPROVAL;
+    metadata contains approve_sync_error with the git error tail."""
+    branch = "feature/approve-sync-divergent"
+    job = _walk_to_ready(db, f"{TEST_TITLE_PREFIX}divergent", branch_name=branch)
+    calls: list[list[str]] = []
+    merge_stderr = (
+        b"hint: You have divergent branches and need to specify how to "
+        b"reconcile them.\n"
+        b"fatal: Not possible to fast-forward, aborting.\n"
+    )
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:2] == ["git", "fetch"]:
+            return _FakeCompleted(returncode=0)
+        if cmd[:3] == ["git", "merge", "--ff-only"]:
+            return _FakeCompleted(returncode=128, stderr=merge_stderr)
+        # push — must NOT be reached
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(orch_mod.subprocess, "run", fake_run)
+
+    result = orch.approve_job(job.id)
+
+    assert result.status == JobStatus.READY_FOR_APPROVAL, (
+        "ff-only failure must leave job at READY_FOR_APPROVAL"
+    )
+    assert "approve_sync_error" in result.metadata
+    err = result.metadata["approve_sync_error"]
+    assert "fast-forward" in err or "divergent" in err, (
+        f"expected git error detail in metadata, got: {err!r}"
+    )
+    push_calls = [c for c in calls if c[:3] == ["git", "push", "-u"]]
+    assert push_calls == [], (
+        f"push must not run when ff-only fails; got: {push_calls}"
+    )
+
+
+# ─── 4. Regression: push-fails-after-sync-succeeds preserves existing path
+
+def test_push_fail_after_sync_preserves_existing_behavior(
+    orch, db, monkeypatch, silence_notify,
+):
+    """Regression guard: fetch + merge succeed, but push itself fails.
+    The existing push-failure behavior — log a warning and still
+    transition to APPROVED — must be preserved. The spec scopes this
+    PR to the sync step only; push semantics must not change."""
+    branch = "feature/approve-sync-push-fail"
+    job = _walk_to_ready(
+        db, f"{TEST_TITLE_PREFIX}push_fail_regression", branch_name=branch,
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == ["git", "push", "-u"]:
+            # Simulate a real push failure (auth prompt hang surfaced
+            # as TimeoutExpired, which the existing except branch
+            # catches and swallows).
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(orch_mod.subprocess, "run", fake_run)
+
+    result = orch.approve_job(job.id)
+
+    # Existing behavior: push failure is swallowed → APPROVED.
+    assert result.status == JobStatus.APPROVED
+    assert "approve_sync_error" not in result.metadata
+    # All three git calls should have fired (push raised after being invoked).
+    fetch_calls = [c for c in calls if c[:2] == ["git", "fetch"]]
+    merge_calls = [c for c in calls if c[:3] == ["git", "merge", "--ff-only"]]
+    push_calls = [c for c in calls if c[:3] == ["git", "push", "-u"]]
+    assert len(fetch_calls) == 1
+    assert len(merge_calls) == 1
+    assert len(push_calls) == 1

--- a/factory/tests/test_factory_approve_sync.py
+++ b/factory/tests/test_factory_approve_sync.py
@@ -261,3 +261,49 @@ def test_push_fail_after_sync_preserves_existing_behavior(
     assert len(fetch_calls) == 1
     assert len(merge_calls) == 1
     assert len(push_calls) == 1
+
+
+# ─── 5. Merge subprocess exception: must not silently fall through to push
+#
+# Addresses the PR #33 arch-review WARNING: when `subprocess.run` raises
+# (TimeoutExpired, OSError) on the merge call, fetch already confirmed
+# origin is ahead — pushing anyway would silently advance to stale tips
+# and the existing push-swallow would mark the job APPROVED with no
+# diagnostic. The fix funnels the exception into the same bail-out path
+# as a non-zero returncode.
+
+def test_merge_subprocess_exception_reverts_and_records_error(
+    orch, db, monkeypatch,
+):
+    """Regression for the merge-exception silent-fallthrough bug.
+    If `git merge --ff-only` raises after fetch confirmed origin is
+    ahead, the job must stay at READY_FOR_APPROVAL with
+    approve_sync_error set and push must NOT run."""
+    branch = "feature/approve-sync-merge-exception"
+    job = _walk_to_ready(
+        db, f"{TEST_TITLE_PREFIX}merge_exception", branch_name=branch,
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:2] == ["git", "fetch"]:
+            return _FakeCompleted(returncode=0)
+        if cmd[:3] == ["git", "merge", "--ff-only"]:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+        # push — must NOT be reached
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(orch_mod.subprocess, "run", fake_run)
+
+    result = orch.approve_job(job.id)
+
+    assert result.status == JobStatus.READY_FOR_APPROVAL, (
+        "merge subprocess exception must leave job at READY_FOR_APPROVAL"
+    )
+    assert "approve_sync_error" in result.metadata
+    assert "merge subprocess failed" in result.metadata["approve_sync_error"]
+    push_calls = [c for c in calls if c[:3] == ["git", "push", "-u"]]
+    assert push_calls == [], (
+        f"push must not run when merge subprocess raised; got: {push_calls}"
+    )

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -3,8 +3,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { spawn, spawnSync } from 'child_process'
-import { writeFileSync, unlinkSync } from 'fs'
-import { tmpdir } from 'os'
+import { existsSync, writeFileSync, unlinkSync } from 'fs'
+import { homedir, tmpdir } from 'os'
 import { join, resolve } from 'path'
 import { z } from 'zod'
 import { query } from './db.js'
@@ -616,11 +616,63 @@ server.tool(
         return { content: [{ type: 'text', text: `Job "${title}" APPROVED, but the project has no root_path on record — can't locate the git worktree. Push branch '${branch_name}' manually.` }] }
       }
 
+      // Worktree-aware cwd: factory jobs run in per-job worktrees at
+      // ~/devbrain-worktrees/<job_id>/. Mirrors Python's _get_job_cwd.
+      // Falls back to root_path for pre-worktree jobs or planning-only.
+      const worktreeDir = join(homedir(), 'devbrain-worktrees', job_id)
+      const gitCwd = existsSync(worktreeDir) ? worktreeDir : root_path
+
+      // Sync the worktree with origin before pushing. If a human
+      // pushed commits to this branch from another machine between
+      // factory completion and approval, our worktree is behind
+      // origin and `git push` would be rejected as non-fast-forward.
+      // Fetch + ff-only merge catches that silently; divergent
+      // history fails loud so we can surface it.
+      const fetchResult = spawnSync(
+        'git',
+        ['fetch', 'origin', branch_name],
+        { cwd: gitCwd, encoding: 'utf-8', timeout: 30_000 },
+      )
+
+      // Only attempt ff-merge when fetch succeeded. A fetch miss
+      // (e.g. origin has no such branch yet — first push) falls
+      // through to the push; the push itself will surface any real
+      // problem.
+      if (!fetchResult.error && fetchResult.status === 0) {
+        const mergeResult = spawnSync(
+          'git',
+          ['merge', '--ff-only', `origin/${branch_name}`],
+          { cwd: gitCwd, encoding: 'utf-8', timeout: 30_000 },
+        )
+
+        if (mergeResult.error || mergeResult.status !== 0) {
+          // Divergent history — revert status, record the detail in
+          // the job's metadata so the human can inspect, and return.
+          const combined = `${mergeResult.stderr ?? ''}${mergeResult.stdout ?? ''}`.trim()
+          const detail = (combined || mergeResult.error?.message || '(no git output)').slice(-2048)
+          await query(
+            "UPDATE devbrain.factory_jobs "
+            + "SET status = 'ready_for_approval', "
+            + "    current_phase = 'ready_for_approval', "
+            + "    metadata = metadata || $2::jsonb, "
+            + "    updated_at = now() "
+            + "WHERE id = $1",
+            [job_id, JSON.stringify({ approve_sync_error: detail })],
+          )
+          return {
+            content: [{
+              type: 'text',
+              text: `Job "${title}" approval SYNC FAILED (worktree diverged from origin/${branch_name}). Status reverted to ready_for_approval.\n\ngit output tail:\n${detail}\n\nResolve the divergence in the worktree (rebase or reset to origin) then re-run factory_approve.`,
+            }],
+          }
+        }
+      }
+
       // Now actually push. 60s is plenty for a single-branch push;
       // anything longer is a stuck auth prompt or network hang we want
       // to surface, not wait on.
       const push = spawnSync('git', ['push', '-u', 'origin', branch_name], {
-        cwd: root_path,
+        cwd: gitCwd,
         encoding: 'utf-8',
         timeout: 60_000,
       })
@@ -937,8 +989,7 @@ server.tool(
 // The URL is the tunnel-exposed loopback address on THIS machine — set up
 // the SSH tunnel separately (e.g., `ssh -L 18900:127.0.0.1:18900 mac-studio`).
 
-import { homedir } from 'os'
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync } from 'fs'
 import YAML from 'yaml'
 
 interface AgentBusTarget {


### PR DESCRIPTION
## Summary
`factory_approve`'s `git push -u origin <branch>` rejected with `non-fast-forward` any time the factory-host worktree was behind origin — e.g. after a human pushed hand-fix commits from a different machine between factory completion and approval. Hit twice on recent PRs (#29 and the scp-patch workaround on #31/#32). This PR adds a `git fetch origin <branch>` + `git merge --ff-only origin/<branch>` sync step in the worktree cwd before the push, on both the Python orchestrator path and the TypeScript MCP tool path.

## Design (three outcomes)
- **Fetch-miss (origin has no branch yet, first push)**: treat as success signal, proceed to push. This is how we detect "this is the first push."
- **Fetch-ok + ff-merge-ok (origin has the branch, we can advance cleanly)**: push is a clean no-op or advances normally.
- **Fetch-ok + ff-merge fails (divergent history OR subprocess died)**: record `approve_sync_error` in job metadata, leave status at `READY_FOR_APPROVAL`, do NOT push. Human inspects the error detail and decides.

## Produced by
Factory job `dd787f1c` — single clean pass (no fix-loop). Security review: 0 BLOCKING + 0 WARNING, explicit APPROVE. Arch review: 0 BLOCKING + 1 WARNING (addressed in hand-fix commit below).

## Hand-fix on top of factory output
Commit `ac38080` addresses the arch-review WARNING:

The original factory commit had a subtle fallthrough — if `git merge --ff-only` raised (TimeoutExpired, OSError) rather than returning non-zero, `merge_result` stayed `None`, the bail-out branch was skipped, and control fell through to `git push`. But fetch had already told us origin was ahead, so pushing from a known-stale worktree would silently advance to old tips. The existing push-failure swallow would then mark APPROVED with no diagnostic — exactly the failure mode this PR exists to prevent.

Fix: both the non-zero returncode path and the subprocess-exception path now funnel through a single `merge_error` variable with the same bail-out contract. New test covers the exception case (TimeoutExpired on merge) and asserts READY_FOR_APPROVAL + `approve_sync_error` set + push NOT called.

## Tests
- `factory/tests/test_factory_approve_sync.py` — 5 tests:
  1. Happy path (fetch ahead → merge ok → push ok → APPROVED, call sequence asserted)
  2. First push (fetch miss → no merge → push → APPROVED, no `approve_sync_error`)
  3. Divergent history (fetch ok → merge ff-only fails → revert to READY_FOR_APPROVAL, error in metadata, push NOT called)
  4. Push-fail regression guard (fetch ok → merge ok → push raises → APPROVED, existing swallow preserved)
  5. **NEW**: Merge subprocess exception (fetch ok → merge raises TimeoutExpired → revert, error set, push NOT called)

5/5 pass locally.

## Follow-ups
- Arch-review NITs not addressed (deliberate, all optional):
  - Pick `fatal:` line over `hint:` line in log output for divergent case (log-readability only; full detail still lands in metadata).
  - Narrow `except Exception` to `subprocess.TimeoutExpired | OSError` (matches existing pattern elsewhere in the file).
  - Add comment noting 4-stack match boundary test for the `{0,4}` cap on the regex (separate file).
- Deeper architectural: reviewer-count counter is fragile against free-form markdown (arch review for THIS job used `### WARNING` heading-form, which the PR #32 regex still doesn't catch — warning_count=0 in the artifact row despite a real finding). Separate task to be filed: replace counter-parsing with structured reviewer output (JSON severity list).

## Test plan
- [ ] `pytest factory/tests/test_factory_approve_sync.py` — 5 pass (verified locally)
- [ ] After merge, the next factory job's approval path exercises the sync step end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)