### PR TITLE
feat(factory): atomic cred rotation — registry + reload + verify + rollback (task #28)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -588,6 +588,26 @@ the live container password (or rotates it) and rewrites both
 Re-run `./bin/devbrain doctor` afterwards; `postgres_reachable` should
 flip to PASS without any manual SQL.
 
+### Credential rotation
+
+Run `devbrain rotate-db-password` to rotate the DevBrain Postgres password.
+The command auto-reloads registered cred-dependent processes (ingest
+daemon, etc.) and verifies they re-authenticated. If any reload fails,
+the rotation rolls back atomically — old creds remain authoritative.
+
+Manual-restart dependents (Claude Desktop MCP servers, running shells
+with `DEVBRAIN_DB_PASSWORD` exported) cannot be programmatically reloaded.
+The rotation will print which ones need manual action.
+
+To register a custom cred-dependent process, add an entry to
+`factory.cred_dependents` in `config/devbrain.yaml`. See the example
+template for the schema.
+
+Flags:
+- `--skip-dependents` — bypass the registry (legacy single-step behavior).
+- `--no-require-all-healthy` — rotate even if some dependents are
+  already broken (won't make things worse).
+
 ### Common non-doctor issues
 
 - **`./bin/devbrain: command not found`** — you are not in the repo root.

--- a/config/devbrain.yaml.example
+++ b/config/devbrain.yaml.example
@@ -192,6 +192,23 @@ factory:
   # Use Tool(pattern) syntax, e.g. "Bash(terraform:*)".
   permissions_extra_allowed_tools: []
 
+  # Long-running processes that hold cached database credentials.
+  # rotate-db-password reloads each one after the rotation lands and
+  # verifies it can authenticate; if any verification fails, the
+  # rotation rolls back. Add custom entries here for forks/integrations.
+  cred_dependents:
+    - id: ingest_daemon
+      type: launchagent
+      label: com.devbrain.ingest
+      plist: ~/Library/LaunchAgents/com.devbrain.ingest.plist
+      verify: tail_log_no_auth_errors
+      verify_log: ~/devbrain/logs/ingest.err.log
+      verify_window_seconds: 10
+    # Future: factory dashboard, codebase indexer, etc. as they become
+    # daemonized. MCP servers spawned by Claude Desktop are intentionally
+    # NOT registerable — Claude Desktop owns the lifecycle, so rotation
+    # prints a "please restart Claude Desktop" tail message instead.
+
 notifications:
   notify_events:
     - job_started

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -887,7 +887,14 @@ def _offer_devdoctor_fixes(checks: list[dict]) -> None:
             click.echo("   Fix: generate a new password, ALTER USER inside the")
             click.echo("        container, sync .env + yaml, recreate the container.")
             if click.confirm("   Rotate DB password now?", default=True):
-                ctx.invoke(rotate_db_password, yes=False, recreate=True)
+                # devdoctor --fix runs against a known-bad system; pre-flight
+                # baseline failures here are expected, not a reason to abort.
+                ctx.invoke(
+                    rotate_db_password,
+                    yes=False,
+                    recreate=True,
+                    require_all_healthy=False,
+                )
                 click.secho(
                     "   → After this runs, open a new terminal (and restart "
                     "any Claude Code sessions) before using DevBrain MCP tools.",
@@ -1011,7 +1018,15 @@ def _offer_devdoctor_fixes(checks: list[dict]) -> None:
                     "container (applies loopback binding)?",
                     default=True,
                 ):
-                    ctx.invoke(rotate_db_password, yes=False, recreate=True)
+                    # Recovery flow: dependents may still be unhealthy from
+                    # the drift we just fixed. Don't let baseline failures
+                    # abort the rotation the operator just opted into.
+                    ctx.invoke(
+                        rotate_db_password,
+                        yes=False,
+                        recreate=True,
+                        require_all_healthy=False,
+                    )
                     click.secho(
                         "   → Restart any Claude Code sessions using "
                         "DevBrain MCP so their subprocesses reload.",
@@ -1029,10 +1044,14 @@ def _offer_devdoctor_fixes(checks: list[dict]) -> None:
                     "   Skipped — no recovery action taken. If you know"
                 )
                 click.echo(
-                    "   the live DB password, you can also pass it to"
+                    "   the live DB password, you can re-run with"
                 )
                 click.echo(
-                    f"   {click.style('devbrain rotate-db-password --current-password ...', fg='cyan')}"
+                    f"   {click.style('devbrain rotate-db-password --current-password', fg='cyan')}"
+                )
+                click.echo(
+                    "   (you'll be prompted securely; or set "
+                    "DEVBRAIN_CURRENT_DB_PASSWORD for scripted use)."
                 )
 
         elif name.startswith("ollama_model:"):
@@ -1581,7 +1600,14 @@ def upgrade(
                 "   (This recreates the devbrain-db container with the"
                 " loopback-only port binding.)"
             )
-            ctx.invoke(rotate_db_password, yes=yes, recreate=True)
+            # upgrade auto-rotates a weak/default password; a stale
+            # dependent shouldn't block fixing a known-weak credential.
+            ctx.invoke(
+                rotate_db_password,
+                yes=yes,
+                recreate=True,
+                require_all_healthy=False,
+            )
         else:
             click.echo("   ✓ custom password in use")
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -18,6 +18,10 @@ import attribute_orphans
 import backfill_memory
 import schema_migrate
 from config import DATABASE_URL, NL_MODEL, OLLAMA_URL
+from cred_rotate import (
+    rewrite_env_password as _rewrite_env_password,
+    rewrite_yaml_db_password as _rewrite_yaml_db_password,
+)
 from state_machine import FactoryDB
 
 
@@ -1168,50 +1172,6 @@ def doctor_alias(ctx: click.Context, as_json: bool, fix: bool) -> None:
     ctx.invoke(devdoctor, as_json=as_json, fix=fix)
 
 
-def _rewrite_env_password(env_path: Path, new_password: str) -> None:
-    """Replace (or append) DEVBRAIN_DB_PASSWORD in a .env file."""
-    if env_path.exists():
-        lines = [
-            ln for ln in env_path.read_text().splitlines()
-            if not ln.startswith("DEVBRAIN_DB_PASSWORD=")
-        ]
-    else:
-        lines = []
-    lines.append("")
-    lines.append(f"# Database password — rotated {time.strftime('%Y-%m-%d')}")
-    lines.append(f"DEVBRAIN_DB_PASSWORD={new_password}")
-    env_path.write_text("\n".join(lines) + "\n")
-
-
-def _rewrite_yaml_db_password(yaml_path: Path, new_password: str) -> None:
-    """Replace password: under database: in config/devbrain.yaml.
-
-    Line-based rewrite instead of round-tripping through PyYAML (which
-    would strip comments and re-order keys). Scope is limited to the
-    database: block to avoid touching notification-channel passwords.
-    """
-    out: list[str] = []
-    in_db_block = False
-    replaced = False
-    for line in yaml_path.read_text().splitlines():
-        if re.match(r"^database:", line):
-            in_db_block = True
-            out.append(line)
-            continue
-        if in_db_block and re.match(r"^  password:", line):
-            out.append(f"  password: {new_password}")
-            replaced = True
-            continue
-        if re.match(r"^[^\s#]", line):
-            in_db_block = False
-        out.append(line)
-    if not replaced:
-        raise click.ClickException(
-            f"Could not find 'password:' under 'database:' in {yaml_path}"
-        )
-    yaml_path.write_text("\n".join(out) + "\n")
-
-
 @cli.command(name="rotate-db-password")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @click.option(
@@ -1228,14 +1188,36 @@ def _rewrite_yaml_db_password(yaml_path: Path, new_password: str) -> None:
          "and the live DB out of sync — pass the live password here and "
          "rotation will sync config to match on success.",
 )
+@click.option(
+    "--skip-dependents",
+    is_flag=True,
+    default=False,
+    help="Bypass the cred_dependents registry + post-reload verification. "
+         "Restores the legacy single-step rotation. Use for emergencies "
+         "or when rotating in single-user contexts.",
+)
+@click.option(
+    "--require-all-healthy/--no-require-all-healthy",
+    default=True,
+    help="Abort rotation if any dependent fails the pre-flight baseline "
+         "check. Pass --no-require-all-healthy to rotate even when some "
+         "dependents are already broken (won't make things worse).",
+)
 def rotate_db_password(
-    yes: bool, recreate: bool, current_password: str | None,
+    yes: bool,
+    recreate: bool,
+    current_password: str | None,
+    skip_dependents: bool,
+    require_all_healthy: bool,
 ) -> None:
     """Rotate the Postgres password, preserving data.
 
     Generates a new random password, applies it inside the running
     container via ALTER USER, then syncs the new value to .env and
-    config/devbrain.yaml. Optionally recreates the container so updated
+    config/devbrain.yaml. Reloads every dependent process registered in
+    factory.cred_dependents and verifies each one re-authenticated.
+    On any failure, rolls back atomically — old creds remain
+    authoritative. Optionally recreates the container so updated
     docker-compose settings (e.g., loopback-only port binding) take effect.
 
     Use --current-password when .env/yaml drifted from the live DB
@@ -1246,9 +1228,13 @@ def rotate_db_password(
     import subprocess
 
     import psycopg2
-    from psycopg2 import sql
 
-    from config import CONFIG_PATH, DEVBRAIN_HOME, build_database_url, load_config
+    from config import CONFIG_PATH, DEVBRAIN_HOME, load_config
+    from cred_rotate import (
+        RotationContext,
+        list_dependents,
+        rotate_with_dependents,
+    )
 
     # Refuse to run if DEVBRAIN_DATABASE_URL overrides the config — the
     # user wired credentials up explicitly and this command wouldn't help.
@@ -1265,15 +1251,10 @@ def rotate_db_password(
     db_name = db_cfg.get("database", "devbrain")
     db_host = db_cfg.get("host", "localhost")
     db_port = db_cfg.get("port", 5433)
-    if current_password is not None:
-        # User-supplied recovery password — build a URL with it instead
-        # of trusting config, which may be out of sync with the live DB.
-        current_url = (
-            f"postgresql://{db_user}:{current_password}"
-            f"@{db_host}:{db_port}/{db_name}"
-        )
-    else:
-        current_url = build_database_url(cfg)
+    old_password = (
+        current_password if current_password is not None
+        else db_cfg.get("password", "")
+    )
     env_path = DEVBRAIN_HOME / ".env"
     yaml_path = CONFIG_PATH
 
@@ -1292,11 +1273,14 @@ def rotate_db_password(
         click.echo("Aborted.")
         return
 
-    # Step 1: verify the current password actually works. If it doesn't,
-    # there's no point generating a new one — we couldn't apply it.
+    # Verify the current password actually works before generating a new one.
     click.echo("→ Connecting with current password...", nl=False)
     try:
-        verify_conn = psycopg2.connect(current_url, connect_timeout=5)
+        psycopg2.connect(
+            f"postgresql://{db_user}:{old_password}"
+            f"@{db_host}:{db_port}/{db_name}",
+            connect_timeout=5,
+        ).close()
     except psycopg2.Error as exc:
         click.echo(" ❌")
         hint = (
@@ -1310,70 +1294,77 @@ def rotate_db_password(
         )
     click.echo(" ✅")
 
-    # Step 2: generate and apply new password. ALTER USER takes effect
-    # immediately for new connections; existing ones keep working until
-    # they disconnect.
     new_password = secrets.token_hex(32)
-    click.echo("→ Applying new password via ALTER USER...", nl=False)
-    try:
-        with verify_conn:
-            with verify_conn.cursor() as cur:
-                cur.execute(
-                    sql.SQL("ALTER USER {user} PASSWORD {pw}").format(
-                        user=sql.Identifier(db_user),
-                        pw=sql.Literal(new_password),
-                    )
-                )
-    except psycopg2.Error as exc:
-        click.echo(" ❌")
-        verify_conn.close()
-        raise click.ClickException(f"ALTER USER failed: {exc}")
-    verify_conn.close()
-    click.echo(" ✅")
+    ctx = RotationContext(
+        user=db_user, host=db_host, port=db_port, database=db_name,
+        old_password=old_password, env_path=env_path, yaml_path=yaml_path,
+    )
 
-    # Step 3: verify we can connect with the NEW password before writing
-    # it to .env/yaml. If this fails, the DB has a password we can't
-    # recover from config, so print it loudly so the user can paste it in.
-    click.echo("→ Verifying new password...", nl=False)
+    if not skip_dependents:
+        deps = list_dependents(cfg)
+        click.echo(f"[rotate] Pre-flight: {len(deps)} dependents registered")
+    else:
+        click.echo("[rotate] --skip-dependents: registry bypassed")
+
+    click.echo("→ Rotating + reloading dependents...")
+    result = rotate_with_dependents(
+        ctx, new_password,
+        config=cfg,
+        require_all_healthy=require_all_healthy,
+        skip_dependents=skip_dependents,
+    )
+
+    if result.get("aborted_baseline"):
+        click.echo(
+            "[rotate] ABORTED — some dependents are already unhealthy:",
+            err=True,
+        )
+        for c in result["unhealthy"]:
+            click.echo(f"  • {c.id}: {c.error}", err=True)
+        click.echo(
+            "[rotate] Fix them first, or pass --no-require-all-healthy to "
+            "rotate anyway.",
+            err=True,
+        )
+        sys.exit(1)
+
+    if result.get("rolled_back"):
+        click.echo(f"[rotate] FAILED — {result['reason']}", err=True)
+        click.echo(
+            "[rotate] ROLLING BACK ALTER USER + .env + yaml... done.",
+            err=True,
+        )
+        click.echo("[rotate] Old creds remain authoritative.", err=True)
+        for c in result.get("failed", []):
+            click.echo(
+                f"[rotate] Investigate {c.id} manually before retrying.",
+                err=True,
+            )
+        sys.exit(1)
+
+    # Success: report dependent status.
+    for c in result.get("reloaded", []):
+        click.echo(f"  • {c.id} ({c.type}): reloaded, verified ✓")
+    for c in result.get("manual", []):
+        click.echo(
+            f"  • {c.id} (manual_restart): MANUAL ACTION REQUIRED — "
+            f"please restart this dependent to pick up new creds"
+        )
+    n_auto = len(result.get("reloaded", []))
+    n_manual = len(result.get("manual", []))
+    click.echo(
+        f"[rotate] DONE — {n_auto} dependents auto-reloaded, "
+        f"{n_manual} need manual restart."
+    )
+
     new_url = (
         f"postgresql://{db_user}:{new_password}"
         f"@{db_host}:{db_port}/{db_name}"
     )
-    try:
-        psycopg2.connect(new_url, connect_timeout=5).close()
-    except psycopg2.Error as exc:
-        click.echo(" ❌")
-        click.echo(
-            f"\nALTER USER succeeded but the new password doesn't connect: {exc}",
-            err=True,
-        )
-        click.echo(
-            "\nThe database now has this password (NOT yet written to disk):",
-            err=True,
-        )
-        click.echo(f"\n  {new_password}\n", err=True)
-        click.echo(
-            "Update .env (DEVBRAIN_DB_PASSWORD) and config/devbrain.yaml "
-            "(database.password) manually, then re-run 'devbrain doctor'.",
-            err=True,
-        )
-        sys.exit(1)
-    click.echo(" ✅")
 
-    # Step 4: write to .env and yaml. Order: .env first (smaller blast
-    # radius if the process dies between them — re-running this command
-    # will pick up .env and sync yaml).
-    click.echo("→ Writing DEVBRAIN_DB_PASSWORD to .env...", nl=False)
-    _rewrite_env_password(env_path, new_password)
-    click.echo(" ✅")
-
-    click.echo("→ Updating config/devbrain.yaml...", nl=False)
-    _rewrite_yaml_db_password(yaml_path, new_password)
-    click.echo(" ✅")
-
-    # Step 5: optionally recreate the container so docker-compose.yml
-    # changes (port binding, etc.) take effect. Password rotation alone
-    # doesn't require a recreate — ALTER USER already applied it.
+    # Optional container recreate so docker-compose.yml changes (e.g.,
+    # loopback-only port binding) take effect. Password rotation alone
+    # doesn't require this — ALTER USER already applied it.
     if recreate:
         if subprocess.run(
             ["docker", "--version"], capture_output=True

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1182,11 +1182,16 @@ def doctor_alias(ctx: click.Context, as_json: bool, fix: bool) -> None:
 )
 @click.option(
     "--current-password",
-    default=None,
-    help="Use this value as the CURRENT DB password (instead of reading "
-         "from .env/yaml). Useful after an ALTER USER that left config "
-         "and the live DB out of sync — pass the live password here and "
-         "rotation will sync config to match on success.",
+    "current_password_prompt",
+    is_flag=True,
+    default=False,
+    help="Recovery mode: securely prompt for the live DB password "
+         "instead of reading from .env/yaml. Use after a manual ALTER "
+         "USER left config out of sync with the live DB. Set env var "
+         "DEVBRAIN_CURRENT_DB_PASSWORD to skip the prompt for scripted "
+         "use. WARNING: never pass the password as a command argument — "
+         "it would appear in 'ps aux', shell history, and process "
+         "monitoring captures.",
 )
 @click.option(
     "--skip-dependents",
@@ -1206,7 +1211,7 @@ def doctor_alias(ctx: click.Context, as_json: bool, fix: bool) -> None:
 def rotate_db_password(
     yes: bool,
     recreate: bool,
-    current_password: str | None,
+    current_password_prompt: bool,
     skip_dependents: bool,
     require_all_healthy: bool,
 ) -> None:
@@ -1251,8 +1256,20 @@ def rotate_db_password(
     db_name = db_cfg.get("database", "devbrain")
     db_host = db_cfg.get("host", "localhost")
     db_port = db_cfg.get("port", 5433)
+    # Recovery mode: env var > interactive prompt > config. The flag never
+    # accepts a value on the command line, so the password cannot leak via
+    # `ps aux`, shell history, or process-monitoring captures.
+    recovery_password: str | None = None
+    if current_password_prompt:
+        recovery_password = os.environ.get("DEVBRAIN_CURRENT_DB_PASSWORD")
+        if not recovery_password:
+            recovery_password = click.prompt(
+                "Live DB password (input hidden)",
+                hide_input=True,
+                confirmation_prompt=False,
+            )
     old_password = (
-        current_password if current_password is not None
+        recovery_password if recovery_password is not None
         else db_cfg.get("password", "")
     )
     env_path = DEVBRAIN_HOME / ".env"
@@ -1265,7 +1282,7 @@ def rotate_db_password(
     click.echo(f"  Database: {db_name}")
     click.echo(f"  .env:     {env_path}")
     click.echo(f"  yaml:     {yaml_path}")
-    if current_password is not None:
+    if recovery_password is not None:
         click.echo("  Source:   --current-password flag (recovery mode)")
     click.echo()
 
@@ -1274,11 +1291,13 @@ def rotate_db_password(
         return
 
     # Verify the current password actually works before generating a new one.
+    # Use keyword form (host=, port=, ...) so the password never appears in
+    # the connection string libpq echoes back in OperationalError messages.
     click.echo("→ Connecting with current password...", nl=False)
     try:
         psycopg2.connect(
-            f"postgresql://{db_user}:{old_password}"
-            f"@{db_host}:{db_port}/{db_name}",
+            host=db_host, port=db_port,
+            user=db_user, password=old_password, dbname=db_name,
             connect_timeout=5,
         ).close()
     except psycopg2.Error as exc:
@@ -1286,7 +1305,8 @@ def rotate_db_password(
         hint = (
             "If the config drifted from the live DB (e.g. someone ran "
             "ALTER USER manually), retry with:\n"
-            "    devbrain rotate-db-password --current-password '<live-pw>'\n"
+            "    devbrain rotate-db-password --current-password\n"
+            "(you'll be prompted securely for the live password)\n"
             "Or run 'devbrain devdoctor --fix' to interactively recover."
         )
         raise click.ClickException(
@@ -1328,6 +1348,20 @@ def rotate_db_password(
         )
         sys.exit(1)
 
+    if result.get("rollback_failed"):
+        click.echo(f"[rotate] FAILED — {result['reason']}", err=True)
+        click.echo(
+            f"[rotate] ROLLBACK ALSO FAILED — {result['rollback_error']}",
+            err=True,
+        )
+        click.echo(
+            "[rotate] Live DB password state is UNKNOWN. .env and yaml "
+            "still reflect the new password. Check the DB manually before "
+            "retrying — do NOT assume old creds are authoritative.",
+            err=True,
+        )
+        sys.exit(2)
+
     if result.get("rolled_back"):
         click.echo(f"[rotate] FAILED — {result['reason']}", err=True)
         click.echo(
@@ -1335,6 +1369,11 @@ def rotate_db_password(
             err=True,
         )
         click.echo("[rotate] Old creds remain authoritative.", err=True)
+        for err in result.get("reload_rollback_errors", []):
+            click.echo(
+                f"[rotate] WARNING: re-reload during rollback failed: {err}",
+                err=True,
+            )
         for c in result.get("failed", []):
             click.echo(
                 f"[rotate] Investigate {c.id} manually before retrying.",
@@ -1357,9 +1396,9 @@ def rotate_db_password(
         f"{n_manual} need manual restart."
     )
 
-    new_url = (
-        f"postgresql://{db_user}:{new_password}"
-        f"@{db_host}:{db_port}/{db_name}"
+    new_conn_kwargs = dict(
+        host=db_host, port=db_port,
+        user=db_user, password=new_password, dbname=db_name,
     )
 
     # Optional container recreate so docker-compose.yml changes (e.g.,
@@ -1400,7 +1439,7 @@ def rotate_db_password(
             click.echo("→ Waiting for Postgres to accept connections...", nl=False)
             for _ in range(30):
                 try:
-                    psycopg2.connect(new_url, connect_timeout=1).close()
+                    psycopg2.connect(**new_conn_kwargs, connect_timeout=1).close()
                     click.echo(" ✅")
                     break
                 except psycopg2.Error:

--- a/factory/config.py
+++ b/factory/config.py
@@ -50,6 +50,22 @@ _DEFAULTS: dict = {
             "branch_cleanup": True,
         },
         "project_paths": {},
+        # Long-running processes that hold cached database credentials.
+        # rotate-db-password reloads each one after the rotation lands
+        # and verifies it can authenticate; if any verification fails
+        # the rotation rolls back. See config/devbrain.yaml.example for
+        # the schema of each entry.
+        "cred_dependents": [
+            {
+                "id": "ingest_daemon",
+                "type": "launchagent",
+                "label": "com.devbrain.ingest",
+                "plist": "~/Library/LaunchAgents/com.devbrain.ingest.plist",
+                "verify": "tail_log_no_auth_errors",
+                "verify_log": "~/devbrain/logs/ingest.err.log",
+                "verify_window_seconds": 10,
+            },
+        ],
         # Permissions tier controls what factory-spawned claude subprocesses
         # are allowed to do. 1 = read-only audit, 2 = guarded dev (curated
         # allowlist), 3 = unrestricted (--dangerously-skip-permissions).
@@ -144,6 +160,7 @@ FACTORY_PERMISSIONS_EXTRA_TOOLS = list(
 FACTORY_TIER_2_SUBCATEGORIES = dict(
     FACTORY_CONFIG.get("permissions_tier_2_subcategories", {})
 )
+FACTORY_CRED_DEPENDENTS = list(FACTORY_CONFIG.get("cred_dependents", []))
 
 # Fix-loop trigger tier. When True (default as of 2026-04-23), reviewer
 # WARNING findings also route a job through FIX_LOOP; when False the

--- a/factory/cred_rotate.py
+++ b/factory/cred_rotate.py
@@ -63,10 +63,18 @@ class RotationContext:
     env_path: Path
     yaml_path: Path
 
-    def url(self, password: str) -> str:
-        return (
-            f"postgresql://{self.user}:{password}"
-            f"@{self.host}:{self.port}/{self.database}"
+    def connect_kwargs(self, password: str) -> dict:
+        """Keyword form for psycopg2.connect.
+
+        Avoids URL-style ``postgresql://user:password@host:...`` strings:
+        passwords containing ``@``, ``:``, ``/``, ``?``, ``#``, ``%``
+        break libpq URL parsing, and the malformed URL — still containing
+        the secret — would surface in OperationalError messages echoed to
+        the operator.
+        """
+        return dict(
+            host=self.host, port=self.port,
+            user=self.user, password=password, dbname=self.database,
         )
 
 
@@ -99,28 +107,46 @@ def precheck_baseline(dependents: list[dict]) -> list[DependentCheck]:
     baseline to compare against post-reload.
 
     For ``manual_restart`` dependents this is always healthy=True
-    (they're informational, not verifiable).
+    (they're informational, not verifiable). Pre-flight passes
+    ``lookback=True`` so the verifier scans the tail of the existing log
+    — that's what catches a daemon that's been silently retrying with
+    stale creds for hours/days, which would otherwise only register if a
+    retry happened to land inside the verify window.
     """
-    return [verify_dependent(dep) for dep in dependents]
+    return [verify_dependent(dep, lookback=True) for dep in dependents]
 
 
-def verify_dependent(dep: dict) -> DependentCheck:
-    """Dispatch on ``dep['verify']``."""
+def verify_dependent(dep: dict, *, lookback: bool = False) -> DependentCheck:
+    """Dispatch on ``dep['verify']``.
+
+    ``lookback`` is set by pre-flight only — the post-reload verify path
+    must not scan pre-rotation log content (it would always find the old
+    auth-failure churn and reject every rotation).
+    """
     if dep.get("type") == "manual_restart":
         return DependentCheck(id=dep["id"], type="manual_restart", healthy=True)
     verify = dep.get("verify", "tail_log_no_auth_errors")
     if verify == "tail_log_no_auth_errors":
-        return _verify_tail_log_no_auth_errors(dep)
+        return _verify_tail_log_no_auth_errors(dep, lookback=lookback)
     if verify == "connect_via_proxy":
-        logger.info("verify connect_via_proxy not yet implemented for %s", dep["id"])
-        return DependentCheck(id=dep["id"], type=dep.get("type", "?"), healthy=True)
+        # Fail closed: returning healthy=True for an unimplemented verifier
+        # would silently green-light rotations whose dependents may still
+        # be auth-failing — exactly the integrity guarantee this feature
+        # is meant to provide.
+        return DependentCheck(
+            id=dep["id"], type=dep.get("type", "?"), healthy=False,
+            error="verify mode 'connect_via_proxy' is not implemented yet — "
+                  "remove the dependent or pick a supported verify mode",
+        )
     return DependentCheck(
         id=dep["id"], type=dep.get("type", "?"), healthy=False,
         error=f"unknown verify mode: {verify}",
     )
 
 
-def _verify_tail_log_no_auth_errors(dep: dict) -> DependentCheck:
+def _verify_tail_log_no_auth_errors(
+    dep: dict, *, lookback: bool = False,
+) -> DependentCheck:
     log_path = Path(dep.get("verify_log", "")).expanduser()
     window = int(dep.get("verify_window_seconds", 10))
     if not log_path.exists():
@@ -143,8 +169,34 @@ def _verify_tail_log_no_auth_errors(dep: dict) -> DependentCheck:
             error=f"could not stat verify_log: {exc}",
         )
 
-    deadline = time.monotonic() + window
     pattern = re.compile(r"authentication failed", re.IGNORECASE)
+
+    # Pre-flight only: scan the tail of the EXISTING log so a daemon
+    # that's been silently retrying with stale creds for hours/days is
+    # caught even if no retry lands inside the verify_window_seconds.
+    if lookback:
+        lookback_bytes = int(dep.get("verify_lookback_bytes", 65536))
+        try:
+            with log_path.open("rb") as f:
+                if start_offset > lookback_bytes:
+                    f.seek(start_offset - lookback_bytes)
+                tail = f.read(start_offset if start_offset <= lookback_bytes
+                              else lookback_bytes)
+        except OSError as exc:
+            return DependentCheck(
+                id=dep["id"], type=dep.get("type", "?"), healthy=False,
+                error=f"could not read verify_log: {exc}",
+            )
+        if pattern.search(tail.decode("utf-8", errors="replace")):
+            return DependentCheck(
+                id=dep["id"], type=dep.get("type", "?"), healthy=False,
+                error=f"saw 'authentication failed' in last "
+                      f"{lookback_bytes} bytes of {log_path} (pre-existing "
+                      f"churn — fix the dependent first or rotate with "
+                      f"--no-require-all-healthy)",
+            )
+
+    deadline = time.monotonic() + window
     while time.monotonic() < deadline:
         try:
             with log_path.open("rb") as f:
@@ -257,7 +309,9 @@ def _alter_user_password(ctx: RotationContext, current_password: str,
     """Issue ALTER USER. Connects with current_password (so rollback can
     pass new_password as 'current' and old_password as 'new').
     """
-    conn = psycopg2.connect(ctx.url(current_password), connect_timeout=5)
+    conn = psycopg2.connect(
+        **ctx.connect_kwargs(current_password), connect_timeout=5,
+    )
     try:
         with conn:
             with conn.cursor() as cur:
@@ -317,21 +371,21 @@ def rotate_with_dependents(
 
     # 3) Sanity check with new creds -------------------------------------
     try:
-        psycopg2.connect(ctx.url(new_password), connect_timeout=5).close()
+        psycopg2.connect(
+            **ctx.connect_kwargs(new_password), connect_timeout=5,
+        ).close()
     except psycopg2.Error as exc:
         # New creds don't connect — roll the DB back; restore files.
-        _alter_user_password(ctx, new_password, ctx.old_password)
-        _restore_file(ctx.env_path, env_snapshot)
-        _restore_file(ctx.yaml_path, yaml_snapshot)
-        return {
-            "rolled_back": True,
-            "reason": f"sanity check connect failed: {exc}",
-            "failed": [],
-            "reloaded": [],
-        }
+        return _rollback(
+            ctx, new_password,
+            env_snapshot=env_snapshot, yaml_snapshot=yaml_snapshot,
+            reloaded=[], reloaded_deps=[], failed=[],
+            reason=f"sanity check connect failed: {exc}",
+        )
 
     # 4) Reload + verify each dependent ----------------------------------
     reloaded: list[DependentCheck] = []
+    reloaded_deps: list[dict] = []  # parallel list — needed to re-reload on rollback
     manual: list[DependentCheck] = []
     failed: list[DependentCheck] = []
     for dep in dependents:
@@ -351,21 +405,19 @@ def rotate_with_dependents(
         check = verify_dependent(dep)
         if check.healthy:
             reloaded.append(check)
+            reloaded_deps.append(dep)
         else:
             failed.append(check)
             break
 
     # 5) Roll back if any dependent failed -------------------------------
     if failed:
-        _alter_user_password(ctx, new_password, ctx.old_password)
-        _restore_file(ctx.env_path, env_snapshot)
-        _restore_file(ctx.yaml_path, yaml_snapshot)
-        return {
-            "rolled_back": True,
-            "reason": f"dependent verification failed: {failed[0].id}",
-            "failed": failed,
-            "reloaded": reloaded,
-        }
+        return _rollback(
+            ctx, new_password,
+            env_snapshot=env_snapshot, yaml_snapshot=yaml_snapshot,
+            reloaded=reloaded, reloaded_deps=reloaded_deps, failed=failed,
+            reason=f"dependent verification failed: {failed[0].id}",
+        )
 
     # 6) Success ---------------------------------------------------------
     return {
@@ -374,6 +426,67 @@ def rotate_with_dependents(
         "manual": manual,
         "skipped": skip_dependents,
     }
+
+
+def _rollback(
+    ctx: RotationContext,
+    new_password: str,
+    *,
+    env_snapshot: bytes | None,
+    yaml_snapshot: bytes,
+    reloaded: list[DependentCheck],
+    reloaded_deps: list[dict],
+    failed: list[DependentCheck],
+    reason: str,
+) -> dict:
+    """Revert DB password + .env + yaml, then re-reload any dependents
+    that already picked up the new (now-reverted) creds.
+
+    Returns ``rollback_failed=True`` if the ALTER USER itself raises —
+    the operator needs an actionable error rather than a stack trace,
+    since at that point .env/yaml are still in their post-write state
+    and the live DB password is in an unknown state.
+    """
+    rollback_errors: list[str] = []
+    try:
+        _alter_user_password(ctx, new_password, ctx.old_password)
+    except Exception as exc:  # noqa: BLE001 — any failure here is operator-actionable
+        # .env/yaml are still showing the new password but the live DB
+        # may or may not have been reverted. Surface this distinctly so
+        # the operator doesn't trust the "old creds remain authoritative"
+        # message.
+        return {
+            "rolled_back": False,
+            "rollback_failed": True,
+            "reason": reason,
+            "rollback_error": f"ALTER USER rollback failed: {exc}",
+            "failed": failed,
+            "reloaded": reloaded,
+        }
+
+    _restore_file(ctx.env_path, env_snapshot)
+    _restore_file(ctx.yaml_path, yaml_snapshot)
+
+    # Re-reload every dependent that already picked up the (now reverted)
+    # new .env. Without this, processes loaded in the failed window keep
+    # running with the new password against a DB reverted to the old one
+    # — recreating the very 'daemon stuck on wrong creds' state this
+    # feature exists to prevent.
+    for dep in reloaded_deps:
+        try:
+            reload_dependent(dep)
+        except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+            rollback_errors.append(f"{dep.get('id', '?')}: {exc}")
+
+    result: dict = {
+        "rolled_back": True,
+        "reason": reason,
+        "failed": failed,
+        "reloaded": reloaded,
+    }
+    if rollback_errors:
+        result["reload_rollback_errors"] = rollback_errors
+    return result
 
 
 def _restore_file(path: Path, snapshot: bytes | None) -> None:

--- a/factory/cred_rotate.py
+++ b/factory/cred_rotate.py
@@ -1,0 +1,384 @@
+"""Atomic credential rotation with dependent-process reload + verify.
+
+The ``rotate-db-password`` CLI delegates to :func:`rotate_with_dependents`
+in this module. The flow:
+
+1. Pre-flight: every dependent declared in ``factory.cred_dependents`` is
+   checked. If ``require_all_healthy=True`` (default) and any are
+   unhealthy, abort before mutating anything — clean signal.
+2. ALTER USER + write ``.env`` + write ``config/devbrain.yaml``.
+3. Sanity check: connect with the new password.
+4. For each dependent: reload (e.g. ``launchctl unload && load``), then
+   verify (e.g. tail the daemon's err log for ``authentication failed``
+   in a window).
+5. If any verification fails: ALTER USER back to the OLD password,
+   revert ``.env`` and yaml, return ``rolled_back=True``.
+6. On success: report which dependents auto-reloaded vs need manual
+   restart.
+
+Background: 2026-04-25 incident — com.devbrain.ingest LaunchAgent had
+been retrying with pre-rotation creds for ~18 days, generating ~8 auth
+failures per 5 minutes against Postgres. The fix is to make rotation
+itself responsible for re-validating every cred-dependent process.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import signal
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import psycopg2
+from psycopg2 import sql
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DependentCheck:
+    """Result of verifying a single registered dependent."""
+    id: str
+    type: str  # 'launchagent' | 'pidfile' | 'manual_restart'
+    healthy: bool
+    error: str | None = None
+
+
+@dataclass
+class RotationContext:
+    """All state the orchestrator needs to mutate (and roll back).
+
+    Built by the CLI from ``load_config()`` + ``DEVBRAIN_HOME``. Tests
+    construct one directly with tmp paths so the live ``.env`` / yaml
+    are never touched.
+    """
+    user: str
+    host: str
+    port: int
+    database: str
+    old_password: str
+    env_path: Path
+    yaml_path: Path
+
+    def url(self, password: str) -> str:
+        return (
+            f"postgresql://{self.user}:{password}"
+            f"@{self.host}:{self.port}/{self.database}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry helpers
+# ---------------------------------------------------------------------------
+
+def list_dependents(config: dict) -> list[dict]:
+    """Read ``factory.cred_dependents`` from config, expand ``~`` in
+    every path field, return a list of dependent specs (deep-copied so
+    the caller can mutate without aliasing the cached config).
+    """
+    raw = (config.get("factory", {}) or {}).get("cred_dependents") or []
+    out: list[dict] = []
+    for item in raw:
+        d = dict(item)
+        for key in ("plist", "verify_log", "pidfile"):
+            if key in d and isinstance(d[key], str):
+                d[key] = str(Path(d[key]).expanduser())
+        out.append(d)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight & verify
+# ---------------------------------------------------------------------------
+
+def precheck_baseline(dependents: list[dict]) -> list[DependentCheck]:
+    """Verify every dependent BEFORE rotation, so we have a clean
+    baseline to compare against post-reload.
+
+    For ``manual_restart`` dependents this is always healthy=True
+    (they're informational, not verifiable).
+    """
+    return [verify_dependent(dep) for dep in dependents]
+
+
+def verify_dependent(dep: dict) -> DependentCheck:
+    """Dispatch on ``dep['verify']``."""
+    if dep.get("type") == "manual_restart":
+        return DependentCheck(id=dep["id"], type="manual_restart", healthy=True)
+    verify = dep.get("verify", "tail_log_no_auth_errors")
+    if verify == "tail_log_no_auth_errors":
+        return _verify_tail_log_no_auth_errors(dep)
+    if verify == "connect_via_proxy":
+        logger.info("verify connect_via_proxy not yet implemented for %s", dep["id"])
+        return DependentCheck(id=dep["id"], type=dep.get("type", "?"), healthy=True)
+    return DependentCheck(
+        id=dep["id"], type=dep.get("type", "?"), healthy=False,
+        error=f"unknown verify mode: {verify}",
+    )
+
+
+def _verify_tail_log_no_auth_errors(dep: dict) -> DependentCheck:
+    log_path = Path(dep.get("verify_log", "")).expanduser()
+    window = int(dep.get("verify_window_seconds", 10))
+    if not log_path.exists():
+        # Missing log = can't verify; treat as unhealthy so the operator
+        # is forced to address it, since silently passing would defeat
+        # the whole point of the check.
+        return DependentCheck(
+            id=dep["id"], type=dep.get("type", "?"), healthy=False,
+            error=f"verify_log not found: {log_path}",
+        )
+
+    # Snapshot the file size at the start; only consider lines APPENDED
+    # during the window, so pre-existing auth-failure lines from before
+    # the rotation don't poison the result.
+    try:
+        start_offset = log_path.stat().st_size
+    except OSError as exc:
+        return DependentCheck(
+            id=dep["id"], type=dep.get("type", "?"), healthy=False,
+            error=f"could not stat verify_log: {exc}",
+        )
+
+    deadline = time.monotonic() + window
+    pattern = re.compile(r"authentication failed", re.IGNORECASE)
+    while time.monotonic() < deadline:
+        try:
+            with log_path.open("rb") as f:
+                f.seek(start_offset)
+                new_bytes = f.read()
+        except OSError as exc:
+            return DependentCheck(
+                id=dep["id"], type=dep.get("type", "?"), healthy=False,
+                error=f"could not read verify_log: {exc}",
+            )
+        if pattern.search(new_bytes.decode("utf-8", errors="replace")):
+            return DependentCheck(
+                id=dep["id"], type=dep.get("type", "?"), healthy=False,
+                error=f"saw 'authentication failed' in {log_path} during {window}s window",
+            )
+        time.sleep(0.5)
+    return DependentCheck(id=dep["id"], type=dep.get("type", "?"), healthy=True)
+
+
+# ---------------------------------------------------------------------------
+# Reload
+# ---------------------------------------------------------------------------
+
+def reload_dependent(dep: dict) -> None:
+    """Dispatch on ``dep['type']``. Raises on subprocess failure."""
+    t = dep.get("type")
+    if t == "launchagent":
+        plist = str(Path(dep["plist"]).expanduser())
+        # unload first; if it's not loaded, launchctl returns nonzero —
+        # we tolerate that on unload because the goal-state is "loaded
+        # with new env". load() failure is fatal.
+        subprocess.run(
+            ["launchctl", "unload", plist],
+            check=False, capture_output=True, text=True,
+        )
+        result = subprocess.run(
+            ["launchctl", "load", plist],
+            check=False, capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"launchctl load failed for {dep['id']}: "
+                f"rc={result.returncode} stderr={result.stderr.strip()}"
+            )
+        return
+    if t == "pidfile":
+        pid_path = Path(dep["pidfile"]).expanduser()
+        pid = int(pid_path.read_text().strip())
+        os.kill(pid, signal.SIGHUP)
+        return
+    if t == "manual_restart":
+        return  # informational; verify step is a no-op too
+    raise ValueError(f"unknown cred_dependents type: {t}")
+
+
+# ---------------------------------------------------------------------------
+# .env / yaml writers (moved from factory/cli.py)
+# ---------------------------------------------------------------------------
+
+def rewrite_env_password(env_path: Path, new_password: str) -> None:
+    """Replace (or append) DEVBRAIN_DB_PASSWORD in a .env file."""
+    if env_path.exists():
+        lines = [
+            ln for ln in env_path.read_text().splitlines()
+            if not ln.startswith("DEVBRAIN_DB_PASSWORD=")
+        ]
+    else:
+        lines = []
+    lines.append("")
+    lines.append(f"# Database password — rotated {time.strftime('%Y-%m-%d')}")
+    lines.append(f"DEVBRAIN_DB_PASSWORD={new_password}")
+    env_path.write_text("\n".join(lines) + "\n")
+
+
+def rewrite_yaml_db_password(yaml_path: Path, new_password: str) -> None:
+    """Replace ``password:`` under ``database:`` in config/devbrain.yaml.
+
+    Line-scoped regex rewrite (not a PyYAML round-trip) to preserve
+    comments and key ordering. Raises ValueError if no ``password:`` is
+    found in the database block.
+    """
+    out: list[str] = []
+    in_db_block = False
+    replaced = False
+    for line in yaml_path.read_text().splitlines():
+        if re.match(r"^database:", line):
+            in_db_block = True
+            out.append(line)
+            continue
+        if in_db_block and re.match(r"^  password:", line):
+            out.append(f"  password: {new_password}")
+            replaced = True
+            continue
+        if re.match(r"^[^\s#]", line):
+            in_db_block = False
+        out.append(line)
+    if not replaced:
+        raise ValueError(
+            f"Could not find 'password:' under 'database:' in {yaml_path}"
+        )
+    yaml_path.write_text("\n".join(out) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# DB primitives
+# ---------------------------------------------------------------------------
+
+def _alter_user_password(ctx: RotationContext, current_password: str,
+                         new_password: str) -> None:
+    """Issue ALTER USER. Connects with current_password (so rollback can
+    pass new_password as 'current' and old_password as 'new').
+    """
+    conn = psycopg2.connect(ctx.url(current_password), connect_timeout=5)
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    sql.SQL("ALTER USER {user} PASSWORD {pw}").format(
+                        user=sql.Identifier(ctx.user),
+                        pw=sql.Literal(new_password),
+                    )
+                )
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+def rotate_with_dependents(
+    ctx: RotationContext,
+    new_password: str,
+    *,
+    config: dict,
+    require_all_healthy: bool = True,
+    skip_dependents: bool = False,
+    dry_run: bool = False,
+) -> dict:
+    """Top-level orchestrator. Returns a result dict — the CLI formats it."""
+    dependents = [] if skip_dependents else list_dependents(config)
+
+    # 1) Pre-flight baseline ---------------------------------------------
+    if dependents:
+        baseline = precheck_baseline(dependents)
+        unhealthy = [c for c in baseline if not c.healthy]
+        if unhealthy and require_all_healthy:
+            return {
+                "rolled_back": False,
+                "aborted_baseline": True,
+                "unhealthy": unhealthy,
+            }
+
+    if dry_run:
+        return {
+            "rolled_back": False,
+            "dry_run": True,
+            "would_reload": [d["id"] for d in dependents
+                             if d.get("type") != "manual_restart"],
+            "would_manual": [d["id"] for d in dependents
+                             if d.get("type") == "manual_restart"],
+        }
+
+    # 2) ALTER USER + .env + yaml ----------------------------------------
+    env_snapshot = ctx.env_path.read_bytes() if ctx.env_path.exists() else None
+    yaml_snapshot = ctx.yaml_path.read_bytes()
+    _alter_user_password(ctx, ctx.old_password, new_password)
+    rewrite_env_password(ctx.env_path, new_password)
+    rewrite_yaml_db_password(ctx.yaml_path, new_password)
+
+    # 3) Sanity check with new creds -------------------------------------
+    try:
+        psycopg2.connect(ctx.url(new_password), connect_timeout=5).close()
+    except psycopg2.Error as exc:
+        # New creds don't connect — roll the DB back; restore files.
+        _alter_user_password(ctx, new_password, ctx.old_password)
+        _restore_file(ctx.env_path, env_snapshot)
+        _restore_file(ctx.yaml_path, yaml_snapshot)
+        return {
+            "rolled_back": True,
+            "reason": f"sanity check connect failed: {exc}",
+            "failed": [],
+            "reloaded": [],
+        }
+
+    # 4) Reload + verify each dependent ----------------------------------
+    reloaded: list[DependentCheck] = []
+    manual: list[DependentCheck] = []
+    failed: list[DependentCheck] = []
+    for dep in dependents:
+        if dep.get("type") == "manual_restart":
+            manual.append(DependentCheck(
+                id=dep["id"], type="manual_restart", healthy=True,
+            ))
+            continue
+        try:
+            reload_dependent(dep)
+        except Exception as exc:  # noqa: BLE001 — any reload failure is a failure
+            failed.append(DependentCheck(
+                id=dep["id"], type=dep.get("type", "?"),
+                healthy=False, error=f"reload failed: {exc}",
+            ))
+            break
+        check = verify_dependent(dep)
+        if check.healthy:
+            reloaded.append(check)
+        else:
+            failed.append(check)
+            break
+
+    # 5) Roll back if any dependent failed -------------------------------
+    if failed:
+        _alter_user_password(ctx, new_password, ctx.old_password)
+        _restore_file(ctx.env_path, env_snapshot)
+        _restore_file(ctx.yaml_path, yaml_snapshot)
+        return {
+            "rolled_back": True,
+            "reason": f"dependent verification failed: {failed[0].id}",
+            "failed": failed,
+            "reloaded": reloaded,
+        }
+
+    # 6) Success ---------------------------------------------------------
+    return {
+        "rolled_back": False,
+        "reloaded": reloaded,
+        "manual": manual,
+        "skipped": skip_dependents,
+    }
+
+
+def _restore_file(path: Path, snapshot: bytes | None) -> None:
+    if snapshot is None:
+        if path.exists():
+            path.unlink()
+    else:
+        path.write_bytes(snapshot)

--- a/factory/tests/test_cred_rotate.py
+++ b/factory/tests/test_cred_rotate.py
@@ -209,7 +209,7 @@ def test_full_rotation_happy_path(tmp_path, ctx, monkeypatch):
         c.id == "ingest_daemon" and c.healthy for c in result["reloaded"]
     )
     # New pw works
-    psycopg2.connect(ctx.url(new_pw), connect_timeout=5).close()
+    psycopg2.connect(**ctx.connect_kwargs(new_pw), connect_timeout=5).close()
     # .env was rewritten
     assert f"DEVBRAIN_DB_PASSWORD={new_pw}" in ctx.env_path.read_text()
     # yaml was rewritten
@@ -237,7 +237,15 @@ def test_rotation_rolls_back_on_dependent_verify_failure(
     )
 
     # Force the verifier to report failure regardless of the log state.
-    def fake_verify(dep):
+    # Pre-flight calls with lookback=True; post-reload calls with the
+    # default (lookback=False) — accept both. Use the actual verifier for
+    # pre-flight (so the test's healthy log passes baseline) and force
+    # failure only on the post-reload path.
+    real_verify = cred_rotate.verify_dependent
+
+    def fake_verify(dep, *, lookback=False):
+        if lookback:
+            return real_verify(dep, lookback=True)
         return DependentCheck(
             id=dep["id"], type=dep["type"], healthy=False,
             error="forced failure for test",
@@ -255,9 +263,11 @@ def test_rotation_rolls_back_on_dependent_verify_failure(
     assert ctx.env_path.read_bytes() == env_before
     assert ctx.yaml_path.read_bytes() == yaml_before
     # OLD password works (rollback restored it); NEW does not.
-    psycopg2.connect(ctx.url(TEST_PW_INITIAL), connect_timeout=5).close()
+    psycopg2.connect(
+        **ctx.connect_kwargs(TEST_PW_INITIAL), connect_timeout=5,
+    ).close()
     with pytest.raises(psycopg2.Error):
-        psycopg2.connect(ctx.url(new_pw), connect_timeout=5)
+        psycopg2.connect(**ctx.connect_kwargs(new_pw), connect_timeout=5)
 
 
 # 7
@@ -291,3 +301,280 @@ def test_manual_restart_type_does_not_block_rotation(
     assert "claude_desktop_mcp" in manual_ids
     reloaded_ids = [c.id for c in result["reloaded"]]
     assert "ingest_daemon" in reloaded_ids
+
+
+# 8 — finding 8.b: --skip-dependents bypasses the registry entirely.
+def test_skip_dependents_bypasses_registry(tmp_path, ctx, monkeypatch):
+    log = _make_log(tmp_path)
+    # Even a *broken* dependent (missing log) must not block rotation
+    # when skip_dependents=True.
+    deps_yaml = [{
+        "id": "ingest_daemon", "type": "launchagent",
+        "plist": str(tmp_path / "p.plist"),
+        "verify": "tail_log_no_auth_errors",
+        "verify_log": str(tmp_path / "definitely_not_here.log"),
+        "verify_window_seconds": 1,
+    }]
+    config = {"factory": {"cred_dependents": deps_yaml}}
+
+    subprocess_calls = []
+
+    def track_subprocess(*a, **kw):
+        subprocess_calls.append(a)
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(cred_rotate.subprocess, "run", track_subprocess)
+
+    new_pw = "skip_dep_test_pw_xyz"
+    result = rotate_with_dependents(
+        ctx, new_pw, config=config, skip_dependents=True,
+    )
+    assert result["rolled_back"] is False
+    assert result["skipped"] is True
+    assert result["reloaded"] == []
+    # No launchctl calls — registry was bypassed completely.
+    assert subprocess_calls == []
+    # New password works.
+    psycopg2.connect(**ctx.connect_kwargs(new_pw), connect_timeout=5).close()
+    # log file untouched (was created by _make_log only as a fixture)
+    assert log.exists()
+
+
+# 9 — finding 8.d: require_all_healthy=False proceeds past unhealthy deps.
+def test_no_require_all_healthy_proceeds_past_unhealthy(
+    tmp_path, ctx, monkeypatch,
+):
+    # Pre-flight will see this dep as unhealthy (log doesn't exist).
+    deps_yaml = [{
+        "id": "broken_dep", "type": "launchagent",
+        "plist": str(tmp_path / "broken.plist"),
+        "verify": "tail_log_no_auth_errors",
+        "verify_log": str(tmp_path / "missing.log"),
+        "verify_window_seconds": 1,
+    }]
+    config = {"factory": {"cred_dependents": deps_yaml}}
+    monkeypatch.setattr(
+        cred_rotate.subprocess, "run",
+        lambda *a, **kw: _FakeCompleted(returncode=0),
+    )
+
+    new_pw = "no_require_all_healthy_pw"
+    result = rotate_with_dependents(
+        ctx, new_pw, config=config, require_all_healthy=False,
+    )
+    # Pre-flight didn't abort (no aborted_baseline) but post-reload verify
+    # still fails (missing log) → triggers rollback.
+    assert result.get("aborted_baseline") is not True
+    assert result["rolled_back"] is True
+    # OLD password still works after rollback.
+    psycopg2.connect(
+        **ctx.connect_kwargs(TEST_PW_INITIAL), connect_timeout=5,
+    ).close()
+
+
+# 10 — finding 8.a: sanity-check failure at step 3 triggers full rollback.
+def test_sanity_check_failure_triggers_rollback(tmp_path, ctx, monkeypatch):
+    env_before = ctx.env_path.read_bytes()
+    yaml_before = ctx.yaml_path.read_bytes()
+    config = {"factory": {"cred_dependents": []}}
+
+    real_connect = psycopg2.connect
+    real_alter = cred_rotate._alter_user_password
+    state = {"alter_count": 0, "in_alter": False}
+
+    def wrapped_alter(c, current, new):
+        state["alter_count"] += 1
+        state["in_alter"] = True
+        try:
+            return real_alter(c, current, new)
+        finally:
+            state["in_alter"] = False
+
+    def flaky_connect(*args, **kwargs):
+        # Fail any direct connect that isn't coming from inside
+        # _alter_user_password — that's the sanity check at step 3.
+        if not state["in_alter"]:
+            raise psycopg2.OperationalError("simulated sanity-check failure")
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(cred_rotate, "_alter_user_password", wrapped_alter)
+    monkeypatch.setattr(cred_rotate.psycopg2, "connect", flaky_connect)
+
+    new_pw = "sanity_check_failure_pw"
+    result = rotate_with_dependents(ctx, new_pw, config=config)
+    assert result["rolled_back"] is True
+    assert "sanity check connect failed" in result["reason"]
+    # ALTER USER was issued twice: forward then rollback.
+    assert state["alter_count"] == 2
+    # Files were restored byte-for-byte.
+    assert ctx.env_path.read_bytes() == env_before
+    assert ctx.yaml_path.read_bytes() == yaml_before
+    # OLD password works after rollback (use real_connect — flaky_connect
+    # is still installed via the active monkeypatch).
+    real_connect(
+        **ctx.connect_kwargs(TEST_PW_INITIAL), connect_timeout=5,
+    ).close()
+
+
+# 11 — finding 8.e + finding 5: multi-dep partial-failure rollback
+# re-reloads dependents that already picked up the new (now-reverted) creds.
+def test_multi_dep_partial_failure_re_reloads_on_rollback(
+    tmp_path, ctx, monkeypatch,
+):
+    dep_a = _healthy_launchagent_dep(tmp_path, dep_id="dep_a")
+    dep_b = _healthy_launchagent_dep(tmp_path, dep_id="dep_b")
+    config = {"factory": {"cred_dependents": [dep_a, dep_b]}}
+
+    monkeypatch.setattr(
+        cred_rotate.subprocess, "run",
+        lambda *a, **kw: _FakeCompleted(returncode=0),
+    )
+
+    # Track every reload_dependent call (forward + rollback).
+    reload_calls: list[str] = []
+    real_reload = cred_rotate.reload_dependent
+
+    def tracking_reload(dep):
+        reload_calls.append(dep["id"])
+        return real_reload(dep)
+
+    monkeypatch.setattr(cred_rotate, "reload_dependent", tracking_reload)
+
+    # dep_a verifies healthy; dep_b verifies unhealthy → triggers rollback.
+    real_verify = cred_rotate.verify_dependent
+
+    def selective_verify(dep, *, lookback=False):
+        if lookback:
+            return real_verify(dep, lookback=True)
+        if dep["id"] == "dep_b":
+            return DependentCheck(
+                id=dep["id"], type=dep["type"], healthy=False,
+                error="forced post-reload failure for dep_b",
+            )
+        return real_verify(dep)
+
+    monkeypatch.setattr(cred_rotate, "verify_dependent", selective_verify)
+
+    new_pw = "multi_dep_partial_failure_pw"
+    result = rotate_with_dependents(ctx, new_pw, config=config)
+    assert result["rolled_back"] is True
+    # Forward path reloaded dep_a then dep_b; rollback re-reloaded dep_a
+    # (the one that already picked up the new — now reverted — creds).
+    # dep_b is NOT re-reloaded because it never made it into `reloaded`.
+    assert reload_calls == ["dep_a", "dep_b", "dep_a"]
+    assert "reload_rollback_errors" not in result
+
+
+# 12 — finding 8.f: rollback ALTER USER itself failing surfaces a
+# distinct rollback_failed result instead of propagating the exception.
+def test_rollback_alter_user_failure_returns_rollback_failed(
+    tmp_path, ctx, monkeypatch,
+):
+    config = {"factory": {"cred_dependents": []}}
+
+    real_alter = cred_rotate._alter_user_password
+    real_connect = psycopg2.connect
+    state = {"alter_count": 0, "in_alter": False}
+
+    def alter_then_fail(c, current, new):
+        state["alter_count"] += 1
+        if state["alter_count"] == 1:
+            state["in_alter"] = True
+            try:
+                return real_alter(c, current, new)
+            finally:
+                state["in_alter"] = False
+        raise psycopg2.OperationalError(
+            "simulated rollback ALTER USER failure (transient connectivity)"
+        )
+
+    monkeypatch.setattr(cred_rotate, "_alter_user_password", alter_then_fail)
+
+    # Fail the sanity-check connect to force entry into the rollback
+    # path; allow alter-internal connects (in_alter=True) through.
+    def selective_connect(*args, **kwargs):
+        if state["in_alter"]:
+            return real_connect(*args, **kwargs)
+        raise psycopg2.OperationalError("forced sanity-check failure")
+
+    monkeypatch.setattr(cred_rotate.psycopg2, "connect", selective_connect)
+
+    new_pw = "rollback_failure_test_pw"
+    result = rotate_with_dependents(ctx, new_pw, config=config)
+    assert result.get("rollback_failed") is True
+    assert result["rolled_back"] is False
+    assert "ALTER USER rollback failed" in result["rollback_error"]
+    assert "sanity check connect failed" in result["reason"]
+    assert state["alter_count"] == 2  # forward succeeded, rollback raised
+
+
+# 13 — finding 3 + 6: connect_via_proxy verifier fails closed.
+def test_connect_via_proxy_fails_closed(tmp_path):
+    dep = {
+        "id": "proxy_dep", "type": "launchagent",
+        "verify": "connect_via_proxy",
+    }
+    check = verify_dependent(dep)
+    assert check.healthy is False
+    assert "not implemented" in (check.error or "").lower()
+
+
+# 14 — finding 4: pre-flight catches pre-existing auth-failure churn
+# in the log tail (the 18-day stale-creds incident this feature exists
+# to prevent), even when no retry happens during the verify window.
+def test_precheck_lookback_catches_existing_auth_failure_in_log(tmp_path):
+    log = tmp_path / "ingest.err.log"
+    # Pre-existing auth failure from BEFORE the rotation window starts.
+    log.write_text(
+        "2026-04-25 03:14:07 psycopg2.OperationalError: FATAL: "
+        "authentication failed for user devbrain\n"
+    )
+    dep = {
+        "id": "stale_creds_dep", "type": "launchagent",
+        "plist": str(tmp_path / "p.plist"),
+        "verify": "tail_log_no_auth_errors",
+        "verify_log": str(log),
+        # 0-second window so the test doesn't wait — lookback alone must
+        # be sufficient to catch the existing entry.
+        "verify_window_seconds": 0,
+    }
+    checks = precheck_baseline([dep])
+    assert checks[0].healthy is False
+    assert "authentication failed" in (checks[0].error or "")
+    # Post-reload verify (lookback=False) must NOT flag pre-existing
+    # entries — otherwise rotation could never succeed against a daemon
+    # that had any prior auth failure.
+    post = verify_dependent(dep)
+    assert post.healthy is True
+
+
+# 15 — finding 8.c: --current-password is a flag (no value), prompts
+# securely for the password, never accepts it on the command line.
+def test_current_password_flag_prompts_and_never_takes_value():
+    """The CLI option must NOT accept a string value.
+
+    Regression guard: a value-taking option leaks the password into
+    `ps aux`, shell history, and process-monitoring captures. Verify the
+    option's Click metadata is `is_flag=True` so passing
+    `--current-password VALUE` is rejected.
+    """
+    from click.testing import CliRunner
+
+    from cli import cli as devbrain_cli
+
+    runner = CliRunner()
+    # Locate the param on the command.
+    rotate_cmd = devbrain_cli.commands["rotate-db-password"]
+    cur_param = next(
+        p for p in rotate_cmd.params
+        if "--current-password" in p.opts
+    )
+    assert cur_param.is_flag is True, (
+        "--current-password must be a flag (no value) so the password "
+        "never appears in `ps aux` or shell history"
+    )
+    # Help text warns operators against passing the password.
+    result = runner.invoke(devbrain_cli, ["rotate-db-password", "--help"])
+    assert result.exit_code == 0
+    assert "WARNING" in result.output
+    assert "ps aux" in result.output

--- a/factory/tests/test_cred_rotate.py
+++ b/factory/tests/test_cred_rotate.py
@@ -1,0 +1,293 @@
+"""Tests for atomic credential rotation (factory/cred_rotate.py).
+
+Real Postgres but on a throwaway test role; LaunchAgent / launchctl
+calls are mocked. Filesystem state lives entirely in tmp_path so the
+real .env / config/devbrain.yaml are never touched.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import psycopg2
+import pytest
+from psycopg2 import sql
+
+import cred_rotate
+from config import DATABASE_URL
+from cred_rotate import (
+    DependentCheck,
+    RotationContext,
+    precheck_baseline,
+    reload_dependent,
+    rotate_with_dependents,
+    verify_dependent,
+)
+
+TEST_ROLE = "cred_rotate_test_user"
+TEST_PW_INITIAL = "cred_rotate_test_pw_initial"
+
+
+@dataclass
+class _FakeCompleted:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+def _admin_conn():
+    return psycopg2.connect(DATABASE_URL)
+
+
+@pytest.fixture
+def test_role():
+    """Create a throwaway Postgres role for the rotation, drop it after."""
+    with _admin_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("DROP ROLE IF EXISTS {r}").format(r=sql.Identifier(TEST_ROLE))
+        )
+        cur.execute(
+            sql.SQL("CREATE ROLE {r} LOGIN PASSWORD {pw}").format(
+                r=sql.Identifier(TEST_ROLE), pw=sql.Literal(TEST_PW_INITIAL),
+            )
+        )
+        conn.commit()
+    yield TEST_ROLE
+    with _admin_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("DROP ROLE IF EXISTS {r}").format(r=sql.Identifier(TEST_ROLE))
+        )
+        conn.commit()
+
+
+@pytest.fixture
+def ctx(tmp_path, test_role):
+    """RotationContext pointing at the test role + tmp env/yaml files."""
+    env_path = tmp_path / ".env"
+    yaml_path = tmp_path / "devbrain.yaml"
+    env_path.write_text(f"DEVBRAIN_DB_PASSWORD={TEST_PW_INITIAL}\n")
+    yaml_path.write_text(
+        "database:\n"
+        "  host: localhost\n"
+        "  port: 5433\n"
+        f"  user: {TEST_ROLE}\n"
+        f"  password: {TEST_PW_INITIAL}\n"
+        "  database: devbrain\n"
+    )
+    return RotationContext(
+        user=TEST_ROLE, host="localhost", port=5433, database="devbrain",
+        old_password=TEST_PW_INITIAL, env_path=env_path, yaml_path=yaml_path,
+    )
+
+
+def _make_log(tmp_path: Path, content: str = "") -> Path:
+    p = tmp_path / "ingest.err.log"
+    p.write_text(content)
+    return p
+
+
+def _healthy_launchagent_dep(tmp_path, dep_id="ingest_daemon"):
+    return {
+        "id": dep_id,
+        "type": "launchagent",
+        "label": f"com.devbrain.{dep_id}",
+        "plist": str(tmp_path / f"{dep_id}.plist"),
+        "verify": "tail_log_no_auth_errors",
+        "verify_log": str(_make_log(tmp_path)),
+        "verify_window_seconds": 1,
+    }
+
+
+# 1
+def test_baseline_passes_with_healthy_dependents(tmp_path):
+    deps = [_healthy_launchagent_dep(tmp_path)]
+    checks = precheck_baseline(deps)
+    assert all(c.healthy for c in checks)
+    assert checks[0].id == "ingest_daemon"
+
+
+# 2
+def test_baseline_fails_loud_when_dependent_unhealthy(tmp_path, ctx, monkeypatch):
+    # Point verify_log at a path that doesn't exist — the verifier flags
+    # this as unhealthy with a clear error (per the edge-case spec). A
+    # pre-populated "authentication failed" line wouldn't work because
+    # the verifier snapshots start_offset = file size first to ignore
+    # entries from before the rotation window.
+    missing_log = tmp_path / "definitely_not_here" / "ingest.err.log"
+    deps_yaml = [{
+        "id": "ingest_daemon",
+        "type": "launchagent",
+        "plist": str(tmp_path / "p.plist"),
+        "verify": "tail_log_no_auth_errors",
+        "verify_log": str(missing_log),
+        "verify_window_seconds": 1,
+    }]
+    config = {"factory": {"cred_dependents": deps_yaml}}
+    altered = []
+
+    def trip_alter(*a, **kw):
+        altered.append(a)
+
+    monkeypatch.setattr(cred_rotate, "_alter_user_password", trip_alter)
+
+    result = rotate_with_dependents(
+        ctx, "newpw_unused", config=config, require_all_healthy=True,
+    )
+    assert result.get("aborted_baseline") is True
+    assert any(
+        c.id == "ingest_daemon" and not c.healthy for c in result["unhealthy"]
+    )
+    assert altered == []  # never touched the DB
+
+
+# 3
+def test_reload_launchagent_invokes_unload_then_load(tmp_path, monkeypatch):
+    plist = tmp_path / "com.devbrain.ingest.plist"
+    plist.write_text("<dummy/>")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(cred_rotate.subprocess, "run", fake_run)
+    reload_dependent({"id": "x", "type": "launchagent", "plist": str(plist)})
+    assert len(calls) == 2
+    assert calls[0][:2] == ["launchctl", "unload"]
+    assert calls[1][:2] == ["launchctl", "load"]
+    assert calls[0][2] == str(plist)
+    assert calls[1][2] == str(plist)
+
+
+# 4
+def test_verify_tail_log_detects_auth_failures(tmp_path):
+    log = tmp_path / "ingest.err.log"
+    log.write_text("")  # start empty so the verifier's start_offset = 0
+
+    dep = {
+        "id": "ingest_daemon", "type": "launchagent",
+        "verify": "tail_log_no_auth_errors",
+        "verify_log": str(log), "verify_window_seconds": 2,
+    }
+
+    # Append an auth-failure mid-window to simulate a daemon that came
+    # back up but couldn't reauthenticate.
+    def append_after_delay():
+        time.sleep(0.5)
+        with log.open("a") as f:
+            f.write(
+                "psycopg2.OperationalError: FATAL: "
+                "authentication failed for user devbrain\n"
+            )
+
+    threading.Thread(target=append_after_delay, daemon=True).start()
+    check = verify_dependent(dep)
+    assert check.healthy is False
+    assert "authentication failed" in (check.error or "")
+
+
+# 5
+def test_full_rotation_happy_path(tmp_path, ctx, monkeypatch):
+    log = _make_log(tmp_path)  # empty — no auth-failure lines ever appear
+    deps_yaml = [{
+        "id": "ingest_daemon", "type": "launchagent",
+        "plist": str(tmp_path / "p.plist"),
+        "verify": "tail_log_no_auth_errors",
+        "verify_log": str(log), "verify_window_seconds": 1,
+    }]
+    config = {"factory": {"cred_dependents": deps_yaml}}
+    monkeypatch.setattr(
+        cred_rotate.subprocess, "run",
+        lambda *a, **kw: _FakeCompleted(returncode=0),
+    )
+    new_pw = "rotation_test_new_password_xyz"
+    result = rotate_with_dependents(ctx, new_pw, config=config)
+    assert result["rolled_back"] is False
+    assert any(
+        c.id == "ingest_daemon" and c.healthy for c in result["reloaded"]
+    )
+    # New pw works
+    psycopg2.connect(ctx.url(new_pw), connect_timeout=5).close()
+    # .env was rewritten
+    assert f"DEVBRAIN_DB_PASSWORD={new_pw}" in ctx.env_path.read_text()
+    # yaml was rewritten
+    assert f"password: {new_pw}" in ctx.yaml_path.read_text()
+
+
+# 6
+def test_rotation_rolls_back_on_dependent_verify_failure(
+    tmp_path, ctx, monkeypatch,
+):
+    env_before = ctx.env_path.read_bytes()
+    yaml_before = ctx.yaml_path.read_bytes()
+
+    deps_yaml = [{
+        "id": "ingest_daemon", "type": "launchagent",
+        "plist": str(tmp_path / "p.plist"),
+        "verify": "tail_log_no_auth_errors",
+        "verify_log": str(_make_log(tmp_path)),
+        "verify_window_seconds": 1,
+    }]
+    config = {"factory": {"cred_dependents": deps_yaml}}
+    monkeypatch.setattr(
+        cred_rotate.subprocess, "run",
+        lambda *a, **kw: _FakeCompleted(returncode=0),
+    )
+
+    # Force the verifier to report failure regardless of the log state.
+    def fake_verify(dep):
+        return DependentCheck(
+            id=dep["id"], type=dep["type"], healthy=False,
+            error="forced failure for test",
+        )
+
+    monkeypatch.setattr(cred_rotate, "verify_dependent", fake_verify)
+
+    new_pw = "test_password_should_be_rolled_back"
+    result = rotate_with_dependents(
+        ctx, new_pw, config=config, require_all_healthy=False,
+    )
+    assert result["rolled_back"] is True
+    assert "ingest_daemon" in result["reason"]
+    # Files reverted byte-for-byte
+    assert ctx.env_path.read_bytes() == env_before
+    assert ctx.yaml_path.read_bytes() == yaml_before
+    # OLD password works (rollback restored it); NEW does not.
+    psycopg2.connect(ctx.url(TEST_PW_INITIAL), connect_timeout=5).close()
+    with pytest.raises(psycopg2.Error):
+        psycopg2.connect(ctx.url(new_pw), connect_timeout=5)
+
+
+# 7
+def test_manual_restart_type_does_not_block_rotation(
+    tmp_path, ctx, monkeypatch,
+):
+    deps_yaml = [
+        {
+            "id": "claude_desktop_mcp",
+            "type": "manual_restart",
+        },
+        {
+            "id": "ingest_daemon", "type": "launchagent",
+            "plist": str(tmp_path / "p.plist"),
+            "verify": "tail_log_no_auth_errors",
+            "verify_log": str(_make_log(tmp_path)),
+            "verify_window_seconds": 1,
+        },
+    ]
+    config = {"factory": {"cred_dependents": deps_yaml}}
+    monkeypatch.setattr(
+        cred_rotate.subprocess, "run",
+        lambda *a, **kw: _FakeCompleted(returncode=0),
+    )
+
+    result = rotate_with_dependents(
+        ctx, "another_test_password_abc", config=config,
+    )
+    assert result["rolled_back"] is False
+    manual_ids = [c.id for c in result["manual"]]
+    assert "claude_desktop_mcp" in manual_ids
+    reloaded_ids = [c.id for c in result["reloaded"]]
+    assert "ingest_daemon" in reloaded_ids


### PR DESCRIPTION
Closes the 18-day stale-cred drift surfaced earlier today. `devbrain rotate-db-password` now reloads registered cred-dependent processes (LaunchAgents, pidfile-based daemons) after rotating Postgres + .env + yaml, verifies each post-reload, and rolls back atomically if any verify fails. Manual-restart dependents (Claude Desktop MCP, shells with DEVBRAIN_DB_PASSWORD exported) reported but non-blocking.

Factory job cbe001e8 — TWO fix-loops (round 1: 5 arch + 3 sec WARNINGs, round 2: 2 arch WARNINGs, round 3: clean). 1308 lines across 6 files, 17 tests.

Default config ships with the `ingest_daemon` LaunchAgent entry so fresh installs get auto-reload coverage. INSTALL.md updated with rotation hygiene subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)