### PR TITLE
feat(db): add devbrain.memory unified table — P2.a (task #22)

### DIFF
--- a/docs/MEMORY_MODEL.md
+++ b/docs/MEMORY_MODEL.md
@@ -1,0 +1,48 @@
+# DevBrain Memory Model
+
+> Phase 2 reference. Source of truth for the unified `devbrain.memory` table.
+
+## What this replaces
+
+`devbrain.memory` consolidates four legacy tables — `chunks`, `decisions`,
+`patterns`, `issues` — under a single schema. One table beats four because
+strength/lifecycle, embedding search, graph edges (Phase 5), and the
+discipline pipeline (Phase 3) all want to operate over a single substrate;
+maintaining four parallel surfaces with the same lifecycle hooks would
+duplicate every retrieval, decay, and promotion query.
+
+## The `kind` column — five values
+
+- `chunk` — searchable transcript segment from raw_sessions ingest
+- `decision` — architecture/design choice (replaces `devbrain.decisions`)
+- `pattern` — reusable approach (replaces `devbrain.patterns`)
+- `issue` — bug/lesson with root cause + prevention (replaces `devbrain.issues`)
+- `session_summary` — end_session summary captured by the MCP server
+
+Choose the kind that best describes the artifact at write time; the curator
+may reclassify in P3.
+
+## Lifecycle (Phase 6)
+
+`strength` follows the Enso-derived formula
+`strength = decay × retrievalBoost × emotionalMultiplier × usageFeedback`,
+half-life 7-60d. Thresholds: `< 0.1` → `archived_at = now()`; `0.1-0.3` →
+flagged for review; `> 0.7` → stable. The formula lives in the Phase 6
+memify worker (not in this PR — this PR only stores the `strength`,
+`hit_count`, `last_hit` columns at default values).
+
+## Discipline tiers (Phase 3 prep)
+
+- `memory` — default. Surfaces in `deep_search` results.
+- `lesson` — promoted by the curator agent based on observed effectiveness.
+  Gets injected into the curator brief.
+- `rule` — compliance-grade. Feeds the rule engine.
+
+Promotion path: `memory` → `lesson` → `rule` (demotion is allowed). All
+three tiers live in the same table; `tier` is the discipline marker.
+
+## Status
+
+This PR (P2.a) adds the table only. Adapters land in **P2.b**, historical
+data backfill in **P2.c**, legacy table drops in **P2.d**. Until then,
+`devbrain.memory` is empty and reads should still go to the legacy tables.

--- a/factory/tests/test_memory_table.py
+++ b/factory/tests/test_memory_table.py
@@ -1,0 +1,268 @@
+"""Schema verification tests for migrations/010_unified_memory.sql.
+
+Pure schema tests — no adapters or behavior under test. We INSERT
+through psycopg2 directly to verify defaults, constraints, FKs, and
+indexes are wired exactly as the migration declares.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import psycopg2
+import psycopg2.errors
+import pytest
+
+from config import DATABASE_URL
+from state_machine import FactoryDB
+
+# All test-created rows have content starting with this prefix so the
+# cleanup fixture can wipe them with one LIKE query (works even for
+# chunk-kind rows which have title=NULL).
+TEST_CONTENT_PREFIX = "memory_table_test_"
+
+
+@pytest.fixture
+def db():
+    return FactoryDB(DATABASE_URL)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM devbrain.memory WHERE content LIKE %s",
+            (f"{TEST_CONTENT_PREFIX}%",),
+        )
+        conn.commit()
+
+
+def _devbrain_project_id(db) -> str:
+    """The seeded 'devbrain' project (migration 001) — use as a real
+    FK target instead of creating a throwaway project per test."""
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute("SELECT id FROM devbrain.projects WHERE slug = 'devbrain'")
+        return cur.fetchone()[0]
+
+
+# ─── 1. Table exists ─────────────────────────────────────────────────────────
+
+
+def test_memory_table_exists(db):
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'devbrain' AND table_name = 'memory'"
+        )
+        assert cur.fetchone() is not None
+
+
+# ─── 2. Required columns w/ types & nullability ──────────────────────────────
+
+
+def test_memory_required_columns(db):
+    expected = {
+        "id":            ("uuid", "NO"),
+        "project_id":    ("uuid", "NO"),
+        "kind":          ("text", "NO"),
+        "title":         ("text", "YES"),
+        "content":       ("text", "NO"),
+        # `embedding` is a pgvector type — information_schema reports
+        # data_type='USER-DEFINED'; check udt_name='vector' separately.
+        "embedding":     ("USER-DEFINED", "YES"),
+        "strength":      ("numeric", "NO"),
+        "hit_count":     ("integer", "NO"),
+        "last_hit":      ("timestamp with time zone", "YES"),
+        "applies_when":  ("jsonb", "YES"),
+        "provenance_id": ("uuid", "YES"),
+        "tier":          ("text", "NO"),
+        "archived_at":   ("timestamp with time zone", "YES"),
+        "created_at":    ("timestamp with time zone", "NO"),
+        "updated_at":    ("timestamp with time zone", "NO"),
+    }
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name, data_type, is_nullable, udt_name "
+            "FROM information_schema.columns "
+            "WHERE table_schema = 'devbrain' AND table_name = 'memory'"
+        )
+        actual = {
+            name: (data_type, is_nullable, udt_name)
+            for name, data_type, is_nullable, udt_name in cur.fetchall()
+        }
+
+    missing = set(expected) - set(actual)
+    assert not missing, f"missing columns: {missing}"
+    for col, (data_type, nullable) in expected.items():
+        assert actual[col][0] == data_type, (
+            f"{col}: expected data_type={data_type!r}, got {actual[col][0]!r}"
+        )
+        assert actual[col][1] == nullable, (
+            f"{col}: expected nullable={nullable!r}, got {actual[col][1]!r}"
+        )
+    assert actual["embedding"][2] == "vector", (
+        f"embedding udt_name should be 'vector', got {actual['embedding'][2]!r}"
+    )
+
+
+# ─── 3. CHECK constraint on kind ─────────────────────────────────────────────
+
+
+def test_memory_kind_check_constraint(db):
+    pid = _devbrain_project_id(db)
+
+    # Bad kind raises CheckViolation.
+    with pytest.raises(psycopg2.errors.CheckViolation):
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.memory (project_id, kind, content) "
+                "VALUES (%s, %s, %s)",
+                (pid, "not_real", f"{TEST_CONTENT_PREFIX}bad_kind"),
+            )
+            conn.commit()
+
+    # All 5 valid kinds insert.
+    for kind in ("chunk", "decision", "pattern", "issue", "session_summary"):
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.memory (project_id, kind, content) "
+                "VALUES (%s, %s, %s)",
+                (pid, kind, f"{TEST_CONTENT_PREFIX}kind_{kind}"),
+            )
+            conn.commit()
+
+
+# ─── 4. CHECK constraint on tier ─────────────────────────────────────────────
+
+
+def test_memory_tier_check_constraint(db):
+    pid = _devbrain_project_id(db)
+
+    with pytest.raises(psycopg2.errors.CheckViolation):
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.memory "
+                "(project_id, kind, content, tier) VALUES (%s, %s, %s, %s)",
+                (pid, "decision", f"{TEST_CONTENT_PREFIX}bad_tier", "admin"),
+            )
+            conn.commit()
+
+    for tier in ("memory", "lesson", "rule"):
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.memory "
+                "(project_id, kind, content, tier) VALUES (%s, %s, %s, %s)",
+                (pid, "decision", f"{TEST_CONTENT_PREFIX}tier_{tier}", tier),
+            )
+            conn.commit()
+
+
+# ─── 5. project_id FK enforced ───────────────────────────────────────────────
+
+
+def test_memory_project_fk_enforced(db):
+    bogus = "00000000-0000-0000-0000-000000000000"
+    with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.memory (project_id, kind, content) "
+                "VALUES (%s, %s, %s)",
+                (bogus, "decision", f"{TEST_CONTENT_PREFIX}bad_fk"),
+            )
+            conn.commit()
+
+
+# ─── 6. Defaults populate as declared ────────────────────────────────────────
+
+
+def test_memory_defaults(db):
+    pid = _devbrain_project_id(db)
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory (project_id, kind, content) "
+            "VALUES (%s, %s, %s) RETURNING strength, hit_count, tier, "
+            "archived_at, created_at, updated_at",
+            (pid, "decision", f"{TEST_CONTENT_PREFIX}defaults"),
+        )
+        strength, hit_count, tier, archived_at, created_at, updated_at = (
+            cur.fetchone()
+        )
+        conn.commit()
+
+    assert strength == Decimal("1.0")
+    assert hit_count == 0
+    assert tier == "memory"
+    assert archived_at is None
+    assert created_at is not None
+    assert updated_at is not None
+
+
+# ─── 7. embedding dimension enforced ─────────────────────────────────────────
+
+
+def test_memory_embedding_dim(db):
+    pid = _devbrain_project_id(db)
+    good = "[" + ",".join(["0.0"] * 1024) + "]"
+    bad = "[" + ",".join(["0.0"] * 512) + "]"
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, content, embedding) "
+            "VALUES (%s, %s, %s, %s::vector)",
+            (pid, "chunk", f"{TEST_CONTENT_PREFIX}emb_good", good),
+        )
+        conn.commit()
+
+    # pgvector raises a DataException on dimension mismatch; catch the
+    # broad psycopg2.Error to avoid coupling to the precise subclass.
+    with pytest.raises(psycopg2.Error):
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.memory "
+                "(project_id, kind, content, embedding) "
+                "VALUES (%s, %s, %s, %s::vector)",
+                (pid, "chunk", f"{TEST_CONTENT_PREFIX}emb_bad", bad),
+            )
+            conn.commit()
+
+
+# ─── 8. All 5 expected indexes present ───────────────────────────────────────
+
+
+def test_memory_indexes_exist(db):
+    expected = {
+        "idx_memory_project_kind",
+        "idx_memory_embedding",
+        "idx_memory_strength",
+        "idx_memory_applies_when",
+        "idx_memory_provenance",
+    }
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE schemaname = 'devbrain' AND tablename = 'memory'"
+        )
+        present = {r[0] for r in cur.fetchall()}
+    missing = expected - present
+    assert not missing, f"missing indexes: {missing}"
+
+
+# ─── 9. Migration recorded in schema_migrations ──────────────────────────────
+
+
+def test_010_recorded_in_schema_migrations(db):
+    """Integration check: by the time tests run, `bin/devbrain migrate`
+    (or the same code path called from setup) has applied 010 and the
+    runner has recorded the row. If 010 ran but wasn't recorded the
+    runner would re-apply it on every install — surface that bug here."""
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM devbrain.schema_migrations "
+            "WHERE filename = '010_unified_memory.sql'"
+        )
+        assert cur.fetchone() is not None, (
+            "010_unified_memory.sql is not recorded in "
+            "devbrain.schema_migrations — check that the runner ran "
+            "and that the filename is exact"
+        )

--- a/migrations/010_unified_memory.sql
+++ b/migrations/010_unified_memory.sql
@@ -1,0 +1,55 @@
+-- Migration 010: devbrain.memory unified memory table.
+-- ============================================================================
+--
+-- PURE ADDITIVE — chunks/decisions/patterns/issues are unchanged. P2.b will
+-- dual-write into devbrain.memory alongside the legacy tables, P2.c will
+-- backfill historical rows, and P2.d will drop the legacy tables once
+-- readers have switched over.
+--
+-- Until P2.b ships this table is empty and no production code path reads
+-- from it. Schema verification only — no data migration here.
+--
+-- Idempotent (CREATE … IF NOT EXISTS), matching the convention 004-007
+-- established for migrations layered on top of the schema_migrations
+-- runner: re-running on a DB that already has the table is a no-op.
+--
+-- Usage:
+--   docker exec -i devbrain-db psql -U devbrain -d devbrain < migrations/010_unified_memory.sql
+
+CREATE TABLE IF NOT EXISTS devbrain.memory (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    project_id      UUID NOT NULL REFERENCES devbrain.projects(id),
+    kind            TEXT NOT NULL CHECK (kind IN ('chunk', 'decision', 'pattern', 'issue', 'session_summary')),
+    title           TEXT,
+    content         TEXT NOT NULL,
+    embedding       vector(1024),
+    strength        NUMERIC NOT NULL DEFAULT 1.0,
+    hit_count       INTEGER NOT NULL DEFAULT 0,
+    last_hit        TIMESTAMPTZ,
+    applies_when    JSONB,
+    -- Loose pointer to the originating row (raw_sessions, factory_jobs, …);
+    -- intentionally no FK because the source spans multiple tables.
+    provenance_id   UUID,
+    tier            TEXT NOT NULL DEFAULT 'memory' CHECK (tier IN ('memory', 'lesson', 'rule')),
+    archived_at     TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_project_kind ON devbrain.memory (project_id, kind)
+    WHERE archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_memory_embedding ON devbrain.memory
+    USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+
+CREATE INDEX IF NOT EXISTS idx_memory_strength ON devbrain.memory (strength DESC)
+    WHERE archived_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_memory_applies_when ON devbrain.memory
+    USING GIN (applies_when);
+
+CREATE INDEX IF NOT EXISTS idx_memory_provenance ON devbrain.memory (provenance_id)
+    WHERE provenance_id IS NOT NULL;
+
+COMMENT ON TABLE devbrain.memory IS
+    'Phase 2 unified memory store. Consolidates chunks/decisions/patterns/issues. Adapters land in P2.b; backfill in P2.c.';


### PR DESCRIPTION
## Summary
**Phase 2 launches.** Adds `devbrain.memory`, the unified table that consolidates the legacy `chunks` / `decisions` / `patterns` / `issues` tables under one schema with strength + lifecycle metadata. Pure additive — no adapter changes, no data migration. P2.b (adapter dual-write) and P2.c (backfill) follow in separate PRs.

## Produced by
Factory job `fbd78b22` — single clean pass, 0 BLOCKING / 0 WARNING on both reviews. Followed PR #41's per-phase 200-turn bump (the previous attempt `f4fdab6a` had failed at the old 50-turn planning ceiling).

The implementer caught and fixed a real bug in my spec along the way: I said "no `IF NOT EXISTS`" to match migration 001, but 003-009 actually use `IF NOT EXISTS`, and following the spec literally broke the post-#37 bootstrap path (`test_migrate_end_to_end_when_tracking_table_missing`). Implementer switched to `IF NOT EXISTS` and stored the issue (`9f20ec0b`) in DevBrain.

## Schema highlights
- `kind TEXT CHECK IN ('chunk', 'decision', 'pattern', 'issue', 'session_summary')` — type discrimination replacing four legacy tables
- `strength NUMERIC` + `hit_count` + `last_hit` — feeds Phase 6 memify lifecycle (Enso-derived formula documented in `docs/MEMORY_MODEL.md`)
- `applies_when JSONB` — Phase 3 prep for the curator agent's context matching
- `tier TEXT CHECK IN ('memory', 'lesson', 'rule')` — Phase 3 prep for the discipline-pipeline promotion path
- `provenance_id` (FK-less, documented) — back-reference to source artifacts
- 5 indexes including ivfflat on `embedding` (1024-dim, matches existing `chunks` convention)

## Tests
9 schema verification tests in `factory/tests/test_memory_table.py`, all pass locally on MacBook (after `bin/devbrain migrate` applied 010 — automatic via PR #37 runner). Existing chunks/decisions/patterns/issues UNTOUCHED.

## Deferred NITs from security review (all post-Phase-6 concerns)
- `strength` could have a `0..1` CHECK constraint (will add when writers exist in Phase 6)
- `provenance_id` FK-less (intentional, documented)
- `uuid_generate_v4()` vs `gen_random_uuid()` (cosmetic — both extensions available)

## Notification verification side-effect
This was the first job to organically fire a `job_ready` notification (PR #39's emit) and have it routed correctly to `lhtdev`'s subscription. Two rows recorded in `devbrain.notifications` (one duplicate emit — separate small bug to track, see follow-up). Tmux delivery itself failed because (a) my earlier `--channel 'tmux:'` command registered an empty `address`, and (b) `tmux` isn't on Mac Studio's SSH PATH. So routing is verified end-to-end; the channel layer is the remaining surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)