### PR TITLE
feat(install): auto-register default dev + INSTALL.md cross-refs (task #20)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,6 +94,24 @@ git --version
 psql --version
 ```
 
+### AI CLI authentication
+
+The factory shells out to whichever AI CLIs are on `$PATH`. Install one
+or more, then complete each tool's auth flow before running the wizard
+so the factory can spawn them without prompting:
+
+```bash
+claude login              # Anthropic Claude Code (OAuth)
+codex login               # OpenAI Codex (OAuth)
+gemini auth login         # Google Gemini CLI (OAuth)
+```
+
+API-key alternatives are also supported — drop `ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, or `GEMINI_API_KEY` into `.env` and the wizard will
+pick them up. At least one CLI is required for `factory_plan`; the
+wizard prompts for the rest. If you skip this step, the factory falls
+back to whichever credential set is wired up at first invocation.
+
 ---
 
 ## 2. Quick start (TL;DR)
@@ -484,6 +502,24 @@ Smoke-test the server by hand:
 # Exits immediately on EOF; confirms the binary is runnable.
 ```
 
+### 5.1 Optional: Agent Bus
+
+DevBrain integrates with **PKRelay**, a companion browser bus that lets
+agents see and interact with web pages over MCP. Skip if you only need
+local memory and the factory.
+
+```bash
+git clone https://github.com/nooma-stack/pkrelay.git ~/pkrelay
+(cd ~/pkrelay/mcp-server && npm install && npm run build && npm link)
+(cd ~/pkrelay/native-host && bash install.sh)
+```
+
+This installs a `pkrelay` binary on PATH, registers a Chrome
+native-messaging host, and exposes browser tools (page snapshots,
+clicks, form fills) to any MCP client. The DevBrain installer offers
+the same flow under "PKRelay (optional)" — opt out with
+`--no-pkrelay` if scripting an unattended install.
+
 ---
 
 ## 6. Platform notes
@@ -531,6 +567,26 @@ Each row maps a `devbrain doctor` failure to its fix.
 | `ingest_venv` | Skipped Step 7 | `cd ingest && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt` |
 | `config_file` | YAML parse error | Indentation — replace tabs with spaces, align keys |
 | `config_file` | File missing | `cp config/devbrain.yaml.example config/devbrain.yaml` |
+
+### Postgres password drift
+
+If `devbrain doctor` reports `postgres_reachable` failing with
+`password authentication failed` after the container ran fine
+previously, the Postgres role's password has drifted from the value in
+`.env` / `config/devbrain.yaml`. This typically happens after restoring
+from a different `.env`, switching branches that ship a different
+default credential, or running `docker compose down -v` partway.
+
+The dev-doctor variant resolves this interactively — it prompts for
+the live container password (or rotates it) and rewrites both
+`.env` and the YAML in one step:
+
+```bash
+./bin/devbrain devdoctor --fix
+```
+
+Re-run `./bin/devbrain doctor` afterwards; `postgres_reachable` should
+flip to PASS without any manual SQL.
 
 ### Common non-doctor issues
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -62,6 +62,17 @@ def register(dev_id, name, channels):
         click.echo(f"   • {c['type']}: {c['address']}")
 
 
+@cli.command(name="install-identity")
+@click.option(
+    "--dev-id", default=None,
+    help="Dev id to register (defaults to $USER). Skips silently if neither is set.",
+)
+def install_identity_cmd(dev_id):
+    """Non-interactive default dev registration. Called from install.sh."""
+    from setup import install_identity as _install_identity
+    _install_identity(dev_id=dev_id)
+
+
 @cli.command(name="add-channel")
 @click.option("--dev-id", default=None)
 @click.option("--channel", "channel_spec", required=True, help="TYPE:ADDRESS")

--- a/factory/setup.py
+++ b/factory/setup.py
@@ -552,6 +552,26 @@ def setup_identity() -> str:
     return dev_id
 
 
+def install_identity(dev_id: str | None = None) -> str | None:
+    """Non-interactive default dev registration. Called from install.sh.
+
+    Resolves dev_id from the argument or `$USER` and UPSERTs a row into
+    devbrain.devs with empty channels. Idempotent (register_dev is an
+    UPSERT). Returns the dev_id that was registered, or None if neither
+    argument nor $USER was set (silent skip — unattended container builds
+    must not fail here).
+    """
+    resolved = dev_id or os.environ.get("USER", "").strip()
+    if not resolved:
+        click.echo("install-identity: no --dev-id and $USER unset; skipping")
+        return None
+
+    db = FactoryDB(DATABASE_URL)
+    db.register_dev(dev_id=resolved, full_name=None, channels=[])
+    click.echo(f"install-identity: registered default dev '{resolved}'")
+    return resolved
+
+
 def setup_projects() -> None:
     _header("Projects")
     _desc(

--- a/factory/setup.py
+++ b/factory/setup.py
@@ -555,11 +555,12 @@ def setup_identity() -> str:
 def install_identity(dev_id: str | None = None) -> str | None:
     """Non-interactive default dev registration. Called from install.sh.
 
-    Resolves dev_id from the argument or `$USER` and UPSERTs a row into
-    devbrain.devs with empty channels. Idempotent (register_dev is an
-    UPSERT). Returns the dev_id that was registered, or None if neither
-    argument nor $USER was set (silent skip — unattended container builds
-    must not fail here).
+    Resolves dev_id from the argument or `$USER`. If no row exists for the
+    dev_id, INSERTs one with empty channels; if a row already exists, leaves
+    it alone so re-running install.sh does not clobber channels or event
+    subscriptions the user may have customized. Returns the resolved dev_id,
+    or None if neither argument nor $USER was set (silent skip — unattended
+    container builds must not fail here).
     """
     resolved = dev_id or os.environ.get("USER", "").strip()
     if not resolved:
@@ -567,8 +568,11 @@ def install_identity(dev_id: str | None = None) -> str | None:
         return None
 
     db = FactoryDB(DATABASE_URL)
-    db.register_dev(dev_id=resolved, full_name=None, channels=[])
-    click.echo(f"install-identity: registered default dev '{resolved}'")
+    if db.get_dev(resolved):
+        click.echo(f"install-identity: dev '{resolved}' already registered")
+    else:
+        db.register_dev(dev_id=resolved, full_name=None, channels=[])
+        click.echo(f"install-identity: registered default dev '{resolved}'")
     return resolved
 
 

--- a/factory/tests/test_install_identity.py
+++ b/factory/tests/test_install_identity.py
@@ -18,6 +18,7 @@ def test_install_identity_registers_with_explicit_id(monkeypatch):
         return "row-id"
 
     monkeypatch.setattr(FactoryDB, "register_dev", fake_register_dev)
+    monkeypatch.setattr(FactoryDB, "get_dev", lambda self, dev_id: None)
     monkeypatch.delenv("USER", raising=False)
 
     result = setup.install_identity(dev_id="test_install_identity_explicit")
@@ -39,6 +40,7 @@ def test_install_identity_falls_back_to_user_env(monkeypatch):
         return "row-id"
 
     monkeypatch.setattr(FactoryDB, "register_dev", fake_register_dev)
+    monkeypatch.setattr(FactoryDB, "get_dev", lambda self, dev_id: None)
     monkeypatch.setenv("USER", "test_install_identity_envuser")
 
     result = setup.install_identity(dev_id=None)
@@ -62,6 +64,37 @@ def test_install_identity_skips_when_no_id_and_no_user(monkeypatch):
 
     assert result is None
     assert called == []
+
+
+def test_install_identity_preserves_existing_row(monkeypatch):
+    """If a row already exists for dev_id, register_dev is NOT called.
+
+    This protects user-customized channels and event_subscriptions from
+    being overwritten on re-runs of install.sh.
+    """
+    register_calls = []
+
+    def fake_register_dev(self, *args, **kwargs):
+        register_calls.append((args, kwargs))
+        return "row-id"
+
+    existing = {
+        "id": "row-id",
+        "dev_id": "test_install_identity_existing",
+        "full_name": "Existing User",
+        "channels": [{"type": "slack", "target": "#alerts"}],
+        "event_subscriptions": ["job_blocked"],
+    }
+    monkeypatch.setattr(FactoryDB, "register_dev", fake_register_dev)
+    monkeypatch.setattr(
+        FactoryDB, "get_dev",
+        lambda self, dev_id: existing if dev_id == existing["dev_id"] else None,
+    )
+
+    result = setup.install_identity(dev_id="test_install_identity_existing")
+
+    assert result == "test_install_identity_existing"
+    assert register_calls == []
 
 
 # ─── Integration tests (real DB) ───────────────────────────────────────────

--- a/factory/tests/test_install_identity.py
+++ b/factory/tests/test_install_identity.py
@@ -1,0 +1,118 @@
+"""Tests for setup.install_identity — non-interactive default dev registration."""
+import pytest
+
+import setup
+from config import DATABASE_URL
+from state_machine import FactoryDB
+
+
+# ─── Mock-based tests (no DB) ──────────────────────────────────────────────
+
+def test_install_identity_registers_with_explicit_id(monkeypatch):
+    """Explicit dev_id is passed straight through to register_dev."""
+    calls = []
+
+    def fake_register_dev(self, dev_id, full_name=None, channels=None,
+                          event_subscriptions=None):
+        calls.append({"dev_id": dev_id, "full_name": full_name, "channels": channels})
+        return "row-id"
+
+    monkeypatch.setattr(FactoryDB, "register_dev", fake_register_dev)
+    monkeypatch.delenv("USER", raising=False)
+
+    result = setup.install_identity(dev_id="test_install_identity_explicit")
+
+    assert result == "test_install_identity_explicit"
+    assert len(calls) == 1
+    assert calls[0]["dev_id"] == "test_install_identity_explicit"
+    assert calls[0]["full_name"] is None
+    assert calls[0]["channels"] == []
+
+
+def test_install_identity_falls_back_to_user_env(monkeypatch):
+    """When dev_id is None, $USER is used."""
+    calls = []
+
+    def fake_register_dev(self, dev_id, full_name=None, channels=None,
+                          event_subscriptions=None):
+        calls.append(dev_id)
+        return "row-id"
+
+    monkeypatch.setattr(FactoryDB, "register_dev", fake_register_dev)
+    monkeypatch.setenv("USER", "test_install_identity_envuser")
+
+    result = setup.install_identity(dev_id=None)
+
+    assert result == "test_install_identity_envuser"
+    assert calls == ["test_install_identity_envuser"]
+
+
+def test_install_identity_skips_when_no_id_and_no_user(monkeypatch):
+    """No --dev-id and no $USER → return None, do not call register_dev."""
+    called = []
+
+    def fake_register_dev(self, *args, **kwargs):
+        called.append(True)
+        return "row-id"
+
+    monkeypatch.setattr(FactoryDB, "register_dev", fake_register_dev)
+    monkeypatch.delenv("USER", raising=False)
+
+    result = setup.install_identity(dev_id=None)
+
+    assert result is None
+    assert called == []
+
+
+# ─── Integration tests (real DB) ───────────────────────────────────────────
+#
+# `db` fixture connects + purges; mock tests above don't request it, so they
+# never hit Postgres.
+
+@pytest.fixture
+def db():
+    conn_db = FactoryDB(DATABASE_URL)
+
+    def _purge():
+        with conn_db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM devbrain.devs "
+                "WHERE dev_id LIKE 'test_install_identity_%%'"
+            )
+            conn.commit()
+
+    _purge()
+    yield conn_db
+    _purge()
+
+
+def test_install_identity_persists_row(db):
+    """End-to-end: row is written and readable via get_dev."""
+    dev_id = "test_install_identity_persist"
+    result = setup.install_identity(dev_id=dev_id)
+
+    assert result == dev_id
+    row = db.get_dev(dev_id)
+    assert row is not None
+    assert row["dev_id"] == dev_id
+    assert row["full_name"] is None
+    assert row["channels"] == []
+
+
+def test_install_identity_idempotent(db):
+    """Re-running with the same dev_id does not error or duplicate."""
+    dev_id = "test_install_identity_idem"
+
+    first = setup.install_identity(dev_id=dev_id)
+    second = setup.install_identity(dev_id=dev_id)
+
+    assert first == dev_id
+    assert second == dev_id
+
+    # Exactly one row exists for this dev_id.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM devbrain.devs WHERE dev_id = %s",
+            (dev_id,),
+        )
+        assert cur.fetchone()[0] == 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1319,8 +1319,8 @@ register_default_dev() {
     step "Default dev registration"
     desc "Insert a row in devbrain.devs for \$USER so the notification router"
     desc "can attribute jobs and stop logging 'Dev <name> not registered'"
-    desc "warnings. Idempotent UPSERT — safe to re-run. The setup wizard can"
-    desc "still enhance this row later with a full name and channels."
+    desc "warnings. Safe to re-run: an existing row is left untouched so any"
+    desc "channels or event subscriptions you've customized are preserved."
     if ! _run "Registering default dev (\$USER)" \
         "$DEVBRAIN_HOME/bin/devbrain" install-identity; then
         warn "install-identity failed — run './bin/devbrain register --dev-id \$USER' later"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1315,6 +1315,19 @@ apply_migrations() {
     fi
 }
 
+register_default_dev() {
+    step "Default dev registration"
+    desc "Insert a row in devbrain.devs for \$USER so the notification router"
+    desc "can attribute jobs and stop logging 'Dev <name> not registered'"
+    desc "warnings. Idempotent UPSERT — safe to re-run. The setup wizard can"
+    desc "still enhance this row later with a full name and channels."
+    if ! _run "Registering default dev (\$USER)" \
+        "$DEVBRAIN_HOME/bin/devbrain" install-identity; then
+        warn "install-identity failed — run './bin/devbrain register --dev-id \$USER' later"
+        return
+    fi
+}
+
 pull_models() {
     step "Ollama models"
     desc "DevBrain needs two local models:"
@@ -1779,6 +1792,7 @@ main() {
     setup_venvs
     start_postgres
     apply_migrations
+    register_default_dev
 
     # Phase 5: Heavy downloads + builds (~10-20 min unattended)
     install_ollama


### PR DESCRIPTION
## Summary
Bundle of small shareability rough edges. Closes the "Dev <USER> not registered" warning that fires every factory phase, plus three INSTALL.md gaps surfaced when auditing for share-readiness.

## Produced by
Factory job `27e4607c` — second consecutive job to converge through the fix-loop on a real round-1 WARNING. Two commits:

**`150159c`** (initial): non-interactive `install_identity()` helper in `factory/setup.py`, `install-identity` CLI subcommand, `register_default_dev()` step in `install.sh` (runs unconditionally between `apply_migrations` and `install_ollama`), three new INSTALL.md sections, 5 unit + integration tests.

**`fe6cc87`** (factory's fix for round 1 WARNING): the arch reviewer caught that `register_dev` is a hard UPSERT (not idempotent) — channels and event_subscriptions get hard-overwritten. So a user who configures Telegram channels via the wizard and later re-runs `install.sh` would have their channels wiped. Fix: `install_identity` calls `db.get_dev(resolved)` first and only INSERTs when no row exists. Preservation locked in via new test `test_install_identity_preserves_existing_row`.

Round 2 reviews: 0 BLOCKING / 0 WARNING. 1 deferred security NIT (INSTALL.md PKRelay section doesn't pin a commit / include a checksum — supply-chain hygiene).

## INSTALL.md additions
1. **§1 AI CLI authentication** — explicit `claude login` / `codex login` / `gemini auth login` prerequisites.
2. **§5.1 Optional: Agent Bus** — pointer to `nooma-stack/agent-bus`.
3. **§7 Postgres password drift** — `devbrain devdoctor --fix` recovery path.

## Tests
6/6 pass locally on MacBook.

## Notification side-effect
This PR is the predicate for fixing the "Dev <USER> not registered" warnings. Going forward, fresh installs auto-register `\$USER` and notifications should route. Existing installs need a one-shot `bin/devbrain install-identity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)