### PR TITLE
feat(factory): harden JSON findings parser against multi-block attacks (task #18)

### DIFF
--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -192,8 +192,13 @@ def _count_blocking(text: str, return_fallback: bool = False):
         count = sum(1 for f in findings if f["severity"] == "BLOCKING")
         used_fallback = False
     else:
-        # Stacked-prefix tolerant, bounded {0,4} (PR #32).
-        pattern = r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}BLOCKING\b'
+        # Stacked-prefix tolerant, bounded {0,4} (PR #32). Negative
+        # lookahead `(?!\s*→)` skips rubric-echo lines of the form
+        # `- BLOCKING → <explanation>` that the prompts use to define
+        # severity; a reviewer quoting the prompt back plus emitting
+        # two JSON blocks would otherwise have echoed rubric counted
+        # as real findings.
+        pattern = r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}BLOCKING\b(?!\s*→)'
         count = len(re.findall(pattern, text, re.IGNORECASE))
         used_fallback = True
     return (count, used_fallback) if return_fallback else count
@@ -212,13 +217,15 @@ def _extract_blocking_items(text: str, return_fallback: bool = False):
         used_fallback = False
     else:
         items = []
+        # Split on BLOCKING markers but skip rubric-echo `BLOCKING → ...`
+        # lines (see _count_blocking for why).
         parts = re.split(
-            r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}BLOCKING[:\s]*',
+            r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}BLOCKING\b(?!\s*→)[:\s]*',
             text, flags=re.IGNORECASE,
         )
         for part in parts[1:]:
             end = re.search(
-                r'\n\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}(?:WARNING|NIT|BLOCKING)\b',
+                r'\n\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}(?:WARNING|NIT|BLOCKING)\b(?!\s*→)',
                 part, re.IGNORECASE,
             )
             item = part[:end.start()].strip() if end else part.strip()
@@ -241,7 +248,8 @@ def _count_warning(text: str, return_fallback: bool = False):
         count = sum(1 for f in findings if f["severity"] == "WARNING")
         used_fallback = False
     else:
-        pattern = r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}WARNING\b'
+        # See _count_blocking for why the `(?!\s*→)` lookahead is here.
+        pattern = r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}WARNING\b(?!\s*→)'
         count = len(re.findall(pattern, text, re.IGNORECASE))
         used_fallback = True
     return (count, used_fallback) if return_fallback else count
@@ -260,13 +268,14 @@ def _extract_warning_items(text: str, return_fallback: bool = False):
         used_fallback = False
     else:
         items = []
+        # See _count_blocking for why the `(?!\s*→)` lookahead is here.
         parts = re.split(
-            r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}WARNING[:\s]*',
+            r'(?:^|\n)\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}WARNING\b(?!\s*→)[:\s]*',
             text, flags=re.IGNORECASE,
         )
         for part in parts[1:]:
             end = re.search(
-                r'\n\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}(?:BLOCKING|NIT|WARNING)\b',
+                r'\n\s*(?:(?:\d+\.\s*|\*\*?|-\s*)\s*){0,4}(?:BLOCKING|NIT|WARNING)\b(?!\s*→)',
                 part, re.IGNORECASE,
             )
             item = part[:end.start()].strip() if end else part.strip()
@@ -1288,7 +1297,7 @@ If this is a re-review round, explicitly state which prior findings are RESOLVED
 
 ## Required output format
 
-**Emit EXACTLY ONE `` ```json findings `` block at the end of your review.** The pipeline reads this block to count BLOCKING/WARNING/NIT findings; missing, malformed, or multiple blocks trigger a regex fallback and flag the artifact as malformed. Always include the block, even when there are no findings (use an empty list). Do not draft-and-revise — edit your block in place before submitting. Do not paste diff context, examples, or quoted prior reviews that contain additional `` ```json findings `` fences; two or more blocks will be rejected with `multiple_findings_blocks:N`.
+**Emit EXACTLY ONE `` ```json findings `` block at the end of your review.** The pipeline reads this block to count BLOCKING/WARNING/NIT findings; missing, malformed, or multiple blocks trigger a regex fallback and flag the artifact as malformed. Always include the block, even when there are no findings (use an empty list). Do not draft-and-revise — edit your block in place before submitting. Do not paste diff context, examples, or quoted prior reviews that contain additional `` ```json findings `` fences; two or more blocks will be rejected with `multiple_findings_blocks:N`. Do not quote the severity rubric above back in your prose — if the JSON block is malformed, the regex fallback would count each echoed `- BLOCKING` / `- WARNING` line as a real finding.
 
 ```json findings
 {{"findings": [
@@ -1393,7 +1402,7 @@ Store any security issues found in DevBrain with type="issue" and category="secu
 
 ## Required output format
 
-**Emit EXACTLY ONE `` ```json findings `` block at the end of your review.** The pipeline reads this block to count BLOCKING/WARNING/NIT findings; missing, malformed, or multiple blocks trigger a regex fallback and flag the artifact as malformed. Always include the block, even when there are no findings (use an empty list). Do not draft-and-revise — edit your block in place before submitting. Do not paste diff context, examples, or quoted prior reviews that contain additional `` ```json findings `` fences; two or more blocks will be rejected with `multiple_findings_blocks:N`.
+**Emit EXACTLY ONE `` ```json findings `` block at the end of your review.** The pipeline reads this block to count BLOCKING/WARNING/NIT findings; missing, malformed, or multiple blocks trigger a regex fallback and flag the artifact as malformed. Always include the block, even when there are no findings (use an empty list). Do not draft-and-revise — edit your block in place before submitting. Do not paste diff context, examples, or quoted prior reviews that contain additional `` ```json findings `` fences; two or more blocks will be rejected with `multiple_findings_blocks:N`. Do not quote the severity rubric above back in your prose — if the JSON block is malformed, the regex fallback would count each echoed `- BLOCKING` / `- WARNING` line as a real finding.
 
 ```json findings
 {{"findings": [
@@ -1454,7 +1463,37 @@ The prose above the block is what humans read; the block is the machine contract
         warnings_trigger = (
             FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY and total_warning > 0
         )
-        should_fix = total_blocking > 0 or warnings_trigger
+        # Silent-suppression guardrail: when a reviewer emits multiple
+        # JSON findings blocks (rejected by _parse_findings_json with
+        # `multiple_findings_blocks:N`) AND the regex fallback surfaces
+        # zero findings, the counts cannot be trusted — a legitimate
+        # finding in either block would otherwise be silently swallowed
+        # and the job would auto-promote to READY_FOR_APPROVAL. Force a
+        # re-review cycle so the reviewer gets another chance to emit
+        # a single clean block.
+        arch_multi_silent = bool(
+            arch_parse_err
+            and arch_parse_err.startswith("multiple_findings_blocks")
+            and blocking_count == 0
+            and warning_count == 0
+        )
+        sec_multi_silent = bool(
+            sec_parse_err
+            and sec_parse_err.startswith("multiple_findings_blocks")
+            and sec_blocking == 0
+            and sec_warning == 0
+        )
+        reviewer_malformed_silent = arch_multi_silent or sec_multi_silent
+        if reviewer_malformed_silent:
+            logger.warning(
+                "Reviewer emitted multiple JSON findings blocks with zero "
+                "regex-fallback findings for job %s — forcing re-review to "
+                "avoid silent auto-promotion (arch=%s, sec=%s)",
+                job.id[:8], arch_parse_err, sec_parse_err,
+            )
+        should_fix = (
+            total_blocking > 0 or warnings_trigger or reviewer_malformed_silent
+        )
         if not should_fix:
             return self.db.transition(job.id, JobStatus.QA)
 
@@ -1484,14 +1523,22 @@ The prose above the block is what humans read; the block is the machine contract
                 self._notify_warning_oscillation(failed, repeating)
                 return failed
 
+        trigger_reason = (
+            "blocking" if total_blocking > 0
+            else "warning" if warnings_trigger
+            else "reviewer_malformed"
+        )
+        fix_loop_metadata = {
+            "blocking_findings": total_blocking,
+            "warning_findings": total_warning,
+            "trigger_reason": trigger_reason,
+        }
+        if reviewer_malformed_silent:
+            fix_loop_metadata["reviewer_malformed"] = True
         return self.db.transition(
             job.id,
             JobStatus.FIX_LOOP,
-            metadata={
-                "blocking_findings": total_blocking,
-                "warning_findings": total_warning,
-                "trigger_reason": "blocking" if total_blocking > 0 else "warning",
-            },
+            metadata=fix_loop_metadata,
         )
 
     # ─── QA Phase ──────────────────────────────────────────────────────────

--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -117,14 +117,21 @@ def _parse_findings_json(text: str) -> tuple[list[dict] | None, str | None]:
         severity was dropped but the rest was valid) — callers should
         still flag the artifact as malformed.
 
-    Reviewers occasionally write multiple blocks (draft + final). The
-    LAST block is authoritative — re.findall returns matches in order
-    and we take [-1].
+    Exactly one ``` ```json findings ``` block is required. Two or more
+    blocks are rejected with ``multiple_findings_blocks:N`` so the
+    regex fallback fires and the artifact is flagged malformed (PR #36).
+    A prior "last block wins" heuristic made the pipeline vulnerable
+    to diff-echo attacks — a reviewer emitting real findings could be
+    silenced by echoing diff context that happened to contain another
+    ``` ```json findings ``` fence further down the output. Strict
+    single-block contract + fallback eliminates that class of bug.
     """
     matches = _FINDINGS_FENCE_RE.findall(text)
-    if not matches:
+    if len(matches) == 0:
         return (None, "no_findings_block")
-    raw = matches[-1]
+    if len(matches) > 1:
+        return (None, f"multiple_findings_blocks:{len(matches)}")
+    raw = matches[0]
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as e:
@@ -1281,7 +1288,7 @@ If this is a re-review round, explicitly state which prior findings are RESOLVED
 
 ## Required output format
 
-After your prose review, end your response with a fenced JSON findings block. The pipeline reads this block to count BLOCKING/WARNING/NIT findings; missing or malformed JSON triggers a regex fallback and flags the artifact as malformed. Always include the block, even when there are no findings (use an empty list).
+**Emit EXACTLY ONE `` ```json findings `` block at the end of your review.** The pipeline reads this block to count BLOCKING/WARNING/NIT findings; missing, malformed, or multiple blocks trigger a regex fallback and flag the artifact as malformed. Always include the block, even when there are no findings (use an empty list). Do not draft-and-revise — edit your block in place before submitting. Do not paste diff context, examples, or quoted prior reviews that contain additional `` ```json findings `` fences; two or more blocks will be rejected with `multiple_findings_blocks:N`.
 
 ```json findings
 {{"findings": [
@@ -1386,7 +1393,7 @@ Store any security issues found in DevBrain with type="issue" and category="secu
 
 ## Required output format
 
-After your prose review, end your response with a fenced JSON findings block. The pipeline reads this block to count BLOCKING/WARNING/NIT findings; missing or malformed JSON triggers a regex fallback and flags the artifact as malformed. Always include the block, even when there are no findings (use an empty list).
+**Emit EXACTLY ONE `` ```json findings `` block at the end of your review.** The pipeline reads this block to count BLOCKING/WARNING/NIT findings; missing, malformed, or multiple blocks trigger a regex fallback and flag the artifact as malformed. Always include the block, even when there are no findings (use an empty list). Do not draft-and-revise — edit your block in place before submitting. Do not paste diff context, examples, or quoted prior reviews that contain additional `` ```json findings `` fences; two or more blocks will be rejected with `multiple_findings_blocks:N`.
 
 ```json findings
 {{"findings": [

--- a/factory/tests/test_findings_parser.py
+++ b/factory/tests/test_findings_parser.py
@@ -80,8 +80,14 @@ def test_no_json_block_uses_regex_fallback():
     assert err == "no_findings_block"
 
 
-# 5. Multiple JSON blocks — last one wins
-def test_multiple_json_blocks_last_wins():
+# 5. Multiple JSON blocks — rejected, regex fallback fires (PR #36).
+# Prior behavior ("last block wins") opened a diff-echo attack path
+# where a reviewer's real findings could be silenced by any later
+# fenced block — including diff context a reviewer pasted in. The
+# stricter contract rejects >1 blocks with a count-bearing error so
+# the existing regex fallback + reviewer_output_malformed flag
+# (orchestrator.py _run_review) fires automatically.
+def test_multiple_json_blocks_rejects_and_falls_back():
     first = (
         '```json findings\n{"findings": ['
         '{"severity": "WARNING", "title": "a", "body": "x"},'
@@ -98,7 +104,63 @@ def test_multiple_json_blocks_last_wins():
         "]}\n```"
     )
     text = f"draft:\n{first}\n\nFINAL:\n{second}\n"
-    assert _count_warning(text) == 2  # second block, not first
+    findings, err = _parse_findings_json(text)
+    assert findings is None
+    assert err == "multiple_findings_blocks:2"
+    _, used_fallback = _count_warning(text, return_fallback=True)
+    assert used_fallback is True
+
+
+# 5b. Three blocks also rejected — locks in that rejection is not a
+# 2-block special case.
+def test_three_json_blocks_also_rejected():
+    block = (
+        '```json findings\n{"findings": ['
+        '{"severity": "WARNING", "title": "t", "body": "x"}'
+        "]}\n```"
+    )
+    text = f"round 1:\n{block}\n\nround 2:\n{block}\n\nround 3:\n{block}\n"
+    findings, err = _parse_findings_json(text)
+    assert findings is None
+    assert err == "multiple_findings_blocks:3"
+
+
+# 5c. Diff-echo attack: a real BLOCKING block is followed by reviewer
+# prose that quotes diff context containing a benign `{"findings": []}`
+# block. Under "last block wins" the BLOCKING would be silenced. Under
+# PR #36 the parser rejects both blocks and the regex fallback rescues
+# the real finding from the prose.
+def test_diff_echo_attack_does_not_suppress_findings():
+    real_block = (
+        '```json findings\n{"findings": ['
+        '{"severity": "BLOCKING", "title": "sql injection", '
+        '"body": "unescaped input at db.py:42"}'
+        "]}\n```"
+    )
+    echoed_block = '```json findings\n{"findings": []}\n```'
+    text = (
+        "I found a BLOCKING issue. See below.\n\n"
+        f"{real_block}\n\n"
+        "For context, here is the diff the implementer pasted back:\n"
+        f"    {echoed_block}\n"
+    )
+    findings, err = _parse_findings_json(text)
+    assert findings is None
+    assert err == "multiple_findings_blocks:2"
+
+    # Defense-in-depth: when the prose also carries a stacked-prefix
+    # BLOCKING marker, the regex fallback still sees the real finding.
+    text_with_prose_marker = (
+        "1. BLOCKING: sql injection — unescaped input at db.py:42\n\n"
+        f"{real_block}\n\n"
+        "Diff context follows:\n"
+        f"    {echoed_block}\n"
+    )
+    count, used_fallback = _count_blocking(
+        text_with_prose_marker, return_fallback=True
+    )
+    assert used_fallback is True
+    assert count == 1
 
 
 # 6. Malformed JSON — fallback used, error mentions JSONDecodeError

--- a/factory/tests/test_findings_parser.py
+++ b/factory/tests/test_findings_parser.py
@@ -163,6 +163,55 @@ def test_diff_echo_attack_does_not_suppress_findings():
     assert count == 1
 
 
+# 5d. Diff-echo-via-rubric: reviewer quotes the severity rubric from
+# the prompt (lines of the form `- BLOCKING → ...`) AND emits two JSON
+# blocks (forcing multi-block rejection → regex fallback). Without the
+# `(?!\s*→)` negative lookahead added in PR #37, the fallback would
+# count each echoed rubric line as a real finding and incorrectly
+# route the job to fix-loop.
+def test_rubric_echo_with_two_blocks_is_not_miscounted():
+    text = (
+        "# My review\n\n"
+        "Severity rubric (echoed from prompt):\n"
+        "- BLOCKING → actual vulnerability, PHI exposure, missing auth check\n"
+        "- WARNING  → defense-in-depth suggestion, narrow input gap\n"
+        "- NIT      → best-practice suggestion\n\n"
+        "## Findings\n\n"
+        '```json findings\n{"findings": []}\n```\n\n'
+        "## Draft (forgot to delete)\n\n"
+        '```json findings\n{"findings": []}\n```\n'
+    )
+    # Two blocks → multi-block rejection → regex fallback.
+    findings, err = _parse_findings_json(text)
+    assert findings is None
+    assert err.startswith("multiple_findings_blocks")
+    # Fallback must not count the echoed rubric lines.
+    b_count, b_fb = _count_blocking(text, return_fallback=True)
+    w_count, w_fb = _count_warning(text, return_fallback=True)
+    assert b_fb is True and w_fb is True
+    assert b_count == 0
+    assert w_count == 0
+    assert _extract_blocking_items(text) == []
+    assert _extract_warning_items(text) == []
+
+
+# 5e. Sanity check: a real `- BLOCKING: ...` finding in the prose
+# (the shape reviewers actually produce when they fall back to
+# regex) must still be counted by the fallback. The negative
+# lookahead only excludes the `→` rubric form.
+def test_real_dash_prefixed_findings_still_counted_by_fallback():
+    text = (
+        "- BLOCKING: null deref at x.py:42\n"
+        "- WARNING: suboptimal pattern at y.py:10\n"
+    )
+    assert _count_blocking(text) == 1
+    assert _count_warning(text) == 1
+    blockings = _extract_blocking_items(text)
+    warnings = _extract_warning_items(text)
+    assert len(blockings) == 1 and "null deref" in blockings[0]
+    assert len(warnings) == 1 and "suboptimal pattern" in warnings[0]
+
+
 # 6. Malformed JSON — fallback used, error mentions JSONDecodeError
 def test_malformed_json_falls_back():
     text = "```json findings\n{not valid json\n```\n"

--- a/factory/tests/test_review_prompt_calibration.py
+++ b/factory/tests/test_review_prompt_calibration.py
@@ -103,6 +103,8 @@ def test_arch_prompt_contains_severity_cost_guidance(orch, db, monkeypatch):
     # JSON findings contract — added 2026-04-24 (PR 21b1b68a).
     assert "## Required output format" in arch_prompt
     assert "```json findings" in arch_prompt
+    # PR #36: single-block contract communicated to reviewer.
+    assert "EXACTLY ONE" in arch_prompt
 
 
 def test_security_prompt_contains_severity_cost_guidance(orch, db, monkeypatch):
@@ -121,3 +123,5 @@ def test_security_prompt_contains_severity_cost_guidance(orch, db, monkeypatch):
     assert "RESOLVED vs still BLOCKING" in sec_prompt
     assert "## Required output format" in sec_prompt
     assert "```json findings" in sec_prompt
+    # PR #36: single-block contract communicated to reviewer.
+    assert "EXACTLY ONE" in sec_prompt

--- a/factory/tests/test_warning_fix_loop.py
+++ b/factory/tests/test_warning_fix_loop.py
@@ -207,6 +207,97 @@ def test_warning_skipped_when_flag_false(orch, db, monkeypatch):
     assert result.status == JobStatus.QA
 
 
+def test_multi_block_silent_suppression_routes_to_fix_loop(orch, db, monkeypatch):
+    """Reviewer emits two JSON findings blocks with no prose-level
+    severity markers. The parser rejects with `multiple_findings_blocks`
+    and the regex fallback scores 0 on both reviews. Without the silent-
+    suppression guardrail (PR #37) this would auto-promote to QA →
+    READY_FOR_APPROVAL even though any real finding in either block was
+    silently swallowed. The guardrail must route to FIX_LOOP with
+    `reviewer_malformed=True` so a re-review round runs.
+    """
+    monkeypatch.setattr(
+        orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", True
+    )
+    job = _make_implementing_job(
+        db, f"{TEST_TITLE_PREFIX}multi_block_silent"
+    )
+
+    # Two blocks, one with an empty list, one with an empty list → after
+    # multi-block rejection the fallback regex has nothing to match since
+    # there are no prose-level BLOCKING/WARNING markers anywhere.
+    two_empty_blocks = (
+        "Prose-only review body with no severity markers in text.\n\n"
+        '```json findings\n{"findings": []}\n```\n\n'
+        "Draft copy I forgot to delete:\n\n"
+        '```json findings\n{"findings": []}\n```\n'
+    )
+
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout=two_empty_blocks,
+        sec_stdout=two_empty_blocks,
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.FIX_LOOP
+    assert result.metadata.get("reviewer_malformed") is True
+    assert result.metadata.get("trigger_reason") == "reviewer_malformed"
+    assert result.metadata.get("blocking_findings") == 0
+    assert result.metadata.get("warning_findings") == 0
+
+    # The review artifacts themselves must also carry the parse_error
+    # so the metadata is durable even across future routing changes.
+    artifacts = db.get_artifacts(job.id, phase="review")
+    assert any(
+        a["metadata"].get("reviewer_output_malformed") is True
+        and str(a["metadata"].get("parse_error", "")).startswith(
+            "multiple_findings_blocks"
+        )
+        for a in artifacts
+    )
+
+
+def test_multi_block_with_prose_findings_still_uses_fallback_counts(
+    orch, db, monkeypatch
+):
+    """Multi-block rejection + prose-level BLOCKING marker: the regex
+    fallback rescues the real finding, so routing goes to FIX_LOOP as
+    `blocking` (not `reviewer_malformed`). This is the diff-echo
+    defence-in-depth path — confirms the silent-suppression guardrail
+    only fires when the fallback also returns zero.
+    """
+    monkeypatch.setattr(
+        orch_mod, "FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY", True
+    )
+    job = _make_implementing_job(
+        db, f"{TEST_TITLE_PREFIX}multi_block_with_prose"
+    )
+
+    arch_with_prose_marker = (
+        "1. BLOCKING: unescaped input at db.py:42\n\n"
+        '```json findings\n{"findings": [{"severity": "BLOCKING", '
+        '"title": "sql injection", "body": "unescaped input at db.py:42"}]}\n```\n\n'
+        "Diff context echoed below:\n"
+        '```json findings\n{"findings": []}\n```\n'
+    )
+
+    _stub_review_env(
+        monkeypatch,
+        arch_stdout=arch_with_prose_marker,
+        sec_stdout=_with_json("(no findings)", []),
+    )
+
+    result = orch._run_review(job)
+
+    assert result.status == JobStatus.FIX_LOOP
+    assert result.metadata.get("trigger_reason") == "blocking"
+    # Silent-suppression flag must NOT fire when regex fallback found
+    # a real finding.
+    assert result.metadata.get("reviewer_malformed") is not True
+
+
 def test_extract_warning_items_from_review_content(orch, db):
     """Regex-fallback canary — this case intentionally has NO JSON
     block so the helpers exercise the PR #32 fallback path. Don't


### PR DESCRIPTION
## Summary
Closes the last-block-wins vulnerability flagged as a security NIT on PR #34: a PR whose diff contains its own ` ```json findings ``` ` fence could be echoed by the reviewer LLM and silently suppress real findings (including BLOCKING). `_parse_findings_json` now rejects any output with >1 findings block, returning `(None, "multiple_findings_blocks:N")`. The existing regex fallback + `reviewer_output_malformed` artifact flag fire automatically — noncompliance becomes visible instead of silent.

## Produced by
Factory job `eaa0a8c0` — **first organic fix-loop cycle in our session**. The full stack worked as intended:

- **Round 1** arch review (JSON parser from PR #34 correctly detected): 2 WARNINGs
  1. Rubric-echo false positive — if the reviewer echoes the severity rubric `- BLOCKING → …` after a multi-block rejection, the PR #32 regex fallback would miscount the echo as a real finding and thrash the fix-loop
  2. Silent suppression gap — `reviewer_output_malformed=True` was only a human-visible flag; no downstream consumer forced fix-loop, so a malformed output with zero prose-regex counts could still auto-promote
- **Fix loop fired** (PR #29 gate + PR #34 parser working in concert)
- **Round 2**: both reviews 0 BLOCKING + 0 WARNING, 2 hypothetical NITs each (bolded rubric bypass of `\s*→` lookahead; single-block diff-echo when reviewer omits own block — both behind existing prompt defenses, not currently exploitable)

This is the live validation of tasks #13-#18 in aggregate. The factory fixed its own WARNINGs without hand intervention, convergently.

## What shipped in the two commits

**`2a01a4c`** (round 1 — initial strict rejection):
- `_parse_findings_json` returns `(None, "multiple_findings_blocks:N")` when >1 blocks present
- Both reviewer prompts now say "Emit EXACTLY ONE ` ```json findings ``` ` block at the end of your review"
- Tests: replaced `test_multiple_json_blocks_last_wins` → `test_multiple_json_blocks_rejects_and_falls_back`; added `test_three_json_blocks_also_rejected`, `test_diff_echo_attack_does_not_suppress_findings` (with defense-in-depth prose-marker variant), `"EXACTLY ONE"` assertions in both prompt calibration tests

**`a78b7dc`** (fix round — close round 1 WARNINGs):
- Added `(?!\s*→)` negative lookahead to all 4 regex-fallback sites — rubric-echo lines like `- BLOCKING → …` are now skipped
- `_run_review` detects `multiple_findings_blocks:N` with zero counts on either reviewer and forces FIX_LOOP with `trigger_reason="reviewer_malformed"` + `reviewer_malformed=True` metadata — closes the auto-promote gap
- Added "do not echo the severity rubric in prose" guidance to both reviewer prompts
- 4 new tests: `test_rubric_echo_with_two_blocks_is_not_miscounted`, `test_real_dash_prefixed_findings_still_counted_by_fallback`, `test_multi_block_silent_suppression_routes_to_fix_loop`, `test_multi_block_with_prose_findings_still_uses_fallback_counts`

## Tests
Factory-run self-reports 41/41 orchestrator- and review-related tests passing. The 4 DB-backed tests in `test_warning_fix_loop.py` were collected cleanly but couldn't run in the factory worktree env (no Postgres in sandbox — pre-existing limitation). Local verification post-merge will catch any residual.

## Deferred NITs (not blocking)
- Bolded-rubric-echo (`**BLOCKING** → text`) — behind prompt defense telling reviewers not to echo; also the shipping prompt is unbolded. Widen lookahead to `\*{0,2}\s*→` if localization changes.
- Single-block diff-echo where reviewer omits own block — the silent-suppression guardrail only fires on multi-block. Behind explicit prompt defense. Follow-up would be a `json findings-<jobid>` distinguishing marker or extending the guardrail to other parse errors.

## Meta-milestone
This was the first factory job to run with PR #35's auto-pull active — Mac Studio fetched origin at the start, confirmed up-to-date, ran. And it's the first job where the whole fix-loop stack worked organically: JSON parser detected findings → gate fired → fix loop iterated → re-review converged clean. No hand-fix this round.

## Test plan
- [ ] Local: `pytest factory/tests/test_findings_parser.py test_warning_fix_loop.py test_review_prompt_calibration.py` — all pass
- [ ] Post-merge sanity: submit next factory job and verify the `factory.log` shows auto-pull at the start and no unexpected `multiple_findings_blocks` parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)