### PR TITLE
feat(factory): auto-pull factory-host to origin at readiness entry (task #17)

### DIFF
--- a/factory/readiness.py
+++ b/factory/readiness.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ReadinessIssue:
     """A single concrete reason the factory is not ready."""
-    kind: str                    # "head_not_main" | "dirty_working_tree" | "orphan_lock"
+    kind: str                    # "head_not_main" | "behind_origin" | "dirty_working_tree" | "orphan_lock"
     message: str                 # short human-readable summary
     auto_repairable: bool = True
     details: dict = field(default_factory=dict)
@@ -76,9 +76,17 @@ class FactoryReadiness:
     # ─── Public API ───────────────────────────────────────────────────
 
     def verify(self) -> list[ReadinessIssue]:
-        """Return the current list of readiness issues (empty = ready)."""
+        """Return the current list of readiness issues (empty = ready).
+
+        Ordering: head_not_main → behind_origin → dirty_working_tree →
+        orphan_lock. This reads as "checkout main → sync with origin →
+        reset working tree → release orphan locks", which is also the
+        logical order of the repair actions.
+        """
         issues: list[ReadinessIssue] = []
-        issues.extend(self._check_git_state())
+        issues.extend(self._check_head_on_base())
+        issues.extend(self._check_behind_origin())
+        issues.extend(self._check_dirty_working_tree())
         issues.extend(self._check_orphan_locks())
         return issues
 
@@ -93,6 +101,8 @@ class FactoryReadiness:
             try:
                 if issue.kind == "head_not_main":
                     self._repair_head()
+                elif issue.kind == "behind_origin":
+                    self._repair_working_tree()
                 elif issue.kind == "dirty_working_tree":
                     self._repair_working_tree()
                 elif issue.kind == "orphan_lock":
@@ -103,11 +113,17 @@ class FactoryReadiness:
                 logger.warning("Repair of %s failed: %s", issue.kind, exc)
 
     def ensure_ready(self) -> list[ReadinessIssue]:
-        """Verify → repair → verify. Returns the list of issues that
-        could not be auto-repaired (empty list means the factory is
-        ready). Side effect: persists or clears the not_ready flag
-        in devbrain.factory_runtime_state to match the final state.
+        """Fetch-origin → verify → repair → verify. Returns the list of
+        issues that could not be auto-repaired (empty list means the
+        factory is ready). Side effect: persists or clears the not_ready
+        flag in devbrain.factory_runtime_state to match the final state.
+
+        The fetch is best-effort and informational — its return value is
+        deliberately ignored so an offline factory-host still runs local
+        code. The behind_origin check that follows will simply report 0
+        commits behind if the fetch couldn't refresh origin refs.
         """
+        self._fetch_origin()
         issues = self.verify()
         if not issues:
             self._clear_flag()
@@ -167,31 +183,55 @@ class FactoryReadiness:
 
     # ─── Checks ───────────────────────────────────────────────────────
 
-    def _check_git_state(self) -> list[ReadinessIssue]:
-        issues: list[ReadinessIssue] = []
-
-        # HEAD must be on base_branch (usually main).
+    def _check_head_on_base(self) -> list[ReadinessIssue]:
         head = self._run_git(["rev-parse", "--abbrev-ref", "HEAD"])
         if head is not None and head != self.base_branch:
-            issues.append(ReadinessIssue(
+            return [ReadinessIssue(
                 kind="head_not_main",
                 message=f"HEAD is on '{head}' (expected '{self.base_branch}')",
                 details={"current_head": head, "expected": self.base_branch},
-            ))
+            )]
+        return []
 
+    def _check_behind_origin(self) -> list[ReadinessIssue]:
+        """Emit a behind_origin issue if HEAD is behind origin/<base_branch>.
+        Fail-safe: any parse error or git failure returns [] (no false
+        alarm). Runs AFTER _fetch_origin() at the ensure_ready() entry
+        point so the comparison is against freshly-fetched origin refs.
+        """
+        out = self._run_git(
+            ["rev-list", "--count", f"HEAD..origin/{self.base_branch}"],
+            allow_fail=True,
+        )
+        if out is None:
+            return []
+        try:
+            count = int(out.strip())
+        except ValueError:
+            return []
+        if count <= 0:
+            return []
+        return [ReadinessIssue(
+            kind="behind_origin",
+            message=f"HEAD is {count} commit(s) behind origin/{self.base_branch}",
+            details={"commits_behind": count},
+        )]
+
+    def _check_dirty_working_tree(self) -> list[ReadinessIssue]:
         # Working tree must be clean (no uncommitted modifications, no
         # untracked files). We cap entries in the reason payload so a
         # very dirty tree doesn't explode the metadata blob.
         porcelain = self._run_git(["status", "--porcelain"])
-        if porcelain:
-            lines = [ln for ln in porcelain.split("\n") if ln.strip()]
-            if lines:
-                issues.append(ReadinessIssue(
-                    kind="dirty_working_tree",
-                    message=f"Working tree has {len(lines)} dirty/untracked entries",
-                    details={"entries": lines[:20], "truncated": len(lines) > 20},
-                ))
-        return issues
+        if not porcelain:
+            return []
+        lines = [ln for ln in porcelain.split("\n") if ln.strip()]
+        if not lines:
+            return []
+        return [ReadinessIssue(
+            kind="dirty_working_tree",
+            message=f"Working tree has {len(lines)} dirty/untracked entries",
+            details={"entries": lines[:20], "truncated": len(lines) > 20},
+        )]
 
     def _check_orphan_locks(self) -> list[ReadinessIssue]:
         """File locks whose owning job is in a terminal state and should
@@ -217,6 +257,40 @@ class FactoryReadiness:
             message=f"{len(rows)} file lock(s) held by terminal jobs",
             details={"count": len(rows), "sample": sample, "truncated": len(rows) >= 50},
         )]
+
+    # ─── Sync ─────────────────────────────────────────────────────────
+
+    def _fetch_origin(self) -> bool:
+        """Best-effort `git fetch origin <base_branch>` at the start of
+        ensure_ready(). Returns True on success, False on any failure
+        (timeout, git missing, non-zero exit). NEVER raises and NEVER
+        emits a readiness issue — an offline factory-host must still be
+        able to run local code. The subsequent behind_origin check will
+        simply report 0 commits behind if origin couldn't be refreshed.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "fetch", "origin", self.base_branch],
+                cwd=self.project_root,
+                capture_output=True,
+                timeout=30,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning(
+                "git fetch origin %s failed (exception): %s",
+                self.base_branch, exc,
+            )
+            return False
+        if result.returncode != 0:
+            logger.warning(
+                "git fetch origin %s returned %d: %s",
+                self.base_branch,
+                result.returncode,
+                result.stderr.decode("utf-8", "replace").strip(),
+            )
+            return False
+        logger.info("Fetched origin/%s", self.base_branch)
+        return True
 
     # ─── Repair actions ───────────────────────────────────────────────
 

--- a/factory/tests/test_readiness.py
+++ b/factory/tests/test_readiness.py
@@ -1,0 +1,224 @@
+"""Tests for factory readiness: fetch-origin + behind_origin detection.
+
+These tests cover the auto-pull behavior added so the factory-host
+checkout is synced to origin/<base_branch> before every job runs. The
+motivating incident: factory job a51efc39 (PR #34) ran with
+orchestrator.py at commit d2593c9 because no one had pulled; the
+updated parser it was testing was never actually executed.
+
+Pattern: stub `readiness.subprocess.run` via monkeypatch with a
+_FakeCompleted helper, and mock _check_orphan_locks to return [] so
+the dev DB's file_locks state can't pollute assertions. No real git.
+Autouse cleanup handles any factory_runtime_state rows the flag-
+persistence path writes.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+
+import pytest
+
+import readiness as readiness_module
+from readiness import FactoryReadiness, ReadinessIssue
+from state_machine import FactoryDB
+from config import DATABASE_URL
+
+TEST_PROJECT_ROOT = "/tmp/readiness_test_root"
+
+
+@pytest.fixture
+def db():
+    return FactoryDB(DATABASE_URL)
+
+
+@pytest.fixture(autouse=True)
+def cleanup(db):
+    """Clear the not_ready flag row before and after each test so flag
+    persistence from one test can't leak into the next."""
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM devbrain.factory_runtime_state WHERE key = 'not_ready'"
+        )
+        conn.commit()
+
+
+@pytest.fixture
+def readiness(db, monkeypatch):
+    """FactoryReadiness with _check_orphan_locks stubbed to []. Tests
+    that need a custom base_branch build their own instance."""
+    r = FactoryReadiness(db, TEST_PROJECT_ROOT)
+    monkeypatch.setattr(r, "_check_orphan_locks", lambda: [])
+    return r
+
+
+class _FakeCompleted:
+    """Mirror the _FakeCompleted helper in test_factory_approve_sync.py.
+    stdout defaults to bytes because _fetch_origin calls subprocess.run
+    WITHOUT text=True, while _run_git uses text=True. Tests decide which
+    form to return based on the command dispatched in the stub.
+    """
+    def __init__(self, returncode: int = 0, stdout=b"", stderr=b""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _default_git_response(cmd):
+    """Return a happy-path _FakeCompleted for the given git command.
+    Bytes for fetch (no text=True), strings for _run_git (text=True).
+    """
+    if cmd[:2] == ["git", "fetch"]:
+        return _FakeCompleted(returncode=0, stdout=b"", stderr=b"")
+    if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+        return _FakeCompleted(returncode=0, stdout="main\n", stderr="")
+    if cmd[:2] == ["git", "status"]:
+        return _FakeCompleted(returncode=0, stdout="", stderr="")
+    if cmd[:3] == ["git", "rev-list", "--count"]:
+        return _FakeCompleted(returncode=0, stdout="0\n", stderr="")
+    return _FakeCompleted(returncode=0, stdout="", stderr="")
+
+
+# ─── 1. Fetch runs first ────────────────────────────────────────────────
+
+def test_fetch_is_first_subprocess_call(readiness, monkeypatch):
+    """`git fetch origin main` must be the very first subprocess call
+    ensure_ready() issues — before any verify step. This guarantees
+    the behind_origin check that follows compares against fresh refs.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _default_git_response(cmd)
+
+    monkeypatch.setattr(readiness_module.subprocess, "run", fake_run)
+
+    remaining = readiness.ensure_ready()
+
+    assert remaining == []
+    assert len(calls) >= 1
+    assert calls[0][:4] == ["git", "fetch", "origin", "main"]
+
+
+# ─── 2. Fetch timeout is best-effort ────────────────────────────────────
+
+def test_fetch_timeout_does_not_raise_or_emit_issue(
+    readiness, monkeypatch, caplog,
+):
+    """Offline factory-host: fetch raises TimeoutExpired. ensure_ready()
+    must NOT raise, must NOT emit a readiness issue for the fetch
+    failure, and must log a WARNING. Local code still runs.
+    """
+    caplog.set_level(logging.WARNING, logger="readiness")
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["git", "fetch"]:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+        return _default_git_response(cmd)
+
+    monkeypatch.setattr(readiness_module.subprocess, "run", fake_run)
+
+    remaining = readiness.ensure_ready()
+
+    assert remaining == []
+    assert any(
+        "fetch" in rec.message.lower() for rec in caplog.records
+    ), f"expected a fetch-related WARNING, got: {[r.message for r in caplog.records]}"
+
+
+# ─── 3. behind_origin emitted when HEAD is behind ───────────────────────
+
+def test_behind_origin_issue_emitted_when_count_positive(
+    readiness, monkeypatch,
+):
+    """rev-list --count returns a positive number → behind_origin issue
+    with commits_behind detail and auto_repairable=True.
+    """
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return _FakeCompleted(returncode=0, stdout="3\n", stderr="")
+        return _default_git_response(cmd)
+
+    monkeypatch.setattr(readiness_module.subprocess, "run", fake_run)
+
+    issues = readiness.verify()
+    kinds = [i.kind for i in issues]
+
+    assert "behind_origin" in kinds, f"expected behind_origin; got: {kinds}"
+    bo = next(i for i in issues if i.kind == "behind_origin")
+    assert bo.details == {"commits_behind": 3}
+    assert bo.auto_repairable is True
+
+
+# ─── 4. Up-to-date emits no behind_origin ───────────────────────────────
+
+def test_up_to_date_emits_no_behind_origin_issue(readiness, monkeypatch):
+    """rev-list --count returns 0 → no behind_origin issue."""
+    def fake_run(cmd, **kwargs):
+        return _default_git_response(cmd)
+
+    monkeypatch.setattr(readiness_module.subprocess, "run", fake_run)
+
+    issues = readiness.verify()
+
+    assert all(i.kind != "behind_origin" for i in issues), (
+        f"expected no behind_origin issue; got: {[i.kind for i in issues]}"
+    )
+
+
+# ─── 5. behind_origin repair runs reset + clean ─────────────────────────
+
+def test_behind_origin_repair_runs_reset_and_clean(readiness, monkeypatch):
+    """attempt_repair for a behind_origin issue must run
+    `git reset --hard origin/main` + `git clean -fd` (shared primitive
+    with dirty_working_tree).
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _default_git_response(cmd)
+
+    monkeypatch.setattr(readiness_module.subprocess, "run", fake_run)
+
+    issue = ReadinessIssue(
+        kind="behind_origin",
+        message="HEAD is 5 commit(s) behind origin/main",
+        details={"commits_behind": 5},
+    )
+    readiness.attempt_repair([issue])
+
+    reset_calls = [c for c in calls if c[:3] == ["git", "reset", "--hard"]]
+    clean_calls = [c for c in calls if c[:3] == ["git", "clean", "-fd"]]
+    assert len(reset_calls) == 1, f"expected one reset; got: {reset_calls}"
+    assert reset_calls[0][-1] == "origin/main"
+    assert len(clean_calls) == 1, f"expected one clean; got: {clean_calls}"
+
+
+# ─── 6. Configured base_branch flows through ────────────────────────────
+
+def test_fetch_uses_configured_base_branch(db, monkeypatch):
+    """A FactoryReadiness built with base_branch="develop" must fetch
+    origin/develop and compare HEAD..origin/develop — not main.
+    """
+    r = FactoryReadiness(db, TEST_PROJECT_ROOT, base_branch="develop")
+    monkeypatch.setattr(r, "_check_orphan_locks", lambda: [])
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return _FakeCompleted(returncode=0, stdout="develop\n", stderr="")
+        return _default_git_response(cmd)
+
+    monkeypatch.setattr(readiness_module.subprocess, "run", fake_run)
+
+    r.ensure_ready()
+
+    fetch_calls = [c for c in calls if c[:2] == ["git", "fetch"]]
+    revlist_calls = [c for c in calls if c[:3] == ["git", "rev-list", "--count"]]
+    assert fetch_calls[0] == ["git", "fetch", "origin", "develop"]
+    assert revlist_calls[0][-1] == "HEAD..origin/develop"

--- a/factory/tests/test_readiness.py
+++ b/factory/tests/test_readiness.py
@@ -128,6 +128,50 @@ def test_fetch_timeout_does_not_raise_or_emit_issue(
     ), f"expected a fetch-related WARNING, got: {[r.message for r in caplog.records]}"
 
 
+# ─── 2b. Fetch non-zero returncode (auth/DNS/missing-remote) ────────────
+# The more common offline failure mode than TimeoutExpired: git returns
+# a non-zero status (fatal: unable to access, DNS, auth rejection, etc.)
+# rather than raising. Must log + preserve readiness semantics same as
+# the timeout case — no issue emitted, local code still runs.
+
+def test_fetch_non_zero_returncode_logs_but_does_not_emit_issue(
+    readiness, monkeypatch, caplog,
+):
+    """Fetch returns non-zero with stderr (auth failure, DNS, missing
+    remote). ensure_ready() must NOT raise, must NOT emit a readiness
+    issue for the fetch failure, and must log a WARNING including the
+    git stderr so the operator can diagnose."""
+    caplog.set_level(logging.WARNING, logger="readiness")
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["git", "fetch"]:
+            return _FakeCompleted(
+                returncode=128,
+                stdout=b"",
+                stderr=b"fatal: unable to access 'https://example/': DNS lookup failed",
+            )
+        return _default_git_response(cmd)
+
+    monkeypatch.setattr(readiness_module.subprocess, "run", fake_run)
+
+    remaining = readiness.ensure_ready()
+
+    assert remaining == []
+    # WARNING log should include the stderr tail so diagnosis is possible.
+    fetch_warnings = [
+        rec for rec in caplog.records
+        if "fetch" in rec.message.lower()
+    ]
+    assert fetch_warnings, (
+        f"expected a fetch-related WARNING; got: "
+        f"{[r.message for r in caplog.records]}"
+    )
+    assert any(
+        "DNS lookup failed" in rec.message or "unable to access" in rec.message
+        for rec in fetch_warnings
+    ), f"expected stderr detail in WARNING; got: {[r.message for r in fetch_warnings]}"
+
+
 # ─── 3. behind_origin emitted when HEAD is behind ───────────────────────
 
 def test_behind_origin_issue_emitted_when_count_positive(
@@ -165,6 +209,57 @@ def test_up_to_date_emits_no_behind_origin_issue(readiness, monkeypatch):
 
     assert all(i.kind != "behind_origin" for i in issues), (
         f"expected no behind_origin issue; got: {[i.kind for i in issues]}"
+    )
+
+
+# ─── 4b. behind_origin fail-safe branches ───────────────────────────────
+# `_check_behind_origin` has two explicit defensive branches that return
+# [] rather than emit a false-alarm issue: (a) rev-list fails with a
+# non-zero exit (allow_fail=True → _run_git returns None), (b) rev-list
+# returns non-numeric stdout (int() raises ValueError). The plan called
+# these out as load-bearing fail-safe semantics — lock them in.
+
+def test_behind_origin_fail_safe_when_rev_list_fails(readiness, monkeypatch):
+    """rev-list returns a non-zero status (e.g. fresh clone with no
+    origin/<base> ref yet) → _run_git(allow_fail=True) returns None →
+    _check_behind_origin returns [] (no false alarm)."""
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return _FakeCompleted(
+                returncode=128,
+                stdout="",
+                stderr="fatal: ambiguous argument 'HEAD..origin/main'",
+            )
+        return _default_git_response(cmd)
+
+    monkeypatch.setattr(readiness_module.subprocess, "run", fake_run)
+
+    issues = readiness.verify()
+
+    assert all(i.kind != "behind_origin" for i in issues), (
+        f"rev-list failure must not emit behind_origin; got: "
+        f"{[i.kind for i in issues]}"
+    )
+
+
+def test_behind_origin_fail_safe_on_non_numeric_output(readiness, monkeypatch):
+    """rev-list returns non-numeric stdout (corrupt / unexpected output)
+    → int() raises ValueError → _check_behind_origin returns []
+    (no false alarm)."""
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return _FakeCompleted(
+                returncode=0, stdout="not-a-number\n", stderr="",
+            )
+        return _default_git_response(cmd)
+
+    monkeypatch.setattr(readiness_module.subprocess, "run", fake_run)
+
+    issues = readiness.verify()
+
+    assert all(i.kind != "behind_origin" for i in issues), (
+        f"non-numeric rev-list output must not emit behind_origin; got: "
+        f"{[i.kind for i in issues]}"
     )
 
 


### PR DESCRIPTION
## Summary
Factory orchestrator runs from `~/devbrain/factory/orchestrator.py` on the factory-host — that's the code ACTIVE during a job. But the factory's own PRs only land on the machine when someone runs `git pull`. Demonstrated concretely: factory job `a51efc39` (PR #34, structured JSON parser) ran with orchestrator at `d2593c9` — TWO PRs behind `origin/main`. The new parser code in the worktree passed its tests but was never active for its own review/artifact writes. `reviewer_output_malformed` flag writes silently no-op'd because the orchestrator runtime didn't know about the column.

This PR plugs the gap: `FactoryReadiness.ensure_ready()` now runs `git fetch origin <base_branch>` at the very top, and the behind-origin check (new `behind_origin` issue kind) auto-repairs via the existing `_repair_working_tree` path (`reset --hard origin/main` + `clean -fd`).

## Design
- `_fetch_origin()` — best-effort, 30s timeout, swallows subprocess exceptions and non-zero returncodes with WARNING logs. Offline factory-host still runs local code; readiness does NOT hard-block on network.
- New `ReadinessIssue(kind="behind_origin", ...)` emitted when `git rev-list --count HEAD..origin/<base>` returns > 0. Fail-safe: any parse error or git failure returns `[]` (no false alarm).
- `verify()` order: `head_not_main → behind_origin → dirty_working_tree → orphan_lock`. Sync logically precedes reset.
- `attempt_repair()` maps `behind_origin` to the existing `_repair_working_tree()`. Same primitive, two entry points → distinct log attribution (`"behind_origin"` vs `"dirty_working_tree"`).

## Produced by
Factory job `bfd5130d` — single clean pass (planning 3m, implementing 11m, arch review 4m, security review 3m). 0 BLOCKING + 0 WARNING across both reviews; both emitted proper JSON findings blocks (the PR #34 parser working cleanly on its first self-exposed test). Arch review: 3 NITs (2 coverage gaps + 1 observation). Security review: 1 NIT (defense-in-depth for future callers).

## Hand-fix commit
`4fea76c` covers the two load-bearing coverage gaps the arch reviewer correctly flagged:

1. **`_fetch_origin` non-zero returncode path** (arch NIT #1). Only `TimeoutExpired` was tested, but non-zero return is the more common offline failure mode in practice (auth rejection, DNS failure, missing remote). New test stubs fetch to return `returncode=128` with a realistic stderr and asserts ensure_ready() returns `[]`, no issue fires, WARNING log includes the stderr tail for operator diagnosis.

2. **`_check_behind_origin` fail-safe branches** (arch NIT #2). The two defensive paths the plan called out — `out is None` (rev-list exits non-zero) and `ValueError` on `int()` (non-numeric stdout) — had no tests. Two small tests lock them in: first returns `[]` on a fresh-clone-style error, second returns `[]` on corrupt git output. Both must not emit false-alarm `behind_origin` issues.

No production code changes in the hand-fix — pure coverage additions.

## Out-of-scope NITs (deferred)
- Arch NIT #3: `_repair_working_tree` runs twice when both `behind_origin` and `dirty_working_tree` are present in one verify pass. Idempotent, wasteful, reviewer + I both agreed not worth fixing (explicit-elif structure was a deliberate plan choice for log attributability).
- Security NIT: `base_branch` argument lacks `SAFE_BRANCH_RE` validation for defense-in-depth. Not exploitable today (only `"main"` reaches it), worth a follow-up when someone wires user input into the constructor.

## Infrastructure follow-up caught along the way
MacBook's DB was missing migration `007_factory_runtime_state.sql` — surfaced when the new readiness tests tried to run locally. Applied manually. Worth a sweep to verify MacBook DB schema matches Mac Studio's.

## Tests
- `factory/tests/test_readiness.py`: 9 tests total — 6 original from the factory pass + 3 new coverage-gap tests. All pass locally.
- Factory-run impl_output reports 42/42 tests pass across the readiness-adjacent surface on Mac Studio.

## Test plan
- [ ] `pytest factory/tests/test_readiness.py` — 9 pass
- [ ] Post-merge sanity: pull Mac Studio to `HEAD`, then submit the NEXT factory job (task #18, or anything) and verify the `factory.log` shows a fetch + (if applicable) a reset-to-origin/main at the start of the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)