### PR TITLE
feat(factory): structured JSON findings block for reviewers (task #16)

### DIFF
--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -145,7 +145,21 @@ def _parse_findings_json(text: str) -> tuple[list[dict] | None, str | None]:
             return (None, f"missing_keys:{sorted(missing)}")
         sev = str(item["severity"]).upper()
         if sev not in _VALID_SEVERITIES:
-            dropped_severities.append(item["severity"])
+            dropped_severities.append(str(item["severity"])[:64])
+            continue
+        # Title and body must be strings. A reviewer emitting a
+        # dict/list/int for either would crash _signature_for_finding
+        # (title.strip()) or _notify_warning_oscillation (body render)
+        # deeper in the pipeline — fail fast here instead.
+        if not isinstance(item["title"], str):
+            dropped_severities.append(
+                f"non_string_title:{type(item['title']).__name__}"
+            )
+            continue
+        if not isinstance(item["body"], str):
+            dropped_severities.append(
+                f"non_string_body:{type(item['body']).__name__}"
+            )
             continue
         normalized = dict(item)
         normalized["severity"] = sev
@@ -301,26 +315,47 @@ def _finding_signature(text: str) -> str:
     return collapsed[:80]
 
 
-def _signature_for_finding(item) -> str:
-    """Compute the cross-round comparison signature for a finding.
+def _signature_for_finding(item) -> frozenset[str]:
+    """Compute the cross-round comparison signature set for a finding.
 
-    Dispatches on input shape:
-      - dict with truthy ``title`` → normalize the title (lower,
-        collapse whitespace). Titles are short by contract so we do
-        NOT truncate — equality on titles is the whole point of the
-        JSON contract, immune to reviewer paraphrasing of bodies.
-      - dict with None/empty title (regex-fallback synthetic) → fall
-        back to the body-based signature.
-      - str → existing ``_finding_signature`` behavior (back-compat
-        for callers that still pass plain strings).
+    Returns a non-empty frozenset of 1 or 2 normalized signatures so two
+    findings match when they share ANY signature. This absorbs the
+    JSON↔regex-fallback asymmetry: a reviewer who emits compliant JSON
+    in round 1 and falls back to prose in round 2 (or vice versa) would
+    otherwise produce incomparable signatures — one title-based, one
+    body-prefix-based — and the oscillation guardrail would miss the
+    repeat. Carrying both when available gives both paths common
+    ground.
+
+    Shape dispatch:
+      - dict with string ``title`` → {title-sig, body-sig} when body
+        is also present; {title-sig} otherwise.
+      - dict with None/missing title (regex-fallback synthetic) →
+        {body-sig}. Matches a JSON round that has body content.
+      - str → {body-sig} via the existing ``_finding_signature``
+        heuristic (back-compat for callers that still pass strings).
+
+    title-sig: full normalized title (no truncation — titles are short
+    by contract so equality on the full string is what we want).
+    body-sig: 80-char lowercased whitespace-collapsed prefix (see
+    ``_finding_signature``) — survives reviewer paraphrasing of tails.
     """
     if isinstance(item, dict):
+        sigs: set[str] = set()
         title = item.get("title")
-        if title:
-            return re.sub(r'\s+', ' ', title.strip().lower())
-        body = item.get("body") or ""
-        return _finding_signature(body)
-    return _finding_signature(item)
+        if isinstance(title, str) and title.strip():
+            sigs.add(re.sub(r'\s+', ' ', title.strip().lower()))
+        body = item.get("body")
+        if isinstance(body, str) and body.strip():
+            sigs.add(_finding_signature(body))
+        if not sigs:
+            # Defensive: a finding with neither usable title nor body
+            # can't participate in oscillation detection. Return a
+            # synthetic sig so the frozenset is never empty (callers
+            # assume non-empty and use set-intersection semantics).
+            sigs.add("__empty__")
+        return frozenset(sigs)
+    return frozenset({_finding_signature(item)})
 
 
 def _findings_overlap(current, prior) -> list[str]:
@@ -340,13 +375,18 @@ def _findings_overlap(current, prior) -> list[str]:
     the first occurrence so output order is stable and echoes the
     reviewer's own ordering.
     """
-    prior_sigs = {_signature_for_finding(t) for t in prior}
+    # Flatten prior sig-sets into one lookup set. A current finding
+    # matches when ANY of its signatures appears in the prior set —
+    # absorbs the JSON↔regex-fallback asymmetry when rounds mix.
+    prior_sigs: set[str] = set()
+    for p in prior:
+        prior_sigs.update(_signature_for_finding(p))
     repeating: list[str] = []
-    seen: set[str] = set()
+    seen_keys: set[frozenset[str]] = set()
     for item in current:
-        sig = _signature_for_finding(item)
-        if sig in prior_sigs and sig not in seen:
-            seen.add(sig)
+        sigs = _signature_for_finding(item)
+        if sigs & prior_sigs and sigs not in seen_keys:
+            seen_keys.add(sigs)
             if isinstance(item, dict):
                 repeating.append(item.get("body") or item.get("title") or "")
             else:

--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -90,46 +90,202 @@ def _worktree_path_for_job(job) -> str:
     return str(Path.home() / "devbrain-worktrees" / job.id)
 
 
-def _count_blocking(text: str) -> int:
-    """Count actual BLOCKING findings — look for the marker at start of line or list item."""
-    # Match patterns like "BLOCKING:", "**BLOCKING**", "1. BLOCKING:", "- BLOCKING:",
-    # and stacked combos like "**1. BLOCKING" or "- **BLOCKING**" that reviewers
-    # produce when nesting bold/list/number prefixes. {0,4} is bounded — each
-    # alternative consumes ≥1 char so there is no catastrophic backtracking.
-    pattern = r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}BLOCKING\b'
-    return len(re.findall(pattern, text, re.IGNORECASE))
+# JSON findings block — reviewers append a fenced block of the form
+#   ```json findings
+#   {"findings": [{"severity": "BLOCKING", "title": "...", "body": "...",
+#                  "file": "path/x.py", "line": 42}, ...]}
+#   ```
+# (See _run_review's "Required output format" section appended to both
+# review prompts.) The block is the addendum; the prose above it is what
+# humans read. The pipeline reads the JSON.
+_FINDINGS_FENCE_RE = re.compile(
+    r"```json\s+findings\s*\n(.*?)\n```",
+    re.DOTALL | re.IGNORECASE,
+)
+_VALID_SEVERITIES = {"BLOCKING", "WARNING", "NIT"}
+_REQUIRED_FINDING_KEYS = {"severity", "title", "body"}
 
 
-def _extract_blocking_items(text: str) -> list[str]:
-    """Extract individual BLOCKING finding texts."""
-    items = []
-    # Split on BLOCKING markers and capture the text after each
-    parts = re.split(r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}BLOCKING[:\s]*', text, flags=re.IGNORECASE)
-    for part in parts[1:]:  # Skip text before first BLOCKING
-        # Take text until next severity marker or end
-        end = re.search(r'\n\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}(?:WARNING|NIT|BLOCKING)\b', part, re.IGNORECASE)
-        item = part[:end.start()].strip() if end else part.strip()
-        if item:
-            items.append(item)
-    return items
+def _parse_findings_json(text: str) -> tuple[list[dict] | None, str | None]:
+    """Parse the reviewer's structured findings block.
+
+    Returns (findings, error):
+      - (parsed_list, None)         on success (empty list is valid)
+      - (None, "no_findings_block") if no fenced block is present
+      - (None, "<reason>")          on malformed JSON or wrong shape
+      - (filtered_list, "<reason>") on partial parse (e.g. an unknown
+        severity was dropped but the rest was valid) — callers should
+        still flag the artifact as malformed.
+
+    Reviewers occasionally write multiple blocks (draft + final). The
+    LAST block is authoritative — re.findall returns matches in order
+    and we take [-1].
+    """
+    matches = _FINDINGS_FENCE_RE.findall(text)
+    if not matches:
+        return (None, "no_findings_block")
+    raw = matches[-1]
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return (None, f"JSONDecodeError: {e.msg}")
+    if not isinstance(parsed, dict) or "findings" not in parsed:
+        return (None, "missing_findings_key")
+    findings = parsed["findings"]
+    if not isinstance(findings, list):
+        return (None, "findings_not_a_list")
+
+    valid: list[dict] = []
+    dropped_severities: list[str] = []
+    for item in findings:
+        if not isinstance(item, dict):
+            return (None, "finding_not_a_dict")
+        if not _REQUIRED_FINDING_KEYS.issubset(item.keys()):
+            missing = _REQUIRED_FINDING_KEYS - item.keys()
+            return (None, f"missing_keys:{sorted(missing)}")
+        sev = str(item["severity"]).upper()
+        if sev not in _VALID_SEVERITIES:
+            dropped_severities.append(item["severity"])
+            continue
+        normalized = dict(item)
+        normalized["severity"] = sev
+        normalized.setdefault("file", None)
+        normalized.setdefault("line", None)
+        valid.append(normalized)
+
+    if dropped_severities:
+        return (valid, f"invalid_severity:{dropped_severities[0]}")
+    return (valid, None)
 
 
-def _count_warning(text: str) -> int:
-    """Count actual WARNING findings — look for the marker at start of line or list item."""
-    pattern = r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}WARNING\b'
-    return len(re.findall(pattern, text, re.IGNORECASE))
+def _count_blocking(text: str, return_fallback: bool = False):
+    """Count BLOCKING findings. Prefers the JSON findings block; falls
+    back to the stacked-prefix regex on missing/malformed JSON.
+
+    When return_fallback=True, returns (count, used_fallback: bool)
+    instead of bare count. Default False keeps the scalar contract that
+    existing callers and tests rely on.
+    """
+    findings, _err = _parse_findings_json(text)
+    if findings is not None:
+        count = sum(1 for f in findings if f["severity"] == "BLOCKING")
+        used_fallback = False
+    else:
+        # Stacked-prefix tolerant, bounded {0,4} (PR #32).
+        pattern = r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}BLOCKING\b'
+        count = len(re.findall(pattern, text, re.IGNORECASE))
+        used_fallback = True
+    return (count, used_fallback) if return_fallback else count
 
 
-def _extract_warning_items(text: str) -> list[str]:
-    """Extract individual WARNING finding texts."""
-    items = []
-    parts = re.split(r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}WARNING[:\s]*', text, flags=re.IGNORECASE)
-    for part in parts[1:]:
-        end = re.search(r'\n\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}(?:BLOCKING|NIT|WARNING)\b', part, re.IGNORECASE)
-        item = part[:end.start()].strip() if end else part.strip()
-        if item:
-            items.append(item)
-    return items
+def _extract_blocking_items(text: str, return_fallback: bool = False):
+    """Return BLOCKING finding bodies as list[str].
+
+    JSON path: each finding's ``body`` field.
+    Regex fallback: the original split-on-marker behavior (PR #32).
+    Returns (items, used_fallback) when return_fallback=True.
+    """
+    findings, _err = _parse_findings_json(text)
+    if findings is not None:
+        items = [f["body"] for f in findings if f["severity"] == "BLOCKING"]
+        used_fallback = False
+    else:
+        items = []
+        parts = re.split(
+            r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}BLOCKING[:\s]*',
+            text, flags=re.IGNORECASE,
+        )
+        for part in parts[1:]:
+            end = re.search(
+                r'\n\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}(?:WARNING|NIT|BLOCKING)\b',
+                part, re.IGNORECASE,
+            )
+            item = part[:end.start()].strip() if end else part.strip()
+            if item:
+                items.append(item)
+        used_fallback = True
+    return (items, used_fallback) if return_fallback else items
+
+
+def _count_warning(text: str, return_fallback: bool = False):
+    """Count WARNING findings. Prefers the JSON findings block; falls
+    back to the stacked-prefix regex on missing/malformed JSON.
+
+    When return_fallback=True, returns (count, used_fallback: bool)
+    instead of bare count. Default False keeps the scalar contract that
+    existing callers and tests rely on.
+    """
+    findings, _err = _parse_findings_json(text)
+    if findings is not None:
+        count = sum(1 for f in findings if f["severity"] == "WARNING")
+        used_fallback = False
+    else:
+        pattern = r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}WARNING\b'
+        count = len(re.findall(pattern, text, re.IGNORECASE))
+        used_fallback = True
+    return (count, used_fallback) if return_fallback else count
+
+
+def _extract_warning_items(text: str, return_fallback: bool = False):
+    """Return WARNING finding bodies as list[str].
+
+    JSON path: each finding's ``body`` field.
+    Regex fallback: the original split-on-marker behavior (PR #32).
+    Returns (items, used_fallback) when return_fallback=True.
+    """
+    findings, _err = _parse_findings_json(text)
+    if findings is not None:
+        items = [f["body"] for f in findings if f["severity"] == "WARNING"]
+        used_fallback = False
+    else:
+        items = []
+        parts = re.split(
+            r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}WARNING[:\s]*',
+            text, flags=re.IGNORECASE,
+        )
+        for part in parts[1:]:
+            end = re.search(
+                r'\n\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}(?:BLOCKING|NIT|WARNING)\b',
+                part, re.IGNORECASE,
+            )
+            item = part[:end.start()].strip() if end else part.strip()
+            if item:
+                items.append(item)
+        used_fallback = True
+    return (items, used_fallback) if return_fallback else items
+
+
+def _extract_blocking_findings(text: str) -> list[dict]:
+    """Return BLOCKING findings as full dicts.
+
+    Used by callers that need the ``title`` field for signature
+    comparison (oscillation guardrail). On the JSON path, returns the
+    validated finding dicts as-is. On the regex fallback, synthesizes
+    minimal dicts so downstream code sees one shape:
+      {"severity": "BLOCKING", "title": None, "body": <body>,
+       "file": None, "line": None}
+    A None title signals "fall back to body-truncation signature".
+    """
+    findings, _err = _parse_findings_json(text)
+    if findings is not None:
+        return [f for f in findings if f["severity"] == "BLOCKING"]
+    return [
+        {"severity": "BLOCKING", "title": None, "body": body,
+         "file": None, "line": None}
+        for body in _extract_blocking_items(text)
+    ]
+
+
+def _extract_warning_findings(text: str) -> list[dict]:
+    """WARNING twin of ``_extract_blocking_findings``. See that docstring."""
+    findings, _err = _parse_findings_json(text)
+    if findings is not None:
+        return [f for f in findings if f["severity"] == "WARNING"]
+    return [
+        {"severity": "WARNING", "title": None, "body": body,
+         "file": None, "line": None}
+        for body in _extract_warning_items(text)
+    ]
 
 
 def _finding_signature(text: str) -> str:
@@ -145,30 +301,56 @@ def _finding_signature(text: str) -> str:
     return collapsed[:80]
 
 
-def _findings_overlap(current: list[str], prior: list[str]) -> list[str]:
-    """Return current-round finding texts whose normalized signatures
-    also appear in the prior round.
+def _signature_for_finding(item) -> str:
+    """Compute the cross-round comparison signature for a finding.
 
-    Used by the WARNING oscillation guardrail: if any signature shows
-    up in both the most recent review round and the round before it,
-    the fix loop is not converging on those items. Signatures (see
-    `_finding_signature`) are used for matching because reviewers
-    paraphrase tail context round-to-round, but the ORIGINAL current-
-    round text flows out to metadata and human notifications — a
-    lowercased-truncated signature is the wrong thing to show a human.
+    Dispatches on input shape:
+      - dict with truthy ``title`` → normalize the title (lower,
+        collapse whitespace). Titles are short by contract so we do
+        NOT truncate — equality on titles is the whole point of the
+        JSON contract, immune to reviewer paraphrasing of bodies.
+      - dict with None/empty title (regex-fallback synthetic) → fall
+        back to the body-based signature.
+      - str → existing ``_finding_signature`` behavior (back-compat
+        for callers that still pass plain strings).
+    """
+    if isinstance(item, dict):
+        title = item.get("title")
+        if title:
+            return re.sub(r'\s+', ' ', title.strip().lower())
+        body = item.get("body") or ""
+        return _finding_signature(body)
+    return _finding_signature(item)
+
+
+def _findings_overlap(current, prior) -> list[str]:
+    """Return display strings for current-round findings whose
+    signatures also appear in the prior round.
+
+    Both ``current`` and ``prior`` may be lists of finding dicts or
+    plain strings (back-compat for tests that still pass strings).
+    Matching is done via ``_signature_for_finding``; the output is
+    always a list of human-readable display strings — dict bodies
+    (falling back to titles when body is empty), or the str itself
+    for string inputs — so the wire format flowing into job metadata
+    and the notification body (``_notify_warning_oscillation``) is
+    unchanged.
 
     Duplicate current-round findings with the same signature fold to
-    the first occurrence so the output order is stable and echoes the
+    the first occurrence so output order is stable and echoes the
     reviewer's own ordering.
     """
-    prior_sigs = {_finding_signature(t) for t in prior}
+    prior_sigs = {_signature_for_finding(t) for t in prior}
     repeating: list[str] = []
     seen: set[str] = set()
     for item in current:
-        sig = _finding_signature(item)
+        sig = _signature_for_finding(item)
         if sig in prior_sigs and sig not in seen:
             seen.add(sig)
-            repeating.append(item)
+            if isinstance(item, dict):
+                repeating.append(item.get("body") or item.get("title") or "")
+            else:
+                repeating.append(item)
     return repeating
 
 
@@ -521,9 +703,10 @@ class FactoryOrchestrator:
                 prior.extend(items)
         return prior
 
-    def _get_last_round_warnings(self, job: FactoryJob) -> list[str]:
-        """Return WARNING items from the review round immediately before
-        the current one — input to the oscillation guardrail.
+    def _get_last_round_warnings(self, job: FactoryJob) -> list[dict]:
+        """Return WARNING findings (as dicts) from the review round
+        immediately before the current one — input to the oscillation
+        guardrail.
 
         Each round produces two review artifacts (arch + security), so
         the most recent round is `[-2:]` and the prior round is
@@ -532,15 +715,18 @@ class FactoryOrchestrator:
         synchronously after each reviewer completes), so we read prior
         from the DB rather than threading state through call sites.
 
-        Returns `[]` when there are fewer than 4 review artifacts —
-        i.e., this is the first round and there is no prior to compare.
+        Returns finding dicts (via ``_extract_warning_findings``) so
+        ``_signature_for_finding`` can prefer titles over body-prefix
+        truncation. Returns ``[]`` when there are fewer than 4 review
+        artifacts — i.e., this is the first round and there is no
+        prior to compare.
         """
         artifacts = self.db.get_artifacts(job.id, phase="review")
         if len(artifacts) < 4:
             return []
-        items: list[str] = []
+        items: list[dict] = []
         for art in artifacts[-4:-2]:
-            items.extend(_extract_warning_items(art["content"]))
+            items.extend(_extract_warning_findings(art["content"]))
         return items
 
     def _get_fix_history(self, job: FactoryJob) -> str:
@@ -1051,15 +1237,58 @@ Reserve BLOCKING for runtime bugs, data corruption, missing critical functionali
 
 Be precise: include file paths and line numbers.
 
-If this is a re-review round, explicitly state which prior findings are RESOLVED vs still BLOCKING."""
+If this is a re-review round, explicitly state which prior findings are RESOLVED vs still BLOCKING.
+
+## Required output format
+
+After your prose review, end your response with a fenced JSON findings block. The pipeline reads this block to count BLOCKING/WARNING/NIT findings; missing or malformed JSON triggers a regex fallback and flags the artifact as malformed. Always include the block, even when there are no findings (use an empty list).
+
+```json findings
+{{"findings": [
+  {{"severity": "BLOCKING", "title": "short one-liner key", "body": "human-readable detail", "file": "path/to/x.py", "line": 42}},
+  {{"severity": "WARNING",  "title": "another short key", "body": "detail", "file": "path/to/y.py", "line": null}},
+  {{"severity": "NIT",      "title": "style nit key", "body": "detail", "file": null, "line": null}}
+]}}
+```
+
+Field rules:
+- `severity`: one of BLOCKING, WARNING, NIT (case-insensitive on parse).
+- `title`: short distinctive one-liner — used as the cross-round equality key for oscillation detection. Keep it stable across re-reviews of the same finding.
+- `body`: full human-readable detail. Can be multi-line.
+- `file`, `line`: optional, repo-relative path / integer or null.
+
+The prose above the block is what humans read; the block is the machine contract."""
 
         logger.info("Architecture review with %s...", arch_cli)
         arch_result = run_cli(arch_cli, arch_prompt, cwd=project_root,
                               env_override={"DEVBRAIN_PROJECT": job.project_slug},
                               phase="review_arch")
 
-        blocking_count = _count_blocking(arch_result.stdout)
-        warning_count = _count_warning(arch_result.stdout)
+        # Parse the JSON findings block once for the artifact flag AND
+        # derived counts. Partial-parses (invalid_severity dropped from
+        # an otherwise-valid block) also get flagged so rot doesn't
+        # hide.
+        arch_findings, arch_parse_err = _parse_findings_json(arch_result.stdout)
+        if arch_findings is not None:
+            blocking_count = sum(1 for f in arch_findings if f["severity"] == "BLOCKING")
+            warning_count = sum(1 for f in arch_findings if f["severity"] == "WARNING")
+            arch_used_fallback = False
+        else:
+            blocking_count = _count_blocking(arch_result.stdout)
+            warning_count = _count_warning(arch_result.stdout)
+            arch_used_fallback = True
+            logger.warning(
+                "Architecture reviewer output for job %s missing/malformed "
+                "JSON findings block — falling back to regex parse: %s",
+                job.id[:8], arch_parse_err,
+            )
+
+        arch_metadata = (
+            {"reviewer_output_malformed": True, "parse_error": arch_parse_err}
+            if arch_used_fallback or arch_parse_err
+            else None
+        )
+
         self.db.store_artifact(
             job_id=job.id,
             phase="review",
@@ -1069,6 +1298,7 @@ If this is a re-review round, explicitly state which prior findings are RESOLVED
             findings_count=arch_result.stdout.count("\n- ") + arch_result.stdout.count("\n1."),
             blocking_count=blocking_count,
             warning_count=warning_count,
+            metadata=arch_metadata,
         )
 
         # Security/HIPAA review
@@ -1112,15 +1342,54 @@ Be precise: include file paths and line numbers.
 
 If this is a re-review round, explicitly state which prior findings are RESOLVED vs still BLOCKING.
 
-Store any security issues found in DevBrain with type="issue" and category="security"."""
+Store any security issues found in DevBrain with type="issue" and category="security".
+
+## Required output format
+
+After your prose review, end your response with a fenced JSON findings block. The pipeline reads this block to count BLOCKING/WARNING/NIT findings; missing or malformed JSON triggers a regex fallback and flags the artifact as malformed. Always include the block, even when there are no findings (use an empty list).
+
+```json findings
+{{"findings": [
+  {{"severity": "BLOCKING", "title": "short one-liner key", "body": "human-readable detail", "file": "path/to/x.py", "line": 42}},
+  {{"severity": "WARNING",  "title": "another short key", "body": "detail", "file": "path/to/y.py", "line": null}},
+  {{"severity": "NIT",      "title": "style nit key", "body": "detail", "file": null, "line": null}}
+]}}
+```
+
+Field rules:
+- `severity`: one of BLOCKING, WARNING, NIT (case-insensitive on parse).
+- `title`: short distinctive one-liner — used as the cross-round equality key for oscillation detection. Keep it stable across re-reviews of the same finding.
+- `body`: full human-readable detail. Can be multi-line.
+- `file`, `line`: optional, repo-relative path / integer or null.
+
+The prose above the block is what humans read; the block is the machine contract."""
 
         logger.info("Security review with %s...", sec_cli)
         sec_result = run_cli(sec_cli, sec_prompt, cwd=project_root,
                              env_override={"DEVBRAIN_PROJECT": job.project_slug},
                              phase="review_security")
 
-        sec_blocking = _count_blocking(sec_result.stdout)
-        sec_warning = _count_warning(sec_result.stdout)
+        sec_findings, sec_parse_err = _parse_findings_json(sec_result.stdout)
+        if sec_findings is not None:
+            sec_blocking = sum(1 for f in sec_findings if f["severity"] == "BLOCKING")
+            sec_warning = sum(1 for f in sec_findings if f["severity"] == "WARNING")
+            sec_used_fallback = False
+        else:
+            sec_blocking = _count_blocking(sec_result.stdout)
+            sec_warning = _count_warning(sec_result.stdout)
+            sec_used_fallback = True
+            logger.warning(
+                "Security reviewer output for job %s missing/malformed "
+                "JSON findings block — falling back to regex parse: %s",
+                job.id[:8], sec_parse_err,
+            )
+
+        sec_metadata = (
+            {"reviewer_output_malformed": True, "parse_error": sec_parse_err}
+            if sec_used_fallback or sec_parse_err
+            else None
+        )
+
         self.db.store_artifact(
             job_id=job.id,
             phase="review",
@@ -1130,6 +1399,7 @@ Store any security issues found in DevBrain with type="issue" and category="secu
             findings_count=sec_result.stdout.count("\n- ") + sec_result.stdout.count("\n1."),
             blocking_count=sec_blocking,
             warning_count=sec_warning,
+            metadata=sec_metadata,
         )
 
         total_blocking = blocking_count + sec_blocking
@@ -1149,8 +1419,8 @@ Store any security issues found in DevBrain with type="issue" and category="secu
         # we stay in the loop.
         if total_blocking == 0 and warnings_trigger and job.error_count >= 1:
             current_warnings = (
-                _extract_warning_items(arch_result.stdout)
-                + _extract_warning_items(sec_result.stdout)
+                _extract_warning_findings(arch_result.stdout)
+                + _extract_warning_findings(sec_result.stdout)
             )
             prior_warnings = self._get_last_round_warnings(job)
             repeating = _findings_overlap(current_warnings, prior_warnings)

--- a/factory/tests/test_findings_parser.py
+++ b/factory/tests/test_findings_parser.py
@@ -1,0 +1,176 @@
+"""Pure-function tests for the JSON findings-block parser and the
+JSON-aware count/extract/signature helpers in orchestrator.py.
+
+No DB rows are created — the autouse cleanup fixture used elsewhere
+in this directory is unnecessary here.
+"""
+import json as _json
+
+from orchestrator import (
+    _count_blocking,
+    _count_warning,
+    _extract_blocking_items,
+    _extract_warning_items,
+    _parse_findings_json,
+    _signature_for_finding,
+)
+
+
+def _wrap(json_body: str) -> str:
+    """Wrap a JSON body in the fenced block reviewers must produce."""
+    return f"Some prose here.\n\n```json findings\n{json_body}\n```\n"
+
+
+# 1. Well-formed single BLOCKING
+def test_well_formed_single_blocking():
+    text = _wrap(
+        '{"findings": [{"severity": "BLOCKING", '
+        '"title": "null deref", "body": "Null check missing at x.py:42", '
+        '"file": "x.py", "line": 42}]}'
+    )
+    assert _count_blocking(text) == 1
+    items = _extract_blocking_items(text)
+    assert len(items) == 1
+    assert "Null check missing" in items[0]
+    # JSON path should NOT flag fallback usage.
+    count, used_fallback = _count_blocking(text, return_fallback=True)
+    assert count == 1
+    assert used_fallback is False
+
+
+# 2. Empty findings list = clean review
+def test_empty_findings_list_is_clean():
+    text = _wrap('{"findings": []}')
+    assert _count_blocking(text) == 0
+    assert _count_warning(text) == 0
+    _, b_fb = _count_blocking(text, return_fallback=True)
+    _, w_fb = _count_warning(text, return_fallback=True)
+    assert b_fb is False
+    assert w_fb is False
+
+
+# 3. Multiple mixed severities (2 BLOCKING + 3 WARNING + 1 NIT)
+def test_multiple_mixed_severities():
+    findings = [
+        {"severity": "BLOCKING", "title": "b1", "body": "block-body-one"},
+        {"severity": "BLOCKING", "title": "b2", "body": "block-body-two"},
+        {"severity": "WARNING", "title": "w1", "body": "warn-body-one"},
+        {"severity": "WARNING", "title": "w2", "body": "warn-body-two"},
+        {"severity": "WARNING", "title": "w3", "body": "warn-body-three"},
+        {"severity": "NIT", "title": "n1", "body": "nit-body-one"},
+    ]
+    text = _wrap(_json.dumps({"findings": findings}))
+    assert _count_blocking(text) == 2
+    assert _count_warning(text) == 3
+    blockings = _extract_blocking_items(text)
+    warnings = _extract_warning_items(text)
+    assert blockings == ["block-body-one", "block-body-two"]
+    assert warnings == ["warn-body-one", "warn-body-two", "warn-body-three"]
+
+
+# 4. No JSON block — regex fallback used, flag set
+def test_no_json_block_uses_regex_fallback():
+    text = "1. WARNING: bare warning at x.py:1\n"
+    count, used_fallback = _count_warning(text, return_fallback=True)
+    assert count == 1
+    assert used_fallback is True
+    findings, err = _parse_findings_json(text)
+    assert findings is None
+    assert err == "no_findings_block"
+
+
+# 5. Multiple JSON blocks — last one wins
+def test_multiple_json_blocks_last_wins():
+    first = (
+        '```json findings\n{"findings": ['
+        '{"severity": "WARNING", "title": "a", "body": "x"},'
+        '{"severity": "WARNING", "title": "b", "body": "x"},'
+        '{"severity": "WARNING", "title": "c", "body": "x"},'
+        '{"severity": "WARNING", "title": "d", "body": "x"},'
+        '{"severity": "WARNING", "title": "e", "body": "x"}'
+        "]}\n```"
+    )
+    second = (
+        '```json findings\n{"findings": ['
+        '{"severity": "WARNING", "title": "z", "body": "x"},'
+        '{"severity": "WARNING", "title": "y", "body": "x"}'
+        "]}\n```"
+    )
+    text = f"draft:\n{first}\n\nFINAL:\n{second}\n"
+    assert _count_warning(text) == 2  # second block, not first
+
+
+# 6. Malformed JSON — fallback used, error mentions JSONDecodeError
+def test_malformed_json_falls_back():
+    text = "```json findings\n{not valid json\n```\n"
+    findings, err = _parse_findings_json(text)
+    assert findings is None
+    assert "JSONDecodeError" in err
+    count, used_fallback = _count_warning(text, return_fallback=True)
+    assert count == 0
+    assert used_fallback is True
+
+
+# 7. Wrong shape — missing `findings` key
+def test_wrong_shape_missing_findings_key():
+    text = '```json findings\n{"results": []}\n```\n'
+    findings, err = _parse_findings_json(text)
+    assert findings is None
+    assert err == "missing_findings_key"
+    _, used_fallback = _count_warning(text, return_fallback=True)
+    assert used_fallback is True
+
+
+# 8. Invalid severity value — that finding dropped, rest retained, partial flag
+def test_invalid_severity_dropped_rest_retained():
+    text = _wrap(
+        '{"findings": ['
+        '{"severity": "URGENT", "title": "x", "body": "x"},'
+        '{"severity": "WARNING", "title": "real", "body": "real-body"}'
+        "]}"
+    )
+    findings, err = _parse_findings_json(text)
+    assert findings is not None
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "WARNING"
+    assert err is not None
+    assert "URGENT" in err
+    assert _count_warning(text) == 1
+
+
+# 9. Case-insensitive severity
+def test_case_insensitive_severity():
+    text = _wrap(
+        '{"findings": ['
+        '{"severity": "warning", "title": "x", "body": "y"},'
+        '{"severity": "Blocking", "title": "z", "body": "w"}'
+        "]}"
+    )
+    assert _count_warning(text) == 1
+    assert _count_blocking(text) == 1
+
+
+# 10. Signature uses title field, not body truncation
+def test_signature_uses_title_field():
+    finding = {
+        "severity": "WARNING",
+        "title": "off-by-one",
+        "body": (
+            "A long rambling explanation of the off-by-one error "
+            "that sprawls across multiple lines and reviewer "
+            "paraphrases between rounds "
+        ) * 3,
+    }
+    assert _signature_for_finding(finding) == "off-by-one"
+
+    # Same title, different body → same signature (the point of the contract).
+    finding2 = dict(finding)
+    finding2["body"] = "completely different wording"
+    assert _signature_for_finding(finding) == _signature_for_finding(finding2)
+
+    # Dict without title falls back to body-based signature.
+    finding3 = {"severity": "WARNING", "title": None, "body": "Just A Body"}
+    assert _signature_for_finding(finding3) == "just a body"
+
+    # Plain string still works (back-compat).
+    assert _signature_for_finding("Just A Body") == "just a body"

--- a/factory/tests/test_findings_parser.py
+++ b/factory/tests/test_findings_parser.py
@@ -11,6 +11,7 @@ from orchestrator import (
     _count_warning,
     _extract_blocking_items,
     _extract_warning_items,
+    _findings_overlap,
     _parse_findings_json,
     _signature_for_finding,
 )
@@ -150,27 +151,86 @@ def test_case_insensitive_severity():
     assert _count_blocking(text) == 1
 
 
-# 10. Signature uses title field, not body truncation
-def test_signature_uses_title_field():
+# 10. Signature set includes title and body so JSON↔regex-fallback mix still matches
+def test_signature_includes_title_and_body_for_cross_path_matching():
+    """Post-PR #34 contract: `_signature_for_finding` returns a
+    FROZENSET of 1 or 2 signatures (title + body) so two findings
+    match when they share ANY signature — not when their full sets
+    are equal. Solves the JSON-round-vs-regex-round asymmetry flagged
+    in the arch review of job a51efc39."""
     finding = {
         "severity": "WARNING",
         "title": "off-by-one",
-        "body": (
-            "A long rambling explanation of the off-by-one error "
-            "that sprawls across multiple lines and reviewer "
-            "paraphrases between rounds "
-        ) * 3,
+        "body": "A long rambling explanation of the off-by-one error "
+                "that sprawls across multiple lines",
     }
-    assert _signature_for_finding(finding) == "off-by-one"
+    sigs = _signature_for_finding(finding)
+    assert isinstance(sigs, frozenset)
+    assert "off-by-one" in sigs
+    # Body signature is also present (80-char lowercased prefix).
+    assert any("off-by-one error" in s for s in sigs)
 
-    # Same title, different body → same signature (the point of the contract).
+    # Same title, different body → sig SETS overlap (share title) but
+    # are not equal (bodies differ). Overlap is the matching contract.
     finding2 = dict(finding)
-    finding2["body"] = "completely different wording"
-    assert _signature_for_finding(finding) == _signature_for_finding(finding2)
+    finding2["body"] = "completely different wording here"
+    sigs2 = _signature_for_finding(finding2)
+    assert sigs & sigs2  # non-empty intersection — will match in oscillation
+    assert sigs != sigs2  # not identical — body sigs differ
 
-    # Dict without title falls back to body-based signature.
+    # Dict with None title → only body-sig in the set.
     finding3 = {"severity": "WARNING", "title": None, "body": "Just A Body"}
-    assert _signature_for_finding(finding3) == "just a body"
+    sigs3 = _signature_for_finding(finding3)
+    assert sigs3 == frozenset({"just a body"})
 
-    # Plain string still works (back-compat).
-    assert _signature_for_finding("Just A Body") == "just a body"
+    # Plain string → single body-sig, back-compat.
+    assert _signature_for_finding("Just A Body") == frozenset({"just a body"})
+
+
+# 11. _findings_overlap matches across JSON↔regex-fallback round boundary
+def test_findings_overlap_bridges_json_and_regex_rounds():
+    """Round 1 emits JSON with title+body; round 2 reviewer ignores
+    the contract and falls back to regex (title=None, body=extracted
+    text). If both rounds reference the same issue via shared body
+    prefix, the guardrail should still see the repeat. This is the
+    arch-review WARNING on job a51efc39 — before fix, these two
+    signature paths were incomparable and the repeat was missed."""
+    # Shared body prefix long enough for the 80-char body-sig to match.
+    shared_body = (
+        "The increment at line 42 skips the last element of the array, "
+        "causing an off-by-one error in the iterator consumer downstream"
+    )
+    prior_json = [{
+        "severity": "WARNING", "title": "off-by-one",
+        "body": shared_body,
+    }]
+    # Same issue, but a regex-fallback synthetic dict (title=None,
+    # body carries the same extracted text).
+    current_fallback = [{
+        "severity": "WARNING", "title": None,
+        "body": shared_body + " (reviewer added extra commentary)",
+    }]
+    matches = _findings_overlap(current_fallback, prior_json)
+    assert len(matches) == 1
+
+
+# 12. Non-string title/body dropped with partial-parse flag
+def test_non_string_title_or_body_is_dropped():
+    """Addresses the security-review NIT on job a51efc39: a reviewer
+    emitting `{"title": {...}}` or `{"body": 42}` used to pass
+    validation and then crash `_signature_for_finding`'s `.strip()`
+    deeper in the pipeline. Parser now drops these findings at
+    normalization time, keeps the valid ones, and flags the artifact
+    via the partial-parse error detail."""
+    text = _wrap(_json.dumps({"findings": [
+        {"severity": "WARNING", "title": {"not": "a string"},
+         "body": "has a body"},
+        {"severity": "WARNING", "title": "ok", "body": 42},
+        {"severity": "WARNING", "title": "real", "body": "real-body"},
+    ]}))
+    findings, err = _parse_findings_json(text)
+    assert findings is not None
+    assert len(findings) == 1
+    assert findings[0]["title"] == "real"
+    assert err is not None
+    assert "non_string_title" in err or "non_string_body" in err

--- a/factory/tests/test_oscillation_guardrail.py
+++ b/factory/tests/test_oscillation_guardrail.py
@@ -13,6 +13,8 @@ normal FIX_LOOP transition. We exercise it end-to-end by stubbing
 `git diff main...HEAD`) and reading back the post-review job
 status + metadata.
 """
+import json as _json
+
 import pytest
 
 import orchestrator as orch_mod
@@ -24,6 +26,21 @@ from state_machine import FactoryDB, JobStatus
 from config import DATABASE_URL
 
 TEST_TITLE_PREFIX = "oscillation_test_"
+
+
+def _arch_text_with_warning(title: str, body: str) -> str:
+    """Build a review body with a single-WARNING JSON findings block.
+
+    The JSON block is what the post-21b1b68a parser reads — matching
+    titles round-to-round is what drives the oscillation signal.
+    Prose on the line above is there so ``_extract_warning_items``
+    still produces human-readable output for display strings.
+    """
+    prose = f"1. WARNING: {body}"
+    block = _json.dumps(
+        {"findings": [{"severity": "WARNING", "title": title, "body": body}]}
+    )
+    return f"{prose}\n\n```json findings\n{block}\n```\n"
 
 
 @pytest.fixture
@@ -182,12 +199,16 @@ def test_repeating_warnings_escalate_to_failed(orch, db, monkeypatch):
     job = _make_job_in_fix_cycle(
         db,
         f"{TEST_TITLE_PREFIX}escalate",
-        prior_arch_text="1. WARNING: missing null check at x.py:42",
+        prior_arch_text=_arch_text_with_warning(
+            "missing-null-check", "missing null check at x.py:42"
+        ),
     )
 
     _stub_review_env(
         monkeypatch,
-        arch_stdout="1. WARNING: missing null check at x.py:42",
+        arch_stdout=_arch_text_with_warning(
+            "missing-null-check", "missing null check at x.py:42"
+        ),
         sec_stdout="(no findings)",
     )
 
@@ -209,14 +230,23 @@ def test_blocking_findings_bypass_oscillation_guardrail(orch, db, monkeypatch):
     job = _make_job_in_fix_cycle(
         db,
         f"{TEST_TITLE_PREFIX}blocking_wins",
-        prior_arch_text="1. WARNING: same warning persisting at y.py:1",
+        prior_arch_text=_arch_text_with_warning(
+            "same-warning", "same warning persisting at y.py:1"
+        ),
     )
 
+    mixed_block = _json.dumps({"findings": [
+        {"severity": "WARNING", "title": "same-warning",
+         "body": "same warning persisting at y.py:1"},
+        {"severity": "BLOCKING", "title": "actual-exploit",
+         "body": "actual exploit at y.py:5"},
+    ]})
     _stub_review_env(
         monkeypatch,
         arch_stdout=(
             "1. WARNING: same warning persisting at y.py:1\n"
-            "2. BLOCKING: actual exploit at y.py:5\n"
+            "2. BLOCKING: actual exploit at y.py:5\n\n"
+            f"```json findings\n{mixed_block}\n```\n"
         ),
         sec_stdout="(no findings)",
     )
@@ -236,12 +266,17 @@ def test_different_warnings_do_not_escalate(orch, db, monkeypatch):
     job = _make_job_in_fix_cycle(
         db,
         f"{TEST_TITLE_PREFIX}different",
-        prior_arch_text="1. WARNING: old warning at a.py:1",
+        prior_arch_text=_arch_text_with_warning(
+            "old-warning-title", "old warning at a.py:1"
+        ),
     )
 
     _stub_review_env(
         monkeypatch,
-        arch_stdout="1. WARNING: brand new completely different warning at b.py:2",
+        arch_stdout=_arch_text_with_warning(
+            "brand-new-warning-title",
+            "brand new completely different warning at b.py:2",
+        ),
         sec_stdout="(no findings)",
     )
 
@@ -271,7 +306,9 @@ def test_first_round_no_prior_state_does_not_escalate(orch, db, monkeypatch):
 
     _stub_review_env(
         monkeypatch,
-        arch_stdout="1. WARNING: any warning at a.py:1",
+        arch_stdout=_arch_text_with_warning(
+            "any-warning-title", "any warning at a.py:1"
+        ),
         sec_stdout="(no findings)",
     )
 
@@ -324,7 +361,9 @@ def test_oscillation_notification_fires_with_correct_payload(orch, db, monkeypat
     job = _make_job_in_fix_cycle(
         db,
         f"{TEST_TITLE_PREFIX}notify_fires",
-        prior_arch_text="1. WARNING: Missing Null Check at X.py:42",
+        prior_arch_text=_arch_text_with_warning(
+            "missing-null-check", "Missing Null Check at X.py:42"
+        ),
     )
     with db._conn() as conn, conn.cursor() as cur:
         cur.execute(
@@ -336,7 +375,9 @@ def test_oscillation_notification_fires_with_correct_payload(orch, db, monkeypat
 
     _stub_review_env(
         monkeypatch,
-        arch_stdout="1. WARNING: Missing Null Check at X.py:42",
+        arch_stdout=_arch_text_with_warning(
+            "missing-null-check", "Missing Null Check at X.py:42"
+        ),
         sec_stdout="(no findings)",
     )
 
@@ -367,13 +408,17 @@ def test_oscillation_notification_skips_when_no_submitted_by(orch, db, monkeypat
     job = _make_job_in_fix_cycle(
         db,
         f"{TEST_TITLE_PREFIX}notify_no_submitter",
-        prior_arch_text="1. WARNING: same issue at w.py:1",
+        prior_arch_text=_arch_text_with_warning(
+            "same-issue", "same issue at w.py:1"
+        ),
     )
     assert job.submitted_by is None
 
     _stub_review_env(
         monkeypatch,
-        arch_stdout="1. WARNING: same issue at w.py:1",
+        arch_stdout=_arch_text_with_warning(
+            "same-issue", "same issue at w.py:1"
+        ),
         sec_stdout="(no findings)",
     )
 
@@ -381,3 +426,44 @@ def test_oscillation_notification_skips_when_no_submitted_by(orch, db, monkeypat
 
     assert result.status == JobStatus.FAILED
     assert _FakeRouter.sent_events == []
+
+
+# ─── Title-keyed signature (JSON path) ───────────────────────────────────
+# The regex fallback signs findings by body-prefix (see
+# _finding_signature). The JSON path — added 2026-04-24 by PR
+# 21b1b68a — signs by `title` when present. This test locks in that
+# behavior: same title, deliberately different body → same signature
+# → oscillation fires even though reviewers paraphrased the body
+# between rounds.
+
+def test_signature_uses_title_specifically(orch, db, monkeypatch):
+    """Two findings with the same title but completely different bodies
+    must fold to the same signature. Proves the JSON-path signature is
+    title-keyed, not body-keyed — the core reason for the JSON contract
+    over the bare regex: reviewer paraphrasing of bodies between rounds
+    does not break oscillation detection."""
+    monkeypatch.setattr(orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", True)
+
+    # Round 1: title="dup-key", original body wording.
+    job = _make_job_in_fix_cycle(
+        db,
+        f"{TEST_TITLE_PREFIX}title_keyed",
+        prior_arch_text=_arch_text_with_warning(
+            "dup-key", "Original body text round one"
+        ),
+    )
+
+    # Round 2: SAME title, COMPLETELY different body — should still match.
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout=_arch_text_with_warning(
+            "dup-key",
+            "Reviewer paraphrased it entirely round two with new prose",
+        ),
+        sec_stdout="(no findings)",
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.FAILED
+    assert result.metadata.get("failure") == "warning_oscillation"

--- a/factory/tests/test_review_prompt_calibration.py
+++ b/factory/tests/test_review_prompt_calibration.py
@@ -100,6 +100,9 @@ def test_arch_prompt_contains_severity_cost_guidance(orch, db, monkeypatch):
     assert "each flag costs one implementer round" in arch_prompt
     assert "Err toward NIT" in arch_prompt
     assert "RESOLVED vs still BLOCKING" in arch_prompt
+    # JSON findings contract — added 2026-04-24 (PR 21b1b68a).
+    assert "## Required output format" in arch_prompt
+    assert "```json findings" in arch_prompt
 
 
 def test_security_prompt_contains_severity_cost_guidance(orch, db, monkeypatch):
@@ -116,3 +119,5 @@ def test_security_prompt_contains_severity_cost_guidance(orch, db, monkeypatch):
     assert "Err toward NIT" in sec_prompt
     assert "defense-in-depth" in sec_prompt
     assert "RESOLVED vs still BLOCKING" in sec_prompt
+    assert "## Required output format" in sec_prompt
+    assert "```json findings" in sec_prompt

--- a/factory/tests/test_warning_fix_loop.py
+++ b/factory/tests/test_warning_fix_loop.py
@@ -9,6 +9,8 @@ We exercise it end-to-end by stubbing `run_cli` (no actual claude call)
 and `subprocess.run` (no `git diff main...HEAD`) and reading back the
 post-review job status.
 """
+import json as _json
+
 import pytest
 
 import orchestrator as orch_mod
@@ -17,6 +19,18 @@ from state_machine import FactoryDB, JobStatus
 from config import DATABASE_URL
 
 TEST_TITLE_PREFIX = "warning_fix_loop_test_"
+
+
+def _with_json(prose: str, findings: list[dict]) -> str:
+    """Append a JSON findings block to a prose review body. Used to
+    exercise the JSON-path of the post-PR-21b1b68a parser; the prose
+    side stays in place so fallback regex counts would still match
+    the same numbers (parity check for the parser swap).
+    """
+    return (
+        f"{prose}\n\n```json findings\n"
+        f"{_json.dumps({'findings': findings})}\n```\n"
+    )
 
 
 @pytest.fixture
@@ -116,8 +130,12 @@ def test_blocking_triggers_fix_loop_regardless_of_config(orch, db, monkeypatch):
 
     _stub_review_env(
         monkeypatch,
-        arch_stdout="1. BLOCKING: missing null check at x.py:42",
-        sec_stdout="(no findings)",
+        arch_stdout=_with_json(
+            "1. BLOCKING: missing null check at x.py:42",
+            [{"severity": "BLOCKING", "title": "null-check",
+              "body": "missing null check at x.py:42"}],
+        ),
+        sec_stdout=_with_json("(no findings)", []),
     )
 
     result = orch._run_review(job)
@@ -138,11 +156,17 @@ def test_warning_triggers_fix_loop_when_flag_true(orch, db, monkeypatch):
 
     _stub_review_env(
         monkeypatch,
-        arch_stdout=(
+        arch_stdout=_with_json(
             "1. WARNING: suboptimal pattern at a.py:10\n"
-            "2. WARNING: missing docstring at b.py:5\n"
+            "2. WARNING: missing docstring at b.py:5\n",
+            [
+                {"severity": "WARNING", "title": "suboptimal-pattern",
+                 "body": "suboptimal pattern at a.py:10"},
+                {"severity": "WARNING", "title": "missing-docstring",
+                 "body": "missing docstring at b.py:5"},
+            ],
         ),
-        sec_stdout="(no findings)",
+        sec_stdout=_with_json("(no findings)", []),
     )
 
     result = orch._run_review(job)
@@ -165,11 +189,17 @@ def test_warning_skipped_when_flag_false(orch, db, monkeypatch):
 
     _stub_review_env(
         monkeypatch,
-        arch_stdout=(
+        arch_stdout=_with_json(
             "1. WARNING: suboptimal pattern at a.py:10\n"
-            "2. WARNING: missing docstring at b.py:5\n"
+            "2. WARNING: missing docstring at b.py:5\n",
+            [
+                {"severity": "WARNING", "title": "suboptimal-pattern",
+                 "body": "suboptimal pattern at a.py:10"},
+                {"severity": "WARNING", "title": "missing-docstring",
+                 "body": "missing docstring at b.py:5"},
+            ],
         ),
-        sec_stdout="(no findings)",
+        sec_stdout=_with_json("(no findings)", []),
     )
 
     result = orch._run_review(job)
@@ -178,11 +208,15 @@ def test_warning_skipped_when_flag_false(orch, db, monkeypatch):
 
 
 def test_extract_warning_items_from_review_content(orch, db):
-    """_extract_warning_items extracts individual WARNING items from
-    review-artifact content. This exercises the same extraction path
-    _run_fix uses inline when collecting prior warning findings for
-    the fix prompt (see orchestrator.py _run_fix around the
-    `latest_warning` loop).
+    """Regex-fallback canary — this case intentionally has NO JSON
+    block so the helpers exercise the PR #32 fallback path. Don't
+    add a JSON block here; that would mask a regression in the
+    fallback contract reviewers land on when they don't comply
+    with the JSON format.
+
+    Matches the same extraction path _run_fix uses inline when
+    collecting prior warning findings for the fix prompt (see
+    orchestrator.py _run_fix around the `latest_warning` loop).
     """
     from orchestrator import _extract_warning_items
 


### PR DESCRIPTION
## Summary
Replaces regex-parsing of reviewer markdown with a structured JSON findings contract. Reviewers append ```json findings …``` to their prose; counts and oscillation signatures key off the parsed data when present, falling back to the PR #32 stacked-prefix regex when not. The fallback path flags the artifact via `reviewer_output_malformed` metadata so silent misparses surface instead of hiding.

## Motivation
Three PRs in a row hit counter-bugs: #31 (bold-number form), #32 (fixed stacked prefix), #33's arch review (heading form — `### WARNING`). Whack-a-moling regex against free-form LLM markdown is a losing battle. JSON gives us a reliable machine contract while prose stays human-readable.

## Produced by
Factory job `a51efc39` — single clean pass on main implementation, 408-line orchestrator.py rewrite + 176-line new parser test file + 10 pure-function tests + updates to warning_fix_loop and oscillation_guardrail suites. Security review: proper JSON block at the bottom, 0 BLOCKING + 0 WARNING, 3 NITs. Arch review: 0 BLOCKING + 1 WARNING (signature asymmetry) + 4 NITs.

## Hand-fix commit
`a6b50fd` addresses the arch WARNING and the security NIT that was actually a correctness concern:

**1. Signature asymmetry across JSON↔regex-fallback rounds (arch WARNING)**
`_signature_for_finding` previously returned a single string — the title for JSON dicts, a body-prefix for fallback synthetics. If round 1 emitted JSON and round 2 fell back to regex (or vice versa), the two rounds' signatures were incomparable and the oscillation guardrail missed the repeat. Now returns a `frozenset` of up to 2 signatures (title + body). `_findings_overlap` matches on any shared signature. JSON-vs-JSON rounds still benefit from title stability; mixed-path rounds bridge via the body-prefix sig.

**2. Non-string title/body crashes signature helper (security NIT → promoted)**
`_parse_findings_json` used to accept whatever type the reviewer emitted for title/body. A dict/list/int title would pass validation and then crash inside `_signature_for_finding` via `.strip().lower()` — taking down the oscillation transition rather than falling through to regex safely. Parser now requires string types and drops malformed findings with a partial-parse flag (`non_string_title:dict` / `non_string_body:int`). Caps dropped-severity strings at 64 chars before logging to prevent log noise from pathological reviewers.

## Out-of-scope NITs (deferred)
Reviewer flagged several lower-priority items not addressed here:
- **Last-block-wins vulnerability** (security NIT): a PR that echoes a diff containing its own ```json findings``` fence could suppress real findings. Current prompt structure mitigates; real fix is first-block-wins or multi-block-rejection. Worth a small follow-up.
- `findings_count` heuristic is meaningless on JSON path (arch NIT) — display-only, no gate logic.
- Double JSON parse on the failure path (arch NIT) — trivial CPU cost.
- Fence regex requires newlines (arch NIT) — fallback catches single-line blocks anyway.

## Infrastructure note
The factory job ran on Mac Studio with orchestrator runtime at `d2593c9` (pre-PR #33) — TWO PRs behind main. The new parser code was in the worktree (where tests pass) but wasn't ACTIVE for the job's own prompts or artifact writes. This explains why both reviews' stored metadata is `{}` despite the new code correctly setting `reviewer_output_malformed` for fallback cases. Mac Studio's orchestrator needs pulling to `HEAD` before running jobs that test orchestrator changes. Separate follow-up: auto-pull in `run.py` or the readiness check before implementation phases.

## Tests
- `test_findings_parser.py`: 12 pure-function cases (10 original + 2 new)
- `test_oscillation_guardrail.py`: updated to new sig-set contract + title-keyed sig test
- `test_warning_fix_loop.py`: JSON-form fixtures + regex-fallback canary preserved
- 24 tests pass across the three files locally

## Test plan
- [ ] `pytest factory/tests/test_findings_parser.py` — 12 pass
- [ ] `pytest factory/tests/test_oscillation_guardrail.py` — 7 pass
- [ ] `pytest factory/tests/test_warning_fix_loop.py` — 4 pass
- [ ] Post-merge: pull Mac Studio to main, then submit a factory job whose reviewer emits JSON findings — verify `warning_count > 0` when applicable and metadata has the flag when reviewer doesn't comply

🤖 Generated with [Claude Code](https://claude.com/claude-code)