### PR TITLE
chore(factory): bump per-phase max_turns ceilings to 200 uniformly

### DIFF
--- a/config/devbrain.yaml.example
+++ b/config/devbrain.yaml.example
@@ -130,13 +130,18 @@ factory:
   #   review_*    — read-only audit (tight is fine)
   #   qa          — read-only status check
   #   fix         — between planning and implementing in scope
+  # Bumped to 200 uniformly on 2026-04-25 after observing factory jobs
+  # legitimately need more headroom for deep_search-driven planning,
+  # multi-file refactors, and fix-loop iteration. Wall-clock timeouts in
+  # cli_executor still cap runaway agents. Tighten if you want stricter
+  # cost controls on a specific phase.
   max_turns:
-    planning: 50
-    implementing: 150
-    review_arch: 60
-    review_security: 60
-    qa: 50
-    fix: 100
+    planning: 200
+    implementing: 200
+    review_arch: 200
+    review_security: 200
+    qa: 200
+    fix: 200
   cleanup:
     soft_timer_seconds: 600       # 10 min — triggers self-assessment
     extension_seconds: 300        # 5 min per extension

--- a/factory/config.py
+++ b/factory/config.py
@@ -153,17 +153,22 @@ FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY = bool(
     _FIX_LOOP_CONFIG.get("warnings_trigger_retry", True)
 )
 
-# Per-phase --max-turns ceiling for claude subprocesses. Tuned empirically:
-# implementing needs headroom for reads/edits/test iterations; planning and
-# reviews are tighter. These defaults fire only on yaml-less installs — see
-# config/devbrain.yaml.example for the documented knobs.
+# Per-phase --max-turns ceiling for claude subprocesses. Bumped to 200
+# uniformly on 2026-04-25 after factory job f4fdab6a (P2.a unified memory
+# table) failed at the 50-turn planning ceiling — the planner had spent
+# turns on legitimate deep_search lookups that the previous, tighter
+# limits couldn't accommodate. 200 across all phases gives every agent
+# enough headroom to finish a real-sized job without being blindsided
+# mid-thought; runaway protection is still in place via the wall-clock
+# timeout in cli_executor. These defaults fire only on yaml-less
+# installs — see config/devbrain.yaml.example for the documented knobs.
 _FACTORY_MAX_TURNS_DEFAULTS = {
-    "planning": 50,
-    "implementing": 150,
-    "review_arch": 60,
-    "review_security": 60,
-    "qa": 50,
-    "fix": 100,
+    "planning": 200,
+    "implementing": 200,
+    "review_arch": 200,
+    "review_security": 200,
+    "qa": 200,
+    "fix": 200,
 }
 _FACTORY_MAX_TURNS = FACTORY_CONFIG.get("max_turns") or {}
 


### PR DESCRIPTION
## Summary
Factory job `f4fdab6a` (P2.a unified memory table) failed at the 50-turn planning ceiling — the planner legitimately spent turns on `deep_search` lookups for prior architectural decisions. Previous limits were a holdover from earlier in the project when agents did less context-gathering.

## Change
All six phase ceilings bumped to 200 (planning, implementing, review_arch, review_security, qa, fix). Runaway protection remains via the wall-clock timeout in `cli_executor` (separate concern from turn count).

Updates both the Python defaults (`factory/config.py`, fire on yaml-less installs) and the example template (`config/devbrain.yaml.example`).

## Effect
Mac Studio's live `config/devbrain.yaml` has no `max_turns` block — so it picks up the new Python defaults at the next factory job start (PR #35 auto-pull will land this commit before the next run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)