### PR TITLE
feat(memory): adapter dual-write to devbrain.memory — P2.b (task #23)

### DIFF
--- a/factory/learning.py
+++ b/factory/learning.py
@@ -20,7 +20,11 @@ logger = logging.getLogger(__name__)
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+# ingest/ is a sibling of factory/ — extend sys.path so memory_writer
+# (the canonical Python dual-write helper for P2.b) is importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "ingest"))
 from config import DATABASE_URL, SUMMARIZE_MODEL, load_config  # noqa: E402
+from memory_writer import record_memory  # noqa: E402
 
 _config = load_config()
 OLLAMA_URL = _config.get("embedding", {}).get("url", _config["summarization"]["url"])
@@ -221,6 +225,7 @@ def _store_lessons(
         # Store as pattern + chunk
         vector_str = f"[{','.join(str(x) for x in embedding)}]"
 
+        description = f"{text}\n\nContext: {context}"
         with conn.cursor() as cur:
             cur.execute(
                 """INSERT INTO devbrain.patterns
@@ -231,11 +236,26 @@ def _store_lessons(
                     project_id,
                     text[:100],
                     "factory_review",
-                    f"{text}\n\nContext: {context}",
+                    description,
                     json.dumps([category, "factory_learning"]),
                 ),
             )
             pattern_id = str(cur.fetchone()[0])
+
+            # P2.b dual-write: pattern row → devbrain.memory. We dual-write
+            # the pattern (not the auxiliary chunk insert below) so each
+            # logical lesson lands as exactly one memory row. SAVEPOINT
+            # inside record_memory keeps a memory failure from rolling
+            # back the pattern + chunk legacy commit.
+            record_memory(
+                cur,
+                project_id=project_id,
+                kind="pattern",
+                content=description,
+                title=text[:100],
+                embedding_sql=vector_str,
+                provenance_id=pattern_id,
+            )
 
             cur.execute(
                 """INSERT INTO devbrain.chunks
@@ -244,7 +264,7 @@ def _store_lessons(
                 (
                     project_id,
                     pattern_id,
-                    f"{text}\n\nContext: {context}",
+                    description,
                     vector_str,
                     json.dumps({
                         "category": category,

--- a/factory/tests/test_dual_write.py
+++ b/factory/tests/test_dual_write.py
@@ -1,0 +1,423 @@
+"""Tests for P2.b adapter dual-write into devbrain.memory.
+
+Covers all five `kind` values (chunk/decision/pattern/issue/
+session_summary), the partial unique-index idempotency from migration
+011, and the load-bearing contract that a failed memory dual-write
+must not roll back the surrounding legacy commit (psycopg2 savepoint
+discipline in ingest/memory_writer.py).
+
+The Python helper `record_memory` is shared by all call sites and is
+the unit under direct test for kinds 2-5; the chunk-kind test goes
+through `ingest.db.insert_chunk` to exercise the actual call site.
+The mcp-server TypeScript adapter calls a structurally identical
+`recordMemory` helper — the partial unique index, embedding reuse,
+and best-effort semantics validated here are the same contract those
+paths rely on.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+# Mirror the production sys.path layout: factory/ for config, ingest/
+# for memory_writer + insert_chunk.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent.parent / "ingest")
+)
+
+from config import DATABASE_URL  # noqa: E402  (factory/config.py)
+from db import insert_chunk  # noqa: E402  (ingest/db.py)
+from memory_writer import record_memory  # noqa: E402  (ingest/memory_writer.py)
+from state_machine import FactoryDB  # noqa: E402
+
+# All test rows have content starting with this prefix so the autouse
+# cleanup fixture can wipe them with one LIKE query (works even for
+# chunk-kind memory rows whose title is NULL).
+TEST_CONTENT_PREFIX = "dual_write_test_"
+
+
+@pytest.fixture
+def db():
+    return FactoryDB(DATABASE_URL)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM devbrain.memory WHERE content LIKE %s",
+            (f"{TEST_CONTENT_PREFIX}%",),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.chunks WHERE content LIKE %s",
+            (f"{TEST_CONTENT_PREFIX}%",),
+        )
+        # legacy decisions: title and context are both prefixed in
+        # test_legacy_survives_memory_failure
+        cur.execute(
+            "DELETE FROM devbrain.decisions "
+            "WHERE title LIKE %s OR context LIKE %s",
+            (f"{TEST_CONTENT_PREFIX}%", f"{TEST_CONTENT_PREFIX}%"),
+        )
+        conn.commit()
+
+
+def _devbrain_project_id(db) -> str:
+    """The seeded 'devbrain' project (migration 001) — used as a real
+    FK target instead of creating a throwaway project per test."""
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.projects WHERE slug = 'devbrain'"
+        )
+        return cur.fetchone()[0]
+
+
+def _embedding_sql(value: float = 0.0) -> str:
+    return "[" + ",".join([str(value)] * 1024) + "]"
+
+
+# ─── 1. Migration 011 applied + index present ────────────────────────────
+
+
+def test_migration_011_applied(db):
+    """If 011 hasn't run, the inferred-constraint ON CONFLICT clause
+    in record_memory will error (Postgres can't match a partial unique
+    index without one). Surface that as a clear failure here."""
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM devbrain.schema_migrations "
+            "WHERE filename = %s",
+            ("011_memory_provenance_unique.sql",),
+        )
+        assert cur.fetchone() is not None, (
+            "011_memory_provenance_unique.sql is not recorded in "
+            "schema_migrations — run `bin/devbrain migrate`"
+        )
+        cur.execute(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE schemaname = 'devbrain' AND tablename = 'memory' "
+            "AND indexname = 'idx_memory_provenance_kind_unique'"
+        )
+        row = cur.fetchone()
+        assert row is not None, "partial unique index missing"
+        idxdef = row[0]
+        # Index must be UNIQUE on (provenance_id, kind) WITH the
+        # provenance_id IS NOT NULL predicate — both halves are
+        # required for the inferred-constraint match.
+        assert "UNIQUE" in idxdef.upper()
+        assert "provenance_id" in idxdef
+        assert "kind" in idxdef
+        assert "provenance_id IS NOT NULL" in idxdef
+
+
+# ─── 2-6. Dual-write produces a memory row for each kind ─────────────────
+
+
+def test_dual_write_decision(db):
+    """kind='decision' dual-write: one memory row, embedding+title+
+    content+provenance match, tier defaults to 'memory'."""
+    pid = _devbrain_project_id(db)
+    prov = "11111111-1111-1111-1111-111111111111"
+    content = f"{TEST_CONTENT_PREFIX}decision body"
+    embedding_sql = _embedding_sql(0.1)
+
+    with db._conn() as conn, conn.cursor() as cur:
+        record_memory(
+            cur,
+            project_id=pid,
+            kind="decision",
+            content=content,
+            title=f"{TEST_CONTENT_PREFIX}decision title",
+            embedding_sql=embedding_sql,
+            provenance_id=prov,
+        )
+        conn.commit()
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT project_id, kind, title, content, "
+            "       provenance_id, tier, embedding IS NOT NULL "
+            "FROM devbrain.memory WHERE content = %s",
+            (content,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    project_id, kind, title, content_db, prov_db, tier, has_emb = rows[0]
+    assert str(project_id) == str(pid)
+    assert kind == "decision"
+    assert title == f"{TEST_CONTENT_PREFIX}decision title"
+    assert content_db == content
+    assert str(prov_db) == prov
+    assert tier == "memory"
+    assert has_emb is True
+
+
+def test_dual_write_pattern(db):
+    """kind='pattern' dual-write — exercises the factory.learning
+    call-site shape (provenance_id is the patterns row UUID)."""
+    pid = _devbrain_project_id(db)
+    prov = "22222222-2222-2222-2222-222222222222"
+    content = f"{TEST_CONTENT_PREFIX}pattern body"
+
+    with db._conn() as conn, conn.cursor() as cur:
+        record_memory(
+            cur,
+            project_id=pid,
+            kind="pattern",
+            content=content,
+            title=f"{TEST_CONTENT_PREFIX}pattern_name",
+            embedding_sql=_embedding_sql(0.2),
+            provenance_id=prov,
+        )
+        conn.commit()
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT kind, content, provenance_id "
+            "FROM devbrain.memory WHERE content = %s",
+            (content,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "pattern"
+    assert rows[0][1] == content
+    assert str(rows[0][2]) == prov
+
+
+def test_dual_write_issue(db):
+    """kind='issue' dual-write — exercises the MCP store call-site
+    shape for issue records."""
+    pid = _devbrain_project_id(db)
+    prov = "33333333-3333-3333-3333-333333333333"
+    content = f"{TEST_CONTENT_PREFIX}issue body"
+
+    with db._conn() as conn, conn.cursor() as cur:
+        record_memory(
+            cur,
+            project_id=pid,
+            kind="issue",
+            content=content,
+            title=f"{TEST_CONTENT_PREFIX}issue title",
+            embedding_sql=_embedding_sql(0.3),
+            provenance_id=prov,
+        )
+        conn.commit()
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT kind, provenance_id FROM devbrain.memory "
+            "WHERE content = %s",
+            (content,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "issue"
+    assert str(rows[0][1]) == prov
+
+
+def test_dual_write_session_summary(db):
+    """kind='session_summary' — the MCP end_session anchor uses the
+    chunks row id as provenance (no raw_sessions write in that
+    path); test the same shape."""
+    pid = _devbrain_project_id(db)
+    prov = "44444444-4444-4444-4444-444444444444"
+    content = f"{TEST_CONTENT_PREFIX}session_summary body"
+
+    with db._conn() as conn, conn.cursor() as cur:
+        record_memory(
+            cur,
+            project_id=pid,
+            kind="session_summary",
+            content=content,
+            embedding_sql=_embedding_sql(0.4),
+            provenance_id=prov,
+        )
+        conn.commit()
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT kind, title, provenance_id FROM devbrain.memory "
+            "WHERE content = %s",
+            (content,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "session_summary"
+    assert rows[0][1] is None  # session_summary has no separate title
+    assert str(rows[0][2]) == prov
+
+
+def test_dual_write_chunk_via_insert_chunk(db):
+    """kind='chunk' goes through ingest.db.insert_chunk — the actual
+    call site (not record_memory directly). Verifies the dual-write
+    is wired in there AND that the project_id-None guard skips the
+    memory write but keeps the legacy chunk insert."""
+    pid = _devbrain_project_id(db)
+    content = f"{TEST_CONTENT_PREFIX}chunk via insert_chunk"
+    embedding = [0.5] * 1024
+
+    chunk_id = insert_chunk(
+        project_id=pid,
+        source_type="session",
+        source_id=None,
+        source_line_start=None,
+        source_line_end=None,
+        content=content,
+        embedding=embedding,
+        token_count=10,
+    )
+    assert chunk_id  # legacy row exists
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT kind, content, provenance_id, embedding IS NOT NULL "
+            "FROM devbrain.memory WHERE provenance_id = %s",
+            (chunk_id,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1, (
+        "exactly one memory row expected for the chunk dual-write"
+    )
+    assert rows[0][0] == "chunk"
+    assert rows[0][1] == content
+    assert str(rows[0][2]) == chunk_id
+    assert rows[0][3] is True  # embedding reused, not recomputed null
+
+    # Guard branch: project_id=None must skip the memory write but
+    # still produce a legacy chunk row.
+    null_content = f"{TEST_CONTENT_PREFIX}chunk no project"
+    null_chunk_id = insert_chunk(
+        project_id=None,
+        source_type="session",
+        source_id=None,
+        source_line_start=None,
+        source_line_end=None,
+        content=null_content,
+        embedding=embedding,
+        token_count=10,
+    )
+    assert null_chunk_id  # legacy row still inserted
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM devbrain.memory WHERE provenance_id = %s",
+            (null_chunk_id,),
+        )
+        assert cur.fetchone() is None, (
+            "memory.project_id is NOT NULL; the helper must skip dual-"
+            "write when project_id is None instead of erroring"
+        )
+
+
+# ─── 7. Idempotency: two dual-writes for the same legacy row → one mem row
+
+
+def test_idempotency_two_calls_one_row(db):
+    """The partial unique index turns retry storms into no-ops.
+    First write wins (DO NOTHING); second write's payload is silently
+    discarded."""
+    pid = _devbrain_project_id(db)
+    prov = "55555555-5555-5555-5555-555555555555"
+    first = f"{TEST_CONTENT_PREFIX}idempotent first"
+    second = f"{TEST_CONTENT_PREFIX}idempotent second"
+
+    with db._conn() as conn, conn.cursor() as cur:
+        record_memory(
+            cur,
+            project_id=pid,
+            kind="decision",
+            content=first,
+            embedding_sql=_embedding_sql(0.6),
+            provenance_id=prov,
+        )
+        record_memory(
+            cur,
+            project_id=pid,
+            kind="decision",
+            content=second,
+            embedding_sql=_embedding_sql(0.7),
+            provenance_id=prov,
+        )
+        conn.commit()
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT content FROM devbrain.memory "
+            "WHERE provenance_id = %s AND kind = 'decision'",
+            (prov,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1, (
+        f"expected exactly one row after dedup; got {len(rows)}"
+    )
+    assert rows[0][0] == first  # first write wins under DO NOTHING
+
+
+# ─── 8. Memory failure does NOT roll back the legacy commit ──────────────
+
+
+def test_legacy_survives_memory_failure(db, caplog):
+    """The savepoint discipline in record_memory is the contract that
+    keeps "legacy is source of truth" honest. Force a memory failure
+    (CHECK violation on kind) and verify:
+        - legacy decision row commits;
+        - no orphan memory row;
+        - WARNING log captured so operators can see the drop.
+    Without the savepoint, psycopg2 would put the transaction in
+    InFailedSqlTransaction and the surrounding conn.commit() would
+    silently roll back the legacy decision."""
+    pid = _devbrain_project_id(db)
+    legacy_title = f"{TEST_CONTENT_PREFIX}legacy_title"
+    legacy_content = f"{TEST_CONTENT_PREFIX}legacy_content"
+
+    with caplog.at_level(logging.WARNING, logger="memory_writer"):
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.decisions "
+                "(project_id, title, context, decision) "
+                "VALUES (%s, %s, %s, %s) RETURNING id",
+                (pid, legacy_title, legacy_content, legacy_content),
+            )
+            decision_id = str(cur.fetchone()[0])
+
+            # CHECK constraint forbids kind='not_a_real_kind' — the
+            # INSERT inside record_memory raises, the SAVEPOINT
+            # rolls back, the cursor is healthy again.
+            record_memory(
+                cur,
+                project_id=pid,
+                kind="not_a_real_kind",
+                content=legacy_content,
+                provenance_id=decision_id,
+            )
+
+            # The crucial assertion: this commit MUST succeed despite
+            # the failed dual-write above.
+            conn.commit()
+
+    # Legacy row persisted.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM devbrain.decisions WHERE id = %s",
+            (decision_id,),
+        )
+        assert cur.fetchone() is not None, (
+            "legacy decision row was rolled back — memory failure "
+            "must not poison the legacy commit"
+        )
+        # No memory row for this provenance.
+        cur.execute(
+            "SELECT 1 FROM devbrain.memory WHERE provenance_id = %s",
+            (decision_id,),
+        )
+        assert cur.fetchone() is None
+
+    # WARNING captured.
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any(
+        "dual-write failed" in r.getMessage() for r in warnings
+    ), f"expected dual-write WARNING; got: {[r.getMessage() for r in warnings]}"

--- a/ingest/db.py
+++ b/ingest/db.py
@@ -6,6 +6,7 @@ import psycopg2
 import psycopg2.extras
 
 from config import DATABASE_URL
+from memory_writer import record_memory
 
 psycopg2.extras.register_uuid()
 
@@ -139,8 +140,22 @@ def insert_chunk(
             ),
         )
         row = cur.fetchone()
+        chunk_id = str(row[0]) if row else ""
+        # P2.b dual-write: skip when project_id is None (chunks.project_id
+        # is nullable but devbrain.memory.project_id is NOT NULL). The
+        # SAVEPOINT inside record_memory keeps a memory failure from
+        # poisoning this transaction's commit of the legacy chunk row.
+        if chunk_id and project_id is not None:
+            record_memory(
+                cur,
+                project_id=project_id,
+                kind="chunk",
+                content=content,
+                embedding_sql=vector_str,
+                provenance_id=chunk_id,
+            )
         conn.commit()
-        return str(row[0]) if row else ""
+        return chunk_id
 
 
 def delete_chunks_for_session(session_id: str) -> int:

--- a/ingest/memory_writer.py
+++ b/ingest/memory_writer.py
@@ -1,0 +1,83 @@
+"""Adapter helper for dual-writing into devbrain.memory (P2.b).
+
+Reads still go to the legacy tables (chunks/decisions/patterns/issues).
+Writes go to BOTH the legacy table and devbrain.memory; the unified
+table is best-effort — a memory failure must NOT poison the surrounding
+transaction or roll back the legacy write that is the current source
+of truth.
+
+Idempotency: relies on the partial unique index from migration 011
+(idx_memory_provenance_kind_unique on (provenance_id, kind) WHERE
+provenance_id IS NOT NULL) so two concurrent dual-writes for the same
+legacy row collapse to one memory row via ON CONFLICT DO NOTHING.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_SAVEPOINT_NAME = "memory_write_sp"
+
+
+def record_memory(
+    cur,
+    *,
+    project_id: str,
+    kind: str,
+    content: str,
+    title: str | None = None,
+    embedding_sql: str | None = None,
+    provenance_id: str | None = None,
+) -> None:
+    """Insert a row into devbrain.memory inside the caller's transaction.
+
+    The caller owns the connection / transaction. We wrap the INSERT in
+    a SAVEPOINT/ROLLBACK TO SAVEPOINT so that a failure here (e.g. a
+    new CHECK violation, FK miss, or pgvector dimension error) leaves
+    the caller's transaction healthy: their subsequent legacy commit
+    will succeed.
+
+    Without the savepoint, psycopg2 puts the connection into
+    InFailedSqlTransaction on any error and the caller's
+    `conn.commit()` silently rolls back the legacy INSERT too — which
+    breaks the spec contract that "legacy is the source of truth, the
+    memory dual-write is best-effort."
+
+    Args:
+        cur: an open psycopg2 cursor on the caller's transaction.
+        project_id: required (memory.project_id is NOT NULL — the legacy
+            tables allow nulls; callers must skip the dual-write when the
+            legacy row has no project).
+        kind: one of 'chunk', 'decision', 'pattern', 'issue',
+            'session_summary' (CHECK enforced at the DB).
+        content: required text (memory.content is NOT NULL).
+        title: optional human-friendly title.
+        embedding_sql: optional pgvector literal already formatted as
+            '[v1,v2,…]' — caller passes the existing legacy embedding
+            verbatim. We never recompute embeddings; the legacy row
+            already paid that cost.
+        provenance_id: legacy row's UUID. If None, no dedup is enforced
+            (the partial unique index has WHERE provenance_id IS NOT
+            NULL so two NULL-prov rows can both insert).
+    """
+    cur.execute(f"SAVEPOINT {_SAVEPOINT_NAME}")
+    try:
+        cur.execute(
+            """
+            INSERT INTO devbrain.memory
+                (project_id, kind, title, content, embedding, provenance_id)
+            VALUES (%s, %s, %s, %s, %s::vector, %s)
+            ON CONFLICT (provenance_id, kind) WHERE provenance_id IS NOT NULL
+            DO NOTHING
+            """,
+            (project_id, kind, title, content, embedding_sql, provenance_id),
+        )
+        cur.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
+    except Exception as exc:
+        cur.execute(f"ROLLBACK TO SAVEPOINT {_SAVEPOINT_NAME}")
+        cur.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
+        logger.warning(
+            "devbrain.memory dual-write failed (kind=%s, provenance_id=%s): %s",
+            kind, provenance_id, exc,
+        )

--- a/ingest/memory_writer.py
+++ b/ingest/memory_writer.py
@@ -61,8 +61,12 @@ def record_memory(
             (the partial unique index has WHERE provenance_id IS NOT
             NULL so two NULL-prov rows can both insert).
     """
-    cur.execute(f"SAVEPOINT {_SAVEPOINT_NAME}")
+    # SAVEPOINT itself is inside the try: if the caller's transaction is
+    # already InFailedSqlTransaction, even SAVEPOINT raises — and the
+    # docstring's best-effort guarantee must hold regardless of caller-
+    # side transaction state.
     try:
+        cur.execute(f"SAVEPOINT {_SAVEPOINT_NAME}")
         cur.execute(
             """
             INSERT INTO devbrain.memory
@@ -75,8 +79,13 @@ def record_memory(
         )
         cur.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
     except Exception as exc:
-        cur.execute(f"ROLLBACK TO SAVEPOINT {_SAVEPOINT_NAME}")
-        cur.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
+        try:
+            cur.execute(f"ROLLBACK TO SAVEPOINT {_SAVEPOINT_NAME}")
+            cur.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
+        except Exception:
+            # SAVEPOINT was never established (or already gone) — nothing
+            # to roll back. Swallow so the helper stays best-effort.
+            pass
         logger.warning(
             "devbrain.memory dual-write failed (kind=%s, provenance_id=%s): %s",
             kind, provenance_id, exc,

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -9,6 +9,7 @@ import { join, resolve } from 'path'
 import { z } from 'zod'
 import { query } from './db.js'
 import { embed, toSqlVector } from './embeddings.js'
+import { recordMemory } from './memory.js'
 import { summarizeSession } from './summarize.js'
 
 // Factory orchestrator runner path
@@ -323,7 +324,9 @@ server.tool(
       )
       recordId = result.rows[0].id
     } else {
-      // Generic note stored as a chunk
+      // Generic note stored as a chunk. P2.b does NOT dual-write notes:
+      // 'note' isn't in the devbrain.memory.kind CHECK constraint, and
+      // notes already land in chunks where P2.c backfill will pick them up.
       const result = await query<{ id: string }>(
         `INSERT INTO devbrain.chunks (project_id, source_type, content, embedding, metadata)
          VALUES ($1, 'note', $2, $3::vector, $4) RETURNING id`,
@@ -333,7 +336,24 @@ server.tool(
       return { content: [{ type: 'text', text: `Stored note "${title}" (${recordId.slice(0, 8)}).` }] }
     }
 
-    // Also create an embedded chunk for the record
+    // P2.b dual-write: decision/pattern/issue → devbrain.memory.
+    // Reuses the embedding computed above; provenance_id is the legacy
+    // row's UUID so the partial unique index dedupes concurrent retries.
+    // We dual-write here (the canonical legacy row) — NOT the
+    // auxiliary chunk insert below — so each store() lands exactly one
+    // memory row per logical entity.
+    await recordMemory({
+      projectId,
+      kind: type,
+      title,
+      content: `${title}\n\n${content}`,
+      embeddingSql: vectorStr,
+      provenanceId: recordId,
+    })
+
+    // Also create an embedded chunk for the record. Kept for legacy
+    // search compatibility; no dual-write from here (would duplicate
+    // the memory row created above).
     await query(
       `INSERT INTO devbrain.chunks (project_id, source_type, source_id, content, embedding)
        VALUES ($1, $2, $3, $4, $5::vector)`,
@@ -372,11 +392,13 @@ server.tool(
     ].filter(Boolean).join('\n')
 
     const embedding = await embed(fullContent)
+    const vectorStr = toSqlVector(embedding)
 
-    await query(
+    const chunkResult = await query<{ id: string }>(
       `INSERT INTO devbrain.chunks (project_id, source_type, content, embedding, metadata)
-       VALUES ($1, 'session_summary', $2, $3::vector, $4)`,
-      [projectId, fullContent, toSqlVector(embedding), JSON.stringify({
+       VALUES ($1, 'session_summary', $2, $3::vector, $4)
+       RETURNING id`,
+      [projectId, fullContent, vectorStr, JSON.stringify({
         decisions_made: decisions_made ?? [],
         files_changed: files_changed ?? [],
         issues_found: issues_found ?? [],
@@ -384,6 +406,18 @@ server.tool(
         timestamp: new Date().toISOString(),
       })],
     )
+
+    // P2.b dual-write: session_summary → devbrain.memory. The MCP
+    // end_session tool doesn't write to raw_sessions in the current
+    // code path, so we anchor provenance_id to the chunks row we just
+    // created (deduplicates against concurrent end_session retries).
+    await recordMemory({
+      projectId,
+      kind: 'session_summary',
+      content: fullContent,
+      embeddingSql: vectorStr,
+      provenanceId: chunkResult.rows[0]?.id ?? null,
+    })
 
     return { content: [{ type: 'text', text: `Session summary stored for project "${project}".` }] }
   },

--- a/mcp-server/src/memory.ts
+++ b/mcp-server/src/memory.ts
@@ -1,0 +1,72 @@
+// Adapter helper for dual-writing into devbrain.memory (P2.b).
+//
+// Reads still go to the legacy tables. Writes go to BOTH the legacy
+// table and devbrain.memory; this helper handles the unified-table
+// side. Failures are logged and swallowed — the legacy write that
+// already happened (or is about to happen) remains the source of
+// truth, exactly like ingest/memory_writer.py does on the Python side.
+//
+// No SAVEPOINT here, by design: pg.Pool gives each query() its own
+// connection, so an error on this call cannot poison anyone else's
+// transaction. The Python adapter needs a savepoint because psycopg2
+// runs the dual-write inside the caller's open transaction; pg.Pool
+// doesn't have that constraint.
+//
+// Idempotency: relies on migration 011's partial unique index
+// (idx_memory_provenance_kind_unique on (provenance_id, kind) WHERE
+// provenance_id IS NOT NULL). Two concurrent dual-writes for the same
+// legacy row collapse to one memory row via ON CONFLICT DO NOTHING.
+
+import { query } from './db.js'
+
+export type MemoryKind =
+  | 'chunk'
+  | 'decision'
+  | 'pattern'
+  | 'issue'
+  | 'session_summary'
+
+export interface RecordMemoryArgs {
+  /** memory.project_id is NOT NULL — caller must resolve before calling. */
+  projectId: string
+  kind: MemoryKind
+  content: string
+  /** Optional human-friendly title. Chunks/sessions normally pass undefined. */
+  title?: string | null
+  /**
+   * pgvector literal already formatted as `[v1,v2,…]`. We never
+   * recompute embeddings — pass the legacy row's vector verbatim.
+   */
+  embeddingSql?: string | null
+  /**
+   * Legacy row's UUID. If undefined/null no dedup is enforced (the
+   * partial unique index has WHERE provenance_id IS NOT NULL).
+   */
+  provenanceId?: string | null
+}
+
+export async function recordMemory(args: RecordMemoryArgs): Promise<void> {
+  try {
+    await query(
+      `INSERT INTO devbrain.memory
+           (project_id, kind, title, content, embedding, provenance_id)
+       VALUES ($1, $2, $3, $4, $5::vector, $6)
+       ON CONFLICT (provenance_id, kind) WHERE provenance_id IS NOT NULL
+       DO NOTHING`,
+      [
+        args.projectId,
+        args.kind,
+        args.title ?? null,
+        args.content,
+        args.embeddingSql ?? null,
+        args.provenanceId ?? null,
+      ],
+    )
+  } catch (err) {
+    // Best-effort: never let a memory failure surface to the caller.
+    // The legacy write is the contract; this is shadow-write phase.
+    console.error(
+      `[memory] dual-write failed (kind=${args.kind}, provenance_id=${args.provenanceId ?? 'null'}): ${err}`,
+    )
+  }
+}

--- a/migrations/011_memory_provenance_unique.sql
+++ b/migrations/011_memory_provenance_unique.sql
@@ -1,0 +1,31 @@
+-- Migration 011: idempotency constraint for devbrain.memory dual-writes.
+-- ============================================================================
+--
+-- Adds a partial UNIQUE index on (provenance_id, kind) so the P2.b adapter
+-- helpers (ingest/memory_writer.py and mcp-server/src/memory.ts) can use
+-- ON CONFLICT (provenance_id, kind) WHERE provenance_id IS NOT NULL
+-- DO NOTHING for race-free idempotency. Postgres requires that the
+-- INSERT's WHERE predicate match the index's predicate exactly to infer
+-- the constraint, so both clauses include `WHERE provenance_id IS NOT NULL`.
+--
+-- Why partial: rows without a provenance_id (e.g. ad-hoc curator entries
+-- in the future) are not deduplicated by source — they're allowed to
+-- multiply. The legacy code already inserts unconditionally; carrying
+-- that semantics through to memory keeps P2.b strictly write-additive.
+--
+-- Why split from 010: 010 was scope-limited to "table exists, no writers".
+-- The constraint had no callers in P2.a and would have been dead code.
+-- P2.b needs it now because dual-writes are racy (two ingest workers may
+-- process the same chunk concurrently) and pre-insert existence checks
+-- are slower and still racy.
+--
+-- Idempotent (CREATE UNIQUE INDEX IF NOT EXISTS) — re-running on a DB
+-- that already has the constraint is a no-op. Required by the
+-- schema_migrations bootstrap path which may re-apply on upgrade.
+--
+-- Usage:
+--   bin/devbrain migrate
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_provenance_kind_unique
+    ON devbrain.memory (provenance_id, kind)
+    WHERE provenance_id IS NOT NULL;


### PR DESCRIPTION
## Summary
Phase 2 step B. Every existing write path that touches `chunks` / `decisions` / `patterns` / `issues` / `raw_sessions` now ALSO inserts a corresponding row into `devbrain.memory` with the appropriate `kind`. Read paths are unchanged in this PR — they stay on the legacy tables until P2.c backfills history and P2.d switches the reads.

## Produced by
Factory job `81bf2077` — fourth consecutive fix-loop convergence (arch reviewer caught a real load-bearing bug in round 1, factory fixed it in round 2, both reviewers cleared with empty JSON findings in round 2). Two commits on the branch:

**`2e8e13d`** (initial): dual-write helpers (`ingest/memory_writer.py:record_memory`, `mcp-server/src/memory.ts:recordMemory`), partial unique index (`migrations/011_memory_provenance_unique.sql`), call-site instrumentation in `factory/learning.py`, `ingest/db.py`, `mcp-server/src/index.ts` (store + end_session), 8 tests.

**`19678d4`** (factory's fix for round 1 WARNING): SAVEPOINT was originally executed OUTSIDE the try block in `record_memory`. If a caller passed a cursor whose transaction was already in `InFailedSqlTransaction`, the SAVEPOINT itself would raise and propagate, defeating the helper's "must not poison the surrounding transaction" contract. Fix: move SAVEPOINT inside the try, wrap the ROLLBACK TO + RELEASE cleanup in an inner try/except that swallows.

## Key design choices (locked by reviewers)
- **SAVEPOINT discipline** — Python writers wrap each memory insert in `SAVEPOINT memory_write_sp` so a failure can't poison the legacy commit. TS writers don't need it because `pg.Pool` gives each query its own connection.
- **Idempotency via partial unique index** — migration 011 adds `(provenance_id, kind) WHERE provenance_id IS NOT NULL`, matched exactly by `ON CONFLICT (provenance_id, kind) WHERE provenance_id IS NOT NULL DO NOTHING`.
- **Embedding reuse** — never call Ollama twice for the same logical write; the existing computed vector flows into both legacy and memory inserts.
- **`project_id is not None` guard** in `insert_chunk` — legacy `chunks.project_id` is nullable but `memory.project_id` is `NOT NULL`. Skip the dual-write rather than fabricate a project.
- **Skip auxiliary chunk inserts** — `factory/learning.py:_store_lessons` and the MCP `store` tool both do an auxiliary chunks INSERT alongside the canonical row. Dual-writing that would create duplicate memory rows (same content, different provenance). Skipped deliberately.

## Tests
8 pass locally (after `bin/devbrain migrate` applied 011): migration applied, all 5 `kind` values (chunk/decision/pattern/issue/session_summary), idempotency under repeated calls, legacy-survives-memory-failure under a forced CHECK violation.

## Deferred NIT (security)
- `ingest/memory_writer.py:80-83` logs `str(exc)` on dual-write failure. Defense-in-depth: log `type(exc).__name__` + `exc.diag.sqlstate` instead, in case a future schema change adds a CHECK or trigger that includes the offending row's content in its error text. Not currently exploitable.

## Verification
After merge: any `mcp__devbrain__store` call should produce rows in BOTH the legacy table (decisions/patterns/issues) AND `devbrain.memory` with the matching `kind` and `provenance_id` linking them.

## Scope reminder
- ✅ Dual-WRITE done.
- ⏳ P2.c — backfill historical legacy rows into memory (next).
- ⏳ P2.d — switch reads to memory, drop legacy tables (after P2.c stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)