### PR TITLE
feat(memory): switch reads to devbrain.memory — P2.d.i (task #25)

### DIFF
--- a/factory/backfill_memory.py
+++ b/factory/backfill_memory.py
@@ -54,6 +54,7 @@ dump multi-megabyte transcripts into `memory.content`.
 """
 from __future__ import annotations
 
+import json
 import logging
 import time
 
@@ -62,8 +63,9 @@ logger = logging.getLogger(__name__)
 
 _INSERT_MEMORY_SQL = """
     INSERT INTO devbrain.memory
-        (project_id, kind, title, content, embedding, provenance_id, created_at)
-    VALUES (%s, %s, %s, %s, %s::vector, %s, %s)
+        (project_id, kind, title, content, embedding, provenance_id,
+         created_at, applies_when)
+    VALUES (%s, %s, %s, %s, %s::vector, %s, %s, %s::jsonb)
     ON CONFLICT (provenance_id, kind) WHERE provenance_id IS NOT NULL
     DO NOTHING
 """
@@ -215,7 +217,7 @@ def _run_batched_backfill(
             and ordered `id ASC`. Must return rows whose first column is
             the legacy id (used to advance `last_id`).
         row_to_insert_args: callable(row, counts) -> tuple|None.
-            Returns the args tuple for `_INSERT_MEMORY_SQL` (7 values),
+            Returns the args tuple for `_INSERT_MEMORY_SQL` (8 values),
             or None to skip this row (e.g., NULL project / NULL summary).
             Also responsible for incrementing skip counters in `counts`.
         batch_size: rows per batch.
@@ -359,7 +361,7 @@ def backfill_chunks(
             return None
         return (
             str(project_id), "chunk", None, content, embedding_text,
-            str(chunk_id), created_at,
+            str(chunk_id), created_at, None,
         )
 
     return _run_batched_backfill(
@@ -402,7 +404,7 @@ def backfill_decisions(
             return None
         return (
             str(project_id), "decision", title, decision_text, None,
-            str(decision_id), created_at,
+            str(decision_id), created_at, None,
         )
 
     return _run_batched_backfill(
@@ -423,14 +425,42 @@ def backfill_patterns(
     """Backfill kind='pattern' from devbrain.patterns.
 
     title = name[:80] (legacy `name` is varchar(255)); content =
-    description.
+    description. legacy `category` (e.g. 'factory_review') is mirrored
+    into `applies_when = {"category": <category>}` so the canonical
+    Phase-3 filter in factory/learning.py (get_review_lessons /
+    _store_lessons dedup) selects exactly the rows it would have
+    selected against the legacy `patterns.category` column. Without
+    this, every pre-P2.b factory_review pattern (and any pattern
+    dual-written before applies_when was added) lands with
+    applies_when=NULL and is invisible to the new filter — and
+    re-running backfill won't rescue them because ON CONFLICT DO
+    NOTHING leaves the untagged row in place.
     """
     _ensure_schema(db)
     if dry_run:
         return _dry_run_counts(db, table="patterns", kind="pattern")
 
+    # One-shot recovery for memory rows already backfilled (or
+    # dual-written) before applies_when was being propagated. Scoped
+    # tightly: only fills rows where applies_when IS NULL and the
+    # legacy patterns row has a non-null category — never overwrites
+    # an existing tag.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE devbrain.memory m
+               SET applies_when = jsonb_build_object('category', p.category)
+              FROM devbrain.patterns p
+             WHERE m.kind = 'pattern'
+               AND m.provenance_id = p.id
+               AND m.applies_when IS NULL
+               AND p.category IS NOT NULL
+            """
+        )
+        conn.commit()
+
     select_sql = """
-        SELECT id, project_id, name, description, created_at
+        SELECT id, project_id, name, description, created_at, category
         FROM devbrain.patterns
         WHERE id > %s
         ORDER BY id
@@ -438,14 +468,19 @@ def backfill_patterns(
     """
 
     def to_args(row, counts):
-        pattern_id, project_id, name, description, created_at = row
+        (
+            pattern_id, project_id, name, description, created_at, category,
+        ) = row
         if project_id is None:
             counts["skipped_no_project"] += 1
             return None
         title = (name or "")[:80] or None
+        applies_when = (
+            json.dumps({"category": category}) if category else None
+        )
         return (
             str(project_id), "pattern", title, description, None,
-            str(pattern_id), created_at,
+            str(pattern_id), created_at, applies_when,
         )
 
     return _run_batched_backfill(
@@ -486,7 +521,7 @@ def backfill_issues(
             return None
         return (
             str(project_id), "issue", title, description, None,
-            str(issue_id), created_at,
+            str(issue_id), created_at, None,
         )
 
     return _run_batched_backfill(
@@ -539,7 +574,7 @@ def backfill_raw_sessions(
         title = summary[:80]
         return (
             str(project_id), "session_summary", title, summary, None,
-            str(session_id), created_at,
+            str(session_id), created_at, None,
         )
 
     return _run_batched_backfill(

--- a/factory/backfill_memory.py
+++ b/factory/backfill_memory.py
@@ -123,6 +123,7 @@ def _dry_run_counts(
     table: str,
     kind: str,
     extra_skip_predicate: str = "",
+    scan_where: str = "",
 ) -> dict:
     """Read-only counts that approximate what a real backfill would do.
 
@@ -138,23 +139,32 @@ def _dry_run_counts(
         extra_skip_predicate: optional extra WHERE clause for the
             "rows we would skip" branch (raw_sessions uses this for
             the summary-NULL guard).
+        scan_where: optional WHERE clause that restricts every count in
+            this dry-run to the same row population the live SELECT
+            would fetch (used by chunks to exclude auxiliary
+            source_types). Applied to scanned, skipped_no_project,
+            skipped_no_summary, and would_insert.
     """
     counts = _new_counts()
     fq_table = f"devbrain.{table}"
+    scan_clause = f" WHERE {scan_where}" if scan_where else ""
+    scan_and = f" AND {scan_where}" if scan_where else ""
 
     with db._conn() as conn, conn.cursor() as cur:
-        cur.execute(f"SELECT count(*) FROM {fq_table}")
+        cur.execute(f"SELECT count(*) FROM {fq_table}{scan_clause}")
         counts["scanned"] = int(cur.fetchone()[0])
 
         cur.execute(
-            f"SELECT count(*) FROM {fq_table} WHERE project_id IS NULL"
+            f"SELECT count(*) FROM {fq_table} "
+            f"WHERE project_id IS NULL{scan_and}"
         )
         counts["skipped_no_project"] = int(cur.fetchone()[0])
 
         if extra_skip_predicate:
             cur.execute(
                 f"SELECT count(*) FROM {fq_table} "
-                f"WHERE project_id IS NOT NULL AND ({extra_skip_predicate})"
+                f"WHERE project_id IS NOT NULL AND "
+                f"({extra_skip_predicate}){scan_and}"
             )
             counts["skipped_no_summary"] = int(cur.fetchone()[0])
 
@@ -164,7 +174,7 @@ def _dry_run_counts(
         cur.execute(
             f"""
             SELECT count(*) FROM {fq_table} t
-            WHERE t.project_id IS NOT NULL{anti_join_extra}
+            WHERE t.project_id IS NOT NULL{anti_join_extra}{scan_and}
               AND NOT EXISTS (
                   SELECT 1 FROM devbrain.memory m
                   WHERE m.provenance_id = t.id AND m.kind = %s
@@ -297,6 +307,21 @@ def _run_batched_backfill(
 # ─── Per-table backfills ─────────────────────────────────────────────────────
 
 
+# Auxiliary chunk rows that store()/_store_lessons()/end_session insert
+# alongside a primary entity. Excluded from the chunks→memory backfill
+# because each already has a primary memory row via the P2.b dual-write
+# (decision/pattern/issue from store(), session_summary from
+# end_session); inserting a kind='chunk' row from the auxiliary chunks
+# row would create a second memory row with the same content but a
+# different (provenance_id, kind) tuple — the unique index can't
+# collapse them, so deep_search would surface both and eat its LIMIT
+# budget.
+_CHUNK_BACKFILL_WHERE = (
+    "(source_type IS NULL OR source_type NOT IN "
+    "('decision','pattern','issue','session_summary'))"
+)
+
+
 def backfill_chunks(
     db,
     *,
@@ -306,16 +331,23 @@ def backfill_chunks(
     """Backfill kind='chunk' from devbrain.chunks.
 
     Reuses the legacy embedding via `embedding::text` → `%s::vector`.
-    Skips rows with project_id IS NULL.
+    Skips rows with project_id IS NULL and rows whose source_type
+    indicates an auxiliary insert (see _CHUNK_BACKFILL_WHERE).
     """
     _ensure_schema(db)
     if dry_run:
-        return _dry_run_counts(db, table="chunks", kind="chunk")
+        return _dry_run_counts(
+            db,
+            table="chunks",
+            kind="chunk",
+            scan_where=_CHUNK_BACKFILL_WHERE,
+        )
 
-    select_sql = """
+    select_sql = f"""
         SELECT id, project_id, content, embedding::text, created_at
         FROM devbrain.chunks
         WHERE id > %s
+          AND {_CHUNK_BACKFILL_WHERE}
         ORDER BY id
         LIMIT %s
     """
@@ -335,7 +367,7 @@ def backfill_chunks(
         select_sql=select_sql,
         row_to_insert_args=to_args,
         batch_size=batch_size,
-        skip_filters=["project_id IS NULL"],
+        skip_filters=["project_id IS NULL", _CHUNK_BACKFILL_WHERE],
     )
 
 

--- a/factory/backfill_memory.py
+++ b/factory/backfill_memory.py
@@ -435,16 +435,24 @@ def backfill_patterns(
     applies_when=NULL and is invisible to the new filter — and
     re-running backfill won't rescue them because ON CONFLICT DO
     NOTHING leaves the untagged row in place.
+
+    Embedding reuse: the legacy patterns table has no embedding
+    column, but store() also inserts an auxiliary devbrain.chunks
+    row (source_type='pattern', source_id=p.id) carrying the
+    embedding. LEFT JOIN that aux chunk so memory.embedding is
+    populated; otherwise the dedup SELECT in
+    factory/learning.py:_store_lessons (filters
+    `embedding IS NOT NULL`) skips backfilled rows and the
+    accompanying drift detector falsely fires.
     """
     _ensure_schema(db)
     if dry_run:
         return _dry_run_counts(db, table="patterns", kind="pattern")
 
     # One-shot recovery for memory rows already backfilled (or
-    # dual-written) before applies_when was being propagated. Scoped
-    # tightly: only fills rows where applies_when IS NULL and the
-    # legacy patterns row has a non-null category — never overwrites
-    # an existing tag.
+    # dual-written) before applies_when / embedding fill were being
+    # propagated. Scoped tightly: only fills NULL columns, never
+    # overwrites existing values.
     with db._conn() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -457,19 +465,34 @@ def backfill_patterns(
                AND p.category IS NOT NULL
             """
         )
+        cur.execute(
+            """
+            UPDATE devbrain.memory m
+               SET embedding = c.embedding
+              FROM devbrain.chunks c
+             WHERE m.kind = 'pattern'
+               AND m.embedding IS NULL
+               AND c.source_type = 'pattern'
+               AND c.source_id = m.provenance_id
+            """
+        )
         conn.commit()
 
     select_sql = """
-        SELECT id, project_id, name, description, created_at, category
-        FROM devbrain.patterns
-        WHERE id > %s
-        ORDER BY id
+        SELECT p.id, p.project_id, p.name, p.description, p.created_at,
+               p.category, c.embedding::text
+        FROM devbrain.patterns p
+        LEFT JOIN devbrain.chunks c
+          ON c.source_type = 'pattern' AND c.source_id = p.id
+        WHERE p.id > %s
+        ORDER BY p.id
         LIMIT %s
     """
 
     def to_args(row, counts):
         (
             pattern_id, project_id, name, description, created_at, category,
+            embedding_text,
         ) = row
         if project_id is None:
             counts["skipped_no_project"] += 1
@@ -479,7 +502,7 @@ def backfill_patterns(
             json.dumps({"category": category}) if category else None
         )
         return (
-            str(project_id), "pattern", title, description, None,
+            str(project_id), "pattern", title, description, embedding_text,
             str(pattern_id), created_at, applies_when,
         )
 

--- a/factory/learning.py
+++ b/factory/learning.py
@@ -183,15 +183,23 @@ def _store_lessons(
     """Store lessons as patterns, deduplicating by semantic similarity."""
     stored = []
 
-    # Get existing factory_review pattern embeddings for comparison
+    # P2.d.i read switch: existing-pattern dedup reads embeddings from
+    # devbrain.memory (kind='pattern') instead of the chunks JOIN
+    # patterns shape used pre-switch. The applies_when filter is the
+    # canonical Phase-3 marker; until the curator populates it the
+    # content-LIKE fallback finds factory_review lessons by their
+    # serialized "Context: …" tail.
     with conn.cursor() as cur:
         cur.execute(
-            """SELECT c.embedding::text, c.content
-               FROM devbrain.chunks c
-               JOIN devbrain.patterns p ON c.source_id = p.id AND c.source_type = 'pattern'
-               WHERE p.project_id = %s AND p.category = 'factory_review'
-               AND c.embedding IS NOT NULL""",
-            (project_id,),
+            """SELECT embedding::text, content
+               FROM devbrain.memory
+               WHERE project_id = %s
+                 AND kind = 'pattern'
+                 AND archived_at IS NULL
+                 AND embedding IS NOT NULL
+                 AND (applies_when->>'category' = 'factory_review'
+                      OR content LIKE %s)""",
+            (project_id, "%Context: %"),
         )
         existing = []
         for row in cur.fetchall():
@@ -201,6 +209,25 @@ def _store_lessons(
                     "embedding": [float(x) for x in vec_str.split(",")],
                     "content": row[1],
                 })
+
+        # Dual-write drift detector: if memory returned nothing but the
+        # legacy patterns table has factory_review rows, the dual-write
+        # has fallen behind for this project. Surface as WARNING so
+        # operators can rerun backfill before P2.d.ii drops legacy.
+        if not existing:
+            cur.execute(
+                """SELECT 1 FROM devbrain.patterns
+                   WHERE project_id = %s AND category = 'factory_review'
+                   LIMIT 1""",
+                (project_id,),
+            )
+            if cur.fetchone() is not None:
+                logger.warning(
+                    "dual-write drift: devbrain.memory returned 0 "
+                    "factory_review patterns for project %s but legacy "
+                    "devbrain.patterns has rows — run backfill-memory",
+                    project_id,
+                )
 
     for lesson in lessons:
         text = lesson["lesson"]
@@ -282,18 +309,47 @@ def _store_lessons(
 
 
 def get_review_lessons(project_id: str, limit: int = 10) -> list[str]:
-    """Get stored review lessons for a project, for injection into planning prompts."""
+    """Get stored review lessons for a project, for injection into planning prompts.
+
+    P2.d.i: reads from devbrain.memory (kind='pattern') instead of the
+    legacy patterns table. applies_when->>'category' is the canonical
+    Phase-3 marker; the content-LIKE fallback bridges until the curator
+    populates applies_when on every row. Returns content from the
+    memory row (P2.b dual-write writes the same description).
+    """
     conn = psycopg2.connect(DATABASE_URL)
     try:
         with conn.cursor() as cur:
             cur.execute(
-                """SELECT p.description
-                   FROM devbrain.patterns p
-                   WHERE p.project_id = %s AND p.category = 'factory_review'
-                   ORDER BY p.created_at DESC
+                """SELECT content
+                   FROM devbrain.memory
+                   WHERE project_id = %s
+                     AND kind = 'pattern'
+                     AND archived_at IS NULL
+                     AND (applies_when->>'category' = 'factory_review'
+                          OR content LIKE %s)
+                   ORDER BY created_at DESC
                    LIMIT %s""",
-                (project_id, limit),
+                (project_id, "%Context: %", limit),
             )
-            return [row[0] for row in cur.fetchall()]
+            results = [row[0] for row in cur.fetchall()]
+
+            # Dual-write drift detector — see _store_lessons for context.
+            if not results:
+                cur.execute(
+                    """SELECT 1 FROM devbrain.patterns
+                       WHERE project_id = %s AND category = 'factory_review'
+                       LIMIT 1""",
+                    (project_id,),
+                )
+                if cur.fetchone() is not None:
+                    logger.warning(
+                        "dual-write drift: devbrain.memory returned 0 "
+                        "factory_review lessons for project %s but legacy "
+                        "devbrain.patterns has rows — run backfill-memory",
+                        project_id,
+                    )
+
+            return results
     finally:
         conn.close()

--- a/factory/learning.py
+++ b/factory/learning.py
@@ -185,10 +185,12 @@ def _store_lessons(
 
     # P2.d.i read switch: existing-pattern dedup reads embeddings from
     # devbrain.memory (kind='pattern') instead of the chunks JOIN
-    # patterns shape used pre-switch. The applies_when filter is the
-    # canonical Phase-3 marker; until the curator populates it the
-    # content-LIKE fallback finds factory_review lessons by their
-    # serialized "Context: …" tail.
+    # patterns shape used pre-switch. applies_when->>'category' is set
+    # by the dual-write below so the canonical filter selects exactly
+    # the factory_review lessons — no content-LIKE fallback needed
+    # (which would false-positive on any user-stored pattern containing
+    # the word "Context:" and silently drop a real lesson via the
+    # similarity dedup loop).
     with conn.cursor() as cur:
         cur.execute(
             """SELECT embedding::text, content
@@ -197,9 +199,8 @@ def _store_lessons(
                  AND kind = 'pattern'
                  AND archived_at IS NULL
                  AND embedding IS NOT NULL
-                 AND (applies_when->>'category' = 'factory_review'
-                      OR content LIKE %s)""",
-            (project_id, "%Context: %"),
+                 AND applies_when->>'category' = 'factory_review'""",
+            (project_id,),
         )
         existing = []
         for row in cur.fetchall():
@@ -273,7 +274,9 @@ def _store_lessons(
             # the pattern (not the auxiliary chunk insert below) so each
             # logical lesson lands as exactly one memory row. SAVEPOINT
             # inside record_memory keeps a memory failure from rolling
-            # back the pattern + chunk legacy commit.
+            # back the pattern + chunk legacy commit. applies_when tags
+            # the row as a factory_review lesson — that's the canonical
+            # filter the dedup query and get_review_lessons select on.
             record_memory(
                 cur,
                 project_id=project_id,
@@ -282,6 +285,7 @@ def _store_lessons(
                 title=text[:100],
                 embedding_sql=vector_str,
                 provenance_id=pattern_id,
+                applies_when={"category": "factory_review"},
             )
 
             cur.execute(
@@ -313,9 +317,9 @@ def get_review_lessons(project_id: str, limit: int = 10) -> list[str]:
 
     P2.d.i: reads from devbrain.memory (kind='pattern') instead of the
     legacy patterns table. applies_when->>'category' is the canonical
-    Phase-3 marker; the content-LIKE fallback bridges until the curator
-    populates applies_when on every row. Returns content from the
-    memory row (P2.b dual-write writes the same description).
+    Phase-3 marker, set by _store_lessons on dual-write so this filter
+    selects exactly the factory_review lessons. Returns content from
+    the memory row (P2.b dual-write writes the same description).
     """
     conn = psycopg2.connect(DATABASE_URL)
     try:
@@ -326,11 +330,10 @@ def get_review_lessons(project_id: str, limit: int = 10) -> list[str]:
                    WHERE project_id = %s
                      AND kind = 'pattern'
                      AND archived_at IS NULL
-                     AND (applies_when->>'category' = 'factory_review'
-                          OR content LIKE %s)
+                     AND applies_when->>'category' = 'factory_review'
                    ORDER BY created_at DESC
                    LIMIT %s""",
-                (project_id, "%Context: %", limit),
+                (project_id, limit),
             )
             results = [row[0] for row in cur.fetchall()]
 

--- a/factory/tests/test_read_switch_to_memory.py
+++ b/factory/tests/test_read_switch_to_memory.py
@@ -1,0 +1,534 @@
+"""Tests for P2.d.i — switch read paths from legacy tables to devbrain.memory.
+
+Mirrors the test_dual_write.py setup: rows are content-prefixed so a
+single LIKE-cleanup fixture wipes them, and the seeded 'devbrain'
+project is used as the FK target instead of a throwaway project per
+test.
+
+Two halves:
+
+  - The factory/learning.py read path (get_review_lessons +
+    _store_lessons dedup) is exercised in-process via the imported
+    function, with caplog asserting the dual-write drift WARNING fires
+    when memory is empty but legacy has rows.
+
+  - The mcp-server/src/index.ts read path (deep_search and
+    health_check) is verified by issuing the same SQL shape via
+    psycopg2 — there is no Python test harness for the TS server.
+    The asserted invariants (memory rows visible, archived rows hidden,
+    legacy-only rows hidden, codebase falls back to legacy chunks) are
+    the contract those queries are meant to enforce, regardless of
+    transport.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+# Mirror the production sys.path layout.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent.parent / "ingest")
+)
+
+from config import DATABASE_URL  # noqa: E402  (factory/config.py)
+from state_machine import FactoryDB  # noqa: E402
+
+import learning  # noqa: E402  (factory/learning.py)
+
+TEST_CONTENT_PREFIX = "read_switch_test_"
+
+
+@pytest.fixture
+def db():
+    return FactoryDB(DATABASE_URL)
+
+
+_THROWAWAY_PROJECT_SLUG = f"{TEST_CONTENT_PREFIX}project"
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        # Order matters — child rows (memory/chunks/patterns/etc.) carry
+        # FKs to projects, so wipe content-prefixed rows first then drop
+        # the throwaway project last.
+        cur.execute(
+            "DELETE FROM devbrain.memory WHERE content LIKE %s",
+            (f"{TEST_CONTENT_PREFIX}%",),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.chunks WHERE content LIKE %s",
+            (f"{TEST_CONTENT_PREFIX}%",),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.patterns WHERE description LIKE %s",
+            (f"{TEST_CONTENT_PREFIX}%",),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.decisions "
+            "WHERE title LIKE %s OR context LIKE %s",
+            (f"{TEST_CONTENT_PREFIX}%", f"{TEST_CONTENT_PREFIX}%"),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.issues WHERE description LIKE %s",
+            (f"{TEST_CONTENT_PREFIX}%",),
+        )
+        # Wipe any rows still attached to the throwaway project before
+        # the project DELETE — the FK is RESTRICT, not CASCADE.
+        cur.execute(
+            "SELECT id FROM devbrain.projects WHERE slug = %s",
+            (_THROWAWAY_PROJECT_SLUG,),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            tp_id = row[0]
+            for table in (
+                "memory", "chunks", "patterns", "decisions", "issues",
+            ):
+                cur.execute(
+                    f"DELETE FROM devbrain.{table} WHERE project_id = %s",
+                    (tp_id,),
+                )
+            cur.execute(
+                "DELETE FROM devbrain.projects WHERE id = %s", (tp_id,),
+            )
+        conn.commit()
+
+
+def _devbrain_project_id(db) -> str:
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.projects WHERE slug = 'devbrain'"
+        )
+        return cur.fetchone()[0]
+
+
+def _throwaway_project_id(db) -> str:
+    """A test-only project so dual-write-drift tests can guarantee an
+    empty starting state — the seeded 'devbrain' project carries real
+    memory rows from production usage that would mask the
+    "memory empty + legacy non-empty" condition."""
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.projects WHERE slug = %s",
+            (_THROWAWAY_PROJECT_SLUG,),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            return row[0]
+        cur.execute(
+            """INSERT INTO devbrain.projects (slug, name, description)
+               VALUES (%s, %s, %s)
+               RETURNING id""",
+            (
+                _THROWAWAY_PROJECT_SLUG,
+                "Read-switch test project",
+                "Created by test_read_switch_to_memory.py — safe to drop.",
+            ),
+        )
+        pid = cur.fetchone()[0]
+        conn.commit()
+        return pid
+
+
+def _embedding_sql(value: float = 0.0) -> str:
+    return "[" + ",".join([str(value)] * 1024) + "]"
+
+
+def _seed_memory(
+    db,
+    *,
+    project_id: str,
+    kind: str,
+    content: str,
+    title: str | None = None,
+    embedding_value: float = 0.1,
+    archived: bool = False,
+    applies_when: str | None = None,
+    provenance_id: str | None = None,
+) -> str:
+    """Insert a memory row directly (bypassing record_memory) so the
+    seed itself doesn't go through the dual-write path under test."""
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO devbrain.memory
+                   (project_id, kind, title, content, embedding,
+                    applies_when, provenance_id, archived_at)
+               VALUES (%s, %s, %s, %s, %s::vector, %s::jsonb, %s,
+                       CASE WHEN %s THEN now() ELSE NULL END)
+               RETURNING id""",
+            (
+                project_id,
+                kind,
+                title,
+                content,
+                _embedding_sql(embedding_value),
+                applies_when,
+                provenance_id,
+                archived,
+            ),
+        )
+        memory_id = str(cur.fetchone()[0])
+        conn.commit()
+        return memory_id
+
+
+# ─── 1. deep_search reads from devbrain.memory ───────────────────────────
+
+
+def test_deep_search_reads_from_memory_table(db):
+    """The deep_search query in mcp-server/src/index.ts must surface
+    rows that live ONLY in devbrain.memory (no legacy chunks row)."""
+    pid = _devbrain_project_id(db)
+    content = f"{TEST_CONTENT_PREFIX}deep_search seed body"
+    _seed_memory(
+        db,
+        project_id=pid,
+        kind="decision",
+        title=f"{TEST_CONTENT_PREFIX}seed title",
+        content=content,
+        embedding_value=0.1,
+    )
+
+    # Issue the same SQL shape deep_search runs (memory + LEFT JOIN
+    # chunks). With no legacy chunk for this row, the LEFT JOIN cell
+    # is NULL — the row must still come back.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT m.id, m.kind, m.content, c.id as legacy_chunk_id
+               FROM devbrain.memory m
+               JOIN devbrain.projects p ON m.project_id = p.id
+               LEFT JOIN devbrain.chunks c
+                 ON m.kind = 'chunk' AND c.id = m.provenance_id
+               WHERE m.embedding IS NOT NULL
+                 AND m.archived_at IS NULL
+                 AND m.project_id = %s
+                 AND m.content = %s""",
+            (pid, content),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) == 1
+    _, kind, body, legacy_chunk_id = rows[0]
+    assert kind == "decision"
+    assert body == content
+    assert legacy_chunk_id is None
+
+
+# ─── 2. get_review_lessons reads from memory, not legacy patterns ────────
+
+
+def test_get_review_lessons_reads_from_memory(db):
+    """Lessons live in memory; legacy-only patterns rows must NOT
+    surface (they would, pre-switch — that's the regression we guard
+    against)."""
+    pid = _devbrain_project_id(db)
+    in_memory = (
+        f"{TEST_CONTENT_PREFIX}lesson in memory\n\nContext: applies "
+        "to thing"
+    )
+    _seed_memory(
+        db,
+        project_id=pid,
+        kind="pattern",
+        title=f"{TEST_CONTENT_PREFIX}memory lesson",
+        content=in_memory,
+        embedding_value=0.2,
+        applies_when='{"category": "factory_review"}',
+    )
+
+    # Insert a legacy-only patterns row WITHOUT a corresponding memory
+    # row. Pre-switch this would have come back; post-switch it must
+    # be invisible to get_review_lessons.
+    legacy_only = (
+        f"{TEST_CONTENT_PREFIX}legacy-only lesson\n\nContext: nope"
+    )
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO devbrain.patterns
+                   (project_id, name, category, description, tags)
+               VALUES (%s, %s, %s, %s, %s)""",
+            (
+                pid,
+                f"{TEST_CONTENT_PREFIX}legacy",
+                "factory_review",
+                legacy_only,
+                "[]",
+            ),
+        )
+        conn.commit()
+
+    lessons = learning.get_review_lessons(pid, limit=50)
+
+    assert in_memory in lessons
+    assert legacy_only not in lessons
+
+
+# ─── 3. archived rows are excluded ───────────────────────────────────────
+
+
+def test_archived_rows_excluded_from_reads(db):
+    """`archived_at IS NULL` is the soft-delete signal for Phase 6 and
+    must filter out archived rows on every read path."""
+    pid = _devbrain_project_id(db)
+    live_content = f"{TEST_CONTENT_PREFIX}live lesson\n\nContext: live"
+    archived_content = (
+        f"{TEST_CONTENT_PREFIX}archived lesson\n\nContext: gone"
+    )
+
+    _seed_memory(
+        db,
+        project_id=pid,
+        kind="pattern",
+        title=f"{TEST_CONTENT_PREFIX}live",
+        content=live_content,
+        embedding_value=0.3,
+        applies_when='{"category": "factory_review"}',
+    )
+    _seed_memory(
+        db,
+        project_id=pid,
+        kind="pattern",
+        title=f"{TEST_CONTENT_PREFIX}archived",
+        content=archived_content,
+        embedding_value=0.4,
+        archived=True,
+        applies_when='{"category": "factory_review"}',
+    )
+
+    lessons = learning.get_review_lessons(pid, limit=50)
+
+    assert live_content in lessons
+    assert archived_content not in lessons
+
+    # Also sanity-check the deep_search WHERE clause: archived rows
+    # must not surface even when they would otherwise match.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT m.content
+               FROM devbrain.memory m
+               WHERE m.embedding IS NOT NULL
+                 AND m.archived_at IS NULL
+                 AND m.project_id = %s
+                 AND m.content LIKE %s""",
+            (pid, f"{TEST_CONTENT_PREFIX}%"),
+        )
+        contents = {row[0] for row in cur.fetchall()}
+    assert live_content in contents
+    assert archived_content not in contents
+
+
+# ─── 4. dual-write drift WARNING fires when memory empty + legacy non-empty
+
+
+def test_zero_results_with_legacy_data_logs_warning(db, caplog):
+    """If get_review_lessons returns zero rows from memory but the
+    legacy patterns table has factory_review rows, log a WARNING with
+    "dual-write drift" so operators can rerun backfill before P2.d.ii
+    drops legacy.
+
+    Uses a throwaway project so we can guarantee memory starts empty
+    for that project — the seeded 'devbrain' project has real memory
+    lessons from production use that would otherwise mask the drift
+    condition.
+    """
+    pid = _throwaway_project_id(db)
+
+    # Legacy-only seed: a factory_review pattern with no matching
+    # memory row.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO devbrain.patterns
+                   (project_id, name, category, description, tags)
+               VALUES (%s, %s, %s, %s, %s)""",
+            (
+                pid,
+                f"{TEST_CONTENT_PREFIX}legacy_only",
+                "factory_review",
+                f"{TEST_CONTENT_PREFIX}legacy_only desc\n\nContext: x",
+                "[]",
+            ),
+        )
+        conn.commit()
+
+    with caplog.at_level(logging.WARNING, logger="learning"):
+        lessons = learning.get_review_lessons(pid, limit=50)
+
+    assert lessons == []
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any(
+        "dual-write drift" in r.getMessage() for r in warnings
+    ), (
+        f"expected dual-write drift WARNING; got: "
+        f"{[r.getMessage() for r in warnings]}"
+    )
+
+
+# ─── 5. health_check reports memory + legacy counts ──────────────────────
+
+
+def test_health_check_reports_memory_counts(db):
+    """The new health_check tool must report storage.memory.* and
+    storage.legacy.* counts. Verified by issuing the same per-table
+    COUNT(*) queries the tool runs."""
+    pid = _devbrain_project_id(db)
+
+    # Seed one memory row of each kind.
+    for kind, value in (
+        ("chunk", 0.5),
+        ("decision", 0.51),
+        ("pattern", 0.52),
+        ("issue", 0.53),
+        ("session_summary", 0.54),
+    ):
+        _seed_memory(
+            db,
+            project_id=pid,
+            kind=kind,
+            content=f"{TEST_CONTENT_PREFIX}health {kind}",
+            embedding_value=value,
+        )
+
+    # Snapshot counts (project-scoped, mirroring health_check's $1
+    # filter shape).
+    with db._conn() as conn, conn.cursor() as cur:
+        out: dict = {"memory": {}, "legacy": {}}
+        for label, kind in (
+            ("chunks", "chunk"),
+            ("decisions", "decision"),
+            ("patterns", "pattern"),
+            ("issues", "issue"),
+            ("session_summaries", "session_summary"),
+        ):
+            cur.execute(
+                "SELECT COUNT(*) FROM devbrain.memory "
+                "WHERE kind = %s AND project_id = %s",
+                (kind, pid),
+            )
+            out["memory"][label] = cur.fetchone()[0]
+        for label, table in (
+            ("chunks", "chunks"),
+            ("decisions", "decisions"),
+            ("patterns", "patterns"),
+            ("issues", "issues"),
+            ("raw_sessions", "raw_sessions"),
+        ):
+            cur.execute(
+                f"SELECT COUNT(*) FROM devbrain.{table} "
+                "WHERE project_id = %s",
+                (pid,),
+            )
+            out["legacy"][label] = cur.fetchone()[0]
+
+    # Each seeded kind contributes one memory row; archived rows would
+    # still count (health_check intentionally reports raw counts so
+    # operators see the full picture).
+    assert out["memory"]["chunks"] >= 1
+    assert out["memory"]["decisions"] >= 1
+    assert out["memory"]["patterns"] >= 1
+    assert out["memory"]["issues"] >= 1
+    assert out["memory"]["session_summaries"] >= 1
+    # Schema sanity: every legacy key the tool reports must exist.
+    assert "raw_sessions" in out["legacy"]
+
+
+# ─── 6. kind filter isolates chunks from decisions ───────────────────────
+
+
+def test_kind_filter_isolates_chunks_from_decisions(db):
+    """deep_search filters memory.kind via ANY($kinds). Filtering to
+    decision must NOT return chunk-kind rows even if both have higher
+    scores than the unfiltered universe."""
+    pid = _devbrain_project_id(db)
+    chunk_content = f"{TEST_CONTENT_PREFIX}filter chunk body"
+    decision_content = f"{TEST_CONTENT_PREFIX}filter decision body"
+
+    _seed_memory(
+        db, project_id=pid, kind="chunk",
+        content=chunk_content, embedding_value=0.6,
+    )
+    _seed_memory(
+        db, project_id=pid, kind="decision",
+        title=f"{TEST_CONTENT_PREFIX}filter decision title",
+        content=decision_content, embedding_value=0.6,
+    )
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT m.kind, m.content
+               FROM devbrain.memory m
+               JOIN devbrain.projects p ON m.project_id = p.id
+               WHERE m.embedding IS NOT NULL
+                 AND m.archived_at IS NULL
+                 AND m.project_id = %s
+                 AND m.kind = ANY(%s)
+                 AND m.content LIKE %s""",
+            (pid, ["decision"], f"{TEST_CONTENT_PREFIX}%"),
+        )
+        rows = cur.fetchall()
+
+    kinds = {r[0] for r in rows}
+    contents = {r[1] for r in rows}
+    assert kinds == {"decision"}
+    assert decision_content in contents
+    assert chunk_content not in contents
+
+
+# ─── 7. codebase falls back to legacy chunks ─────────────────────────────
+
+
+def test_codebase_falls_back_to_legacy_chunks(db):
+    """codebase_index ingest never landed in P2.b's dual-write, so
+    deep_search keeps a legacy-only branch for source_type='codebase'.
+    A legacy chunks row with source_type='codebase' must come back via
+    that branch, even though no memory row exists for it."""
+    pid = _devbrain_project_id(db)
+    codebase_content = f"{TEST_CONTENT_PREFIX}codebase fallback body"
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO devbrain.chunks
+                   (project_id, source_type, source_id,
+                    source_line_start, source_line_end, content,
+                    embedding, token_count)
+               VALUES (%s, 'codebase', NULL, 1, 1, %s, %s::vector, 1)
+               RETURNING id""",
+            (pid, codebase_content, _embedding_sql(0.7)),
+        )
+        chunk_id = str(cur.fetchone()[0])
+        conn.commit()
+
+    # The codebase-fallback SQL deep_search runs.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """SELECT c.id, c.source_type, c.content
+               FROM devbrain.chunks c
+               JOIN devbrain.projects p ON c.project_id = p.id
+               WHERE c.embedding IS NOT NULL
+                 AND c.source_type = 'codebase'
+                 AND c.project_id = %s
+                 AND c.content = %s""",
+            (pid, codebase_content),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) == 1
+    assert str(rows[0][0]) == chunk_id
+    assert rows[0][1] == "codebase"
+    assert rows[0][2] == codebase_content
+
+    # And: the codebase chunk has NO memory dual-write (the row would
+    # only exist if codebase_indexer started using insert_chunk's
+    # dual-write — which P2.e tracks separately). Sanity-asserting the
+    # absence here keeps the fallback branch load-bearing.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM devbrain.memory WHERE provenance_id = %s",
+            (chunk_id,),
+        )
+        assert cur.fetchone() is None

--- a/ingest/memory_writer.py
+++ b/ingest/memory_writer.py
@@ -13,6 +13,7 @@ legacy row collapse to one memory row via ON CONFLICT DO NOTHING.
 """
 from __future__ import annotations
 
+import json
 import logging
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,7 @@ def record_memory(
     title: str | None = None,
     embedding_sql: str | None = None,
     provenance_id: str | None = None,
+    applies_when: dict | None = None,
 ) -> None:
     """Insert a row into devbrain.memory inside the caller's transaction.
 
@@ -60,6 +62,10 @@ def record_memory(
         provenance_id: legacy row's UUID. If None, no dedup is enforced
             (the partial unique index has WHERE provenance_id IS NOT
             NULL so two NULL-prov rows can both insert).
+        applies_when: optional JSONB tag dict. Callers populate it on
+            curated rows so canonical filters (e.g. factory_review
+            lessons) match without falling back to content-LIKE
+            heuristics.
     """
     # SAVEPOINT itself is inside the try: if the caller's transaction is
     # already InFailedSqlTransaction, even SAVEPOINT raises — and the
@@ -70,12 +76,17 @@ def record_memory(
         cur.execute(
             """
             INSERT INTO devbrain.memory
-                (project_id, kind, title, content, embedding, provenance_id)
-            VALUES (%s, %s, %s, %s, %s::vector, %s)
+                (project_id, kind, title, content, embedding,
+                 provenance_id, applies_when)
+            VALUES (%s, %s, %s, %s, %s::vector, %s, %s::jsonb)
             ON CONFLICT (provenance_id, kind) WHERE provenance_id IS NOT NULL
             DO NOTHING
             """,
-            (project_id, kind, title, content, embedding_sql, provenance_id),
+            (
+                project_id, kind, title, content, embedding_sql,
+                provenance_id,
+                json.dumps(applies_when) if applies_when is not None else None,
+            ),
         )
         cur.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
     except Exception as exc:

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -144,7 +144,7 @@ server.tool(
     query: z.string().describe('Natural language search query'),
     project: z.string().optional().describe('Project slug (defaults to current project, omit for cross-project)'),
     cross_project: z.boolean().optional().default(false).describe('Search all projects'),
-    source_types: z.array(z.string()).optional().describe('Filter by: session, decision, pattern, issue, codebase'),
+    source_types: z.array(z.string()).optional().describe('Filter by: session, decision, pattern, issue, note, openclaw_memory, codebase'),
     depth: z.enum(['summary', 'full', 'auto']).optional().default('auto').describe('summary=chunks only, full=chunks+raw context, auto=smart drill-down'),
     limit: z.number().optional().default(10).describe('Max results'),
   },
@@ -169,11 +169,13 @@ server.tool(
     // before re-ranking on score.
     //
     // source_types maps to memory.kind:
-    //   'session'   → kind='chunk' AND chunks.source_type='session', plus kind='session_summary'
-    //   'decision'  → kind='decision'
-    //   'pattern'   → kind='pattern'
-    //   'issue'     → kind='issue'
-    //   'codebase'  → legacy fallback only (see above)
+    //   'session'         → kind='chunk' AND chunks.source_type='session', plus kind='session_summary'
+    //   'decision'        → kind='decision'
+    //   'pattern'         → kind='pattern'
+    //   'issue'           → kind='issue'
+    //   'note'            → kind='chunk' AND chunks.source_type='note'
+    //   'openclaw_memory' → kind='chunk' AND chunks.source_type='openclaw_memory'
+    //   'codebase'        → legacy fallback only (see above)
 
     let projectId: string | null = null
     if (!cross_project) {
@@ -201,6 +203,12 @@ server.tool(
           chunkSourceTypes.add('session')
         } else if (st === 'decision' || st === 'pattern' || st === 'issue') {
           kinds.add(st)
+        } else if (st === 'note' || st === 'openclaw_memory') {
+          // Stored as chunks-only (no primary entity dual-write); the
+          // backfill landed them as kind='chunk' memory rows whose LEFT
+          // JOIN'd chunk preserves the original source_type.
+          kinds.add('chunk')
+          chunkSourceTypes.add(st)
         }
         // 'codebase' is handled by the legacy fallback below.
       }
@@ -262,6 +270,14 @@ server.tool(
         pIdx++
       }
 
+      // LEFT JOIN restricts to non-auxiliary chunk source_types so a
+      // kind='chunk' memory row backed by an auxiliary chunk (source_type
+      // 'decision'/'pattern'/'issue'/'session_summary' from
+      // store()/_store_lessons/end_session) doesn't pull in the
+      // auxiliary chunk's source_type / source_id / line range as if it
+      // were a real session result. backfill_memory excludes the same
+      // set, but the JOIN restriction is defense in depth for any
+      // historical rows produced before that filter shipped.
       const memorySql = `
         SELECT
           m.id as memory_id,
@@ -278,6 +294,8 @@ server.tool(
         JOIN devbrain.projects p ON m.project_id = p.id
         LEFT JOIN devbrain.chunks c
           ON m.kind = 'chunk' AND c.id = m.provenance_id
+          AND (c.source_type IS NULL OR c.source_type NOT IN
+               ('decision','pattern','issue','session_summary'))
         WHERE m.embedding IS NOT NULL
           AND m.archived_at IS NULL
           ${memoryWhere}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -79,11 +79,37 @@ server.tool(
       return { content: [{ type: 'text', text: `Project "${slug}" not found in DevBrain.` }] }
     }
 
+    // P2.d.i: decisions/issues/patterns now read from devbrain.memory.
+    // The legacy tables (decisions/issues/patterns) carry richer
+    // schemas (status, rationale, category, fix_applied, name) that
+    // the unified memory table does not — return null for unmapped
+    // fields per spec, preserving the response shape so downstream
+    // consumers don't crash on missing keys. P2.d.ii will drop the
+    // legacy tables once a soak period confirms no readers regress.
     const [projectInfo, decisions, issues, patterns, activeJobs, inactiveJobs, lockCount] = await Promise.all([
       query('SELECT name, description, root_path, constraints, tech_stack FROM devbrain.projects WHERE id = $1', [projectId]),
-      query('SELECT title, decision, rationale, created_at FROM devbrain.decisions WHERE project_id = $1 AND status = \'active\' ORDER BY created_at DESC LIMIT 5', [projectId]),
-      query('SELECT title, category, description, fix_applied, created_at FROM devbrain.issues WHERE project_id = $1 ORDER BY created_at DESC LIMIT 5', [projectId]),
-      query('SELECT name, category, description FROM devbrain.patterns WHERE project_id = $1 ORDER BY created_at DESC LIMIT 5', [projectId]),
+      query(
+        `SELECT title, content AS decision, NULL AS rationale, created_at
+         FROM devbrain.memory
+         WHERE project_id = $1 AND kind = 'decision' AND archived_at IS NULL
+         ORDER BY created_at DESC LIMIT 5`,
+        [projectId],
+      ),
+      query(
+        `SELECT title, NULL AS category, content AS description,
+                NULL AS fix_applied, created_at
+         FROM devbrain.memory
+         WHERE project_id = $1 AND kind = 'issue' AND archived_at IS NULL
+         ORDER BY created_at DESC LIMIT 5`,
+        [projectId],
+      ),
+      query(
+        `SELECT title AS name, NULL AS category, content AS description
+         FROM devbrain.memory
+         WHERE project_id = $1 AND kind = 'pattern' AND archived_at IS NULL
+         ORDER BY created_at DESC LIMIT 5`,
+        [projectId],
+      ),
       query('SELECT title, status, current_phase, branch_name FROM devbrain.factory_jobs WHERE project_id = $1 AND status NOT IN (\'approved\', \'rejected\', \'deployed\', \'failed\') AND archived_at IS NULL ORDER BY created_at DESC LIMIT 5', [projectId]),
       query('SELECT title, status, current_phase, branch_name, error_count, archived_at FROM devbrain.factory_jobs WHERE project_id = $1 AND status IN (\'deployed\', \'failed\', \'approved\', \'rejected\') AND (archived_at IS NULL OR archived_at > now() - interval \'24 hours\') ORDER BY updated_at DESC LIMIT 5', [projectId]),
       query(`SELECT COUNT(*) as count FROM devbrain.file_locks
@@ -126,77 +152,260 @@ server.tool(
     const queryEmbedding = await embed(searchQuery)
     const vectorStr = toSqlVector(queryEmbedding)
 
-    let whereClause = ''
-    const params: unknown[] = [vectorStr, limit]
-    let paramIdx = 3
+    // P2.d.i read-path switch.
+    //
+    // Reads now come from devbrain.memory. Each chunk-kind memory row
+    // is the dual-write of a legacy devbrain.chunks row (provenance_id
+    // points back to chunks.id), so we LEFT JOIN to recover the legacy
+    // chunk's source_type/source_id/line range — needed both to mimic
+    // the pre-switch response shape AND to drive the raw_sessions
+    // drill-down (raw_content was not migrated to memory).
+    //
+    // The codebase source_type does not live in devbrain.memory because
+    // codebase_index ingest was never wired through memory_writer (see
+    // P2.e). When the caller asks for source_types including 'codebase'
+    // (or omits the filter), we run a second query against legacy
+    // chunks WHERE source_type='codebase' and merge the candidate sets
+    // before re-ranking on score.
+    //
+    // source_types maps to memory.kind:
+    //   'session'   → kind='chunk' AND chunks.source_type='session', plus kind='session_summary'
+    //   'decision'  → kind='decision'
+    //   'pattern'   → kind='pattern'
+    //   'issue'     → kind='issue'
+    //   'codebase'  → legacy fallback only (see above)
 
+    let projectId: string | null = null
     if (!cross_project) {
       const slug = project ?? DEFAULT_PROJECT
       if (slug) {
-        const projectId = await resolveProjectId(slug)
-        if (projectId) {
-          whereClause += ` AND c.project_id = $${paramIdx}`
-          params.push(projectId)
-          paramIdx++
+        projectId = await resolveProjectId(slug)
+      }
+    }
+
+    // Build the kind-filter list from the user-supplied source_types.
+    // 'session' covers BOTH chunk-kind memory rows whose underlying
+    // legacy chunk has source_type='session' AND raw session_summary
+    // memory rows; we OR those two together at the SQL level.
+    let kindFilter: string[] | null = null
+    let includeCodebase = true
+    let restrictChunkSourceTypes: string[] | null = null
+    if (source_types && source_types.length > 0) {
+      includeCodebase = source_types.includes('codebase')
+      const kinds = new Set<string>()
+      const chunkSourceTypes = new Set<string>()
+      for (const st of source_types) {
+        if (st === 'session') {
+          kinds.add('chunk')
+          kinds.add('session_summary')
+          chunkSourceTypes.add('session')
+        } else if (st === 'decision' || st === 'pattern' || st === 'issue') {
+          kinds.add(st)
+        }
+        // 'codebase' is handled by the legacy fallback below.
+      }
+      if (kinds.size > 0) {
+        kindFilter = [...kinds]
+        // Only apply chunks.source_type filter when the caller's filter
+        // included 'session' but NOT a wildcard catch-all, so that
+        // chunk-kind rows from non-session legacy sources don't leak.
+        restrictChunkSourceTypes = chunkSourceTypes.size > 0 ? [...chunkSourceTypes] : null
+      } else if (!includeCodebase) {
+        // Caller filtered to source_types we have no mapping for —
+        // return empty rather than a wide-open scan.
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({ results: [], hint: 'No matching source_types.' }, null, 2),
+          }],
         }
       }
     }
 
-    if (source_types && source_types.length > 0) {
-      whereClause += ` AND c.source_type = ANY($${paramIdx})`
-      params.push(source_types)
-      paramIdx++
+    type Candidate = {
+      chunk_id: string
+      content: string
+      score: number
+      source_type: string
+      source_id: string | null
+      source_line_start: number | null
+      source_line_end: number | null
+      project: string
+      memory_id: string
+      memory_kind: string
     }
 
-    const sql = `
-      SELECT
-        c.id as chunk_id,
-        c.content,
-        1 - (c.embedding <=> $1::vector) as score,
-        c.source_type,
-        c.source_id,
-        c.source_line_start,
-        c.source_line_end,
-        c.metadata,
-        p.slug as project
-      FROM devbrain.chunks c
-      JOIN devbrain.projects p ON c.project_id = p.id
-      WHERE c.embedding IS NOT NULL ${whereClause}
-      ORDER BY c.embedding <=> $1::vector
-      LIMIT $2
-    `
+    const candidates: Candidate[] = []
 
-    const result = await query(sql, params)
+    // 1. Memory query — runs unless the caller filtered ONLY to codebase.
+    const runMemoryQuery = kindFilter !== null || (source_types ?? []).length === 0
+    if (runMemoryQuery) {
+      const memoryParams: unknown[] = [vectorStr, limit]
+      let memoryWhere = ''
+      let pIdx = 3
+      if (projectId) {
+        memoryWhere += ` AND m.project_id = $${pIdx}`
+        memoryParams.push(projectId)
+        pIdx++
+      }
+      if (kindFilter) {
+        memoryWhere += ` AND m.kind = ANY($${pIdx})`
+        memoryParams.push(kindFilter)
+        pIdx++
+      }
+      if (restrictChunkSourceTypes) {
+        // chunk-kind rows must match the requested chunks.source_type;
+        // non-chunk kinds (decision/pattern/issue/session_summary) pass
+        // through this filter unaffected.
+        memoryWhere += ` AND (m.kind <> 'chunk' OR c.source_type = ANY($${pIdx}))`
+        memoryParams.push(restrictChunkSourceTypes)
+        pIdx++
+      }
+
+      const memorySql = `
+        SELECT
+          m.id as memory_id,
+          m.kind as memory_kind,
+          m.content,
+          1 - (m.embedding <=> $1::vector) as score,
+          c.id as legacy_chunk_id,
+          c.source_type as chunk_source_type,
+          c.source_id as chunk_source_id,
+          c.source_line_start as chunk_line_start,
+          c.source_line_end as chunk_line_end,
+          p.slug as project
+        FROM devbrain.memory m
+        JOIN devbrain.projects p ON m.project_id = p.id
+        LEFT JOIN devbrain.chunks c
+          ON m.kind = 'chunk' AND c.id = m.provenance_id
+        WHERE m.embedding IS NOT NULL
+          AND m.archived_at IS NULL
+          ${memoryWhere}
+        ORDER BY m.embedding <=> $1::vector
+        LIMIT $2
+      `
+
+      const memoryResult = await query(memorySql, memoryParams)
+
+      // Drift detector: empty memory + non-empty legacy is a signal that
+      // the dual-write fell behind. Logged for operators; does NOT
+      // trigger a fallback (the legacy fallback is for codebase only).
+      if (memoryResult.rows.length === 0 && projectId) {
+        const legacyCount = await query<{ count: string }>(
+          `SELECT COUNT(*)::text as count FROM devbrain.chunks
+           WHERE project_id = $1 AND embedding IS NOT NULL`,
+          [projectId],
+        )
+        if (Number(legacyCount.rows[0]?.count ?? 0) > 0) {
+          console.error(
+            `[deep_search] WARNING: dual-write drift — devbrain.memory empty for project ${projectId} but legacy devbrain.chunks has rows. Run backfill-memory.`,
+          )
+        }
+      }
+
+      for (const row of memoryResult.rows) {
+        const isChunk = row.memory_kind === 'chunk'
+        const chunkId = isChunk && row.legacy_chunk_id ? String(row.legacy_chunk_id) : String(row.memory_id)
+        const sourceType = isChunk && row.chunk_source_type
+          ? String(row.chunk_source_type)
+          : String(row.memory_kind)
+        candidates.push({
+          chunk_id: chunkId,
+          content: String(row.content),
+          score: Number(row.score),
+          source_type: sourceType,
+          source_id: row.chunk_source_id != null ? String(row.chunk_source_id) : null,
+          source_line_start: row.chunk_line_start != null ? Number(row.chunk_line_start) : null,
+          source_line_end: row.chunk_line_end != null ? Number(row.chunk_line_end) : null,
+          project: String(row.project),
+          memory_id: String(row.memory_id),
+          memory_kind: String(row.memory_kind),
+        })
+      }
+    }
+
+    // 2. Codebase fallback — legacy chunks WHERE source_type='codebase'.
+    // codebase_index ingest never landed in P2.b's dual-write, so this
+    // remains a legacy-only read until P2.e consolidates it.
+    if (includeCodebase) {
+      const codebaseParams: unknown[] = [vectorStr, limit]
+      let codebaseWhere = ''
+      if (projectId) {
+        codebaseWhere += ` AND c.project_id = $3`
+        codebaseParams.push(projectId)
+      }
+
+      const codebaseSql = `
+        SELECT
+          c.id as chunk_id,
+          c.content,
+          1 - (c.embedding <=> $1::vector) as score,
+          c.source_type,
+          c.source_id,
+          c.source_line_start,
+          c.source_line_end,
+          p.slug as project
+        FROM devbrain.chunks c
+        JOIN devbrain.projects p ON c.project_id = p.id
+        WHERE c.embedding IS NOT NULL
+          AND c.source_type = 'codebase'
+          ${codebaseWhere}
+        ORDER BY c.embedding <=> $1::vector
+        LIMIT $2
+      `
+      const codebaseResult = await query(codebaseSql, codebaseParams)
+      for (const row of codebaseResult.rows) {
+        candidates.push({
+          chunk_id: String(row.chunk_id),
+          content: String(row.content),
+          score: Number(row.score),
+          source_type: String(row.source_type),
+          source_id: row.source_id != null ? String(row.source_id) : null,
+          source_line_start: row.source_line_start != null ? Number(row.source_line_start) : null,
+          source_line_end: row.source_line_end != null ? Number(row.source_line_end) : null,
+          project: String(row.project),
+          memory_id: '',
+          memory_kind: 'codebase',
+        })
+      }
+    }
+
+    // Re-rank merged candidates by descending score, then slice.
+    candidates.sort((a, b) => b.score - a.score)
+    const top = candidates.slice(0, limit)
 
     const results = await Promise.all(
-      result.rows.map(async (row) => {
+      top.map(async (cand) => {
         const r: Record<string, unknown> = {
-          chunk_id: row.chunk_id,
-          content: row.content,
-          score: Number(Number(row.score).toFixed(4)),
-          source_type: row.source_type,
-          source_ref: row.source_id
-            ? `${row.source_type}_${String(row.source_id).slice(0, 8)}:${row.source_line_start ?? '?'}-${row.source_line_end ?? '?'}`
+          chunk_id: cand.chunk_id,
+          content: cand.content,
+          score: Number(cand.score.toFixed(4)),
+          source_type: cand.source_type,
+          source_ref: cand.source_id
+            ? `${cand.source_type}_${cand.source_id.slice(0, 8)}:${cand.source_line_start ?? '?'}-${cand.source_line_end ?? '?'}`
             : null,
-          project: row.project,
-          has_full_context: row.source_type === 'session' && row.source_id != null,
+          project: cand.project,
+          has_full_context: cand.source_type === 'session' && cand.source_id != null,
         }
 
-        // Auto drill-down: fetch raw context for top results if depth is full or auto with high scores
+        // Auto drill-down: fetch raw context for top results if depth is
+        // full or auto with high scores. Drill-down still uses the
+        // legacy raw_sessions table — raw_content was not migrated to
+        // memory in P2.b/c.
         if (
-          (depth === 'full' || (depth === 'auto' && Number(row.score) > 0.6)) &&
-          row.source_type === 'session' &&
-          row.source_id
+          (depth === 'full' || (depth === 'auto' && cand.score > 0.6)) &&
+          cand.source_type === 'session' &&
+          cand.source_id
         ) {
           const rawResult = await query(
             'SELECT raw_content FROM devbrain.raw_sessions WHERE id = $1',
-            [row.source_id],
+            [cand.source_id],
           )
           if (rawResult.rows[0]) {
             const raw = rawResult.rows[0].raw_content as string
             const lines = raw.split('\n')
-            const start = Math.max(0, (Number(row.source_line_start) || 0) - 25)
-            const end = Math.min(lines.length, (Number(row.source_line_end) || lines.length) + 25)
+            const start = Math.max(0, (cand.source_line_start ?? 0) - 25)
+            const end = Math.min(lines.length, (cand.source_line_end ?? lines.length) + 25)
             r.full_context = lines.slice(start, end).join('\n')
           }
         }
@@ -220,6 +429,14 @@ server.tool(
 )
 
 // ─── Tool: get_source_context ────────────────────────────────────────────────
+//
+// P2.d.i note: this tool intentionally still reads from devbrain.chunks
+// + devbrain.raw_sessions. raw_content was NOT migrated to
+// devbrain.memory in P2.b/c (the unified table holds the chunk's
+// embedded text but not the full transcript), so the drill-down here
+// has no memory-side equivalent. deep_search returns the legacy
+// chunks.id for chunk-kind hits precisely so this tool keeps working
+// after the read-path switch.
 
 server.tool(
   'get_source_context',
@@ -420,6 +637,90 @@ server.tool(
     })
 
     return { content: [{ type: 'text', text: `Session summary stored for project "${project}".` }] }
+  },
+)
+
+// ─── Tool: health_check ──────────────────────────────────────────────────────
+//
+// P2.d.i observability surface for the dual-write soak period. Reports
+// row counts in devbrain.memory (broken down by kind) alongside the
+// matching legacy tables (chunks/decisions/patterns/issues + raw_sessions).
+// Operators compare the two columns to detect dual-write drift before
+// P2.d.ii drops the legacy tables. Optional `project` filter scopes
+// counts to a single project; omit for cluster-wide totals.
+
+server.tool(
+  'health_check',
+  'Report DevBrain storage row counts in devbrain.memory (by kind) alongside legacy tables. Use to verify dual-write parity during the P2 soak period.',
+  {
+    project: z.string().optional().describe('Project slug to scope counts (omit for all projects).'),
+  },
+  async ({ project }) => {
+    const slug = project ?? null
+    let projectId: string | null = null
+    if (slug) {
+      projectId = await resolveProjectId(slug)
+      if (!projectId) {
+        return { content: [{ type: 'text', text: `Project "${slug}" not found.` }] }
+      }
+    }
+
+    // Build per-table count SQL with an optional project filter. We
+    // run the queries in parallel — none of them mutate state.
+    const memoryFilter = projectId ? 'AND project_id = $1' : ''
+    const legacyFilter = projectId ? 'WHERE project_id = $1' : ''
+    const params: unknown[] = projectId ? [projectId] : []
+
+    const [
+      memChunks,
+      memDecisions,
+      memPatterns,
+      memIssues,
+      memSessionSummaries,
+      legChunks,
+      legDecisions,
+      legPatterns,
+      legIssues,
+      legRawSessions,
+    ] = await Promise.all([
+      query<{ count: string }>(`SELECT COUNT(*)::text as count FROM devbrain.memory WHERE kind = 'chunk' ${memoryFilter}`, params),
+      query<{ count: string }>(`SELECT COUNT(*)::text as count FROM devbrain.memory WHERE kind = 'decision' ${memoryFilter}`, params),
+      query<{ count: string }>(`SELECT COUNT(*)::text as count FROM devbrain.memory WHERE kind = 'pattern' ${memoryFilter}`, params),
+      query<{ count: string }>(`SELECT COUNT(*)::text as count FROM devbrain.memory WHERE kind = 'issue' ${memoryFilter}`, params),
+      query<{ count: string }>(`SELECT COUNT(*)::text as count FROM devbrain.memory WHERE kind = 'session_summary' ${memoryFilter}`, params),
+      query<{ count: string }>(`SELECT COUNT(*)::text as count FROM devbrain.chunks ${legacyFilter}`, params),
+      query<{ count: string }>(`SELECT COUNT(*)::text as count FROM devbrain.decisions ${legacyFilter}`, params),
+      query<{ count: string }>(`SELECT COUNT(*)::text as count FROM devbrain.patterns ${legacyFilter}`, params),
+      query<{ count: string }>(`SELECT COUNT(*)::text as count FROM devbrain.issues ${legacyFilter}`, params),
+      query<{ count: string }>(`SELECT COUNT(*)::text as count FROM devbrain.raw_sessions ${legacyFilter}`, params),
+    ])
+
+    const num = (r: { rows: { count: string }[] }) => Number(r.rows[0]?.count ?? 0)
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          project: slug,
+          storage: {
+            memory: {
+              chunks: num(memChunks),
+              decisions: num(memDecisions),
+              patterns: num(memPatterns),
+              issues: num(memIssues),
+              session_summaries: num(memSessionSummaries),
+            },
+            legacy: {
+              chunks: num(legChunks),
+              decisions: num(legDecisions),
+              patterns: num(legPatterns),
+              issues: num(legIssues),
+              raw_sessions: num(legRawSessions),
+            },
+          },
+        }, null, 2),
+      }],
+    }
   },
 )
 


### PR DESCRIPTION
## Summary
**Phase 2 substantively complete.** Read paths for `mcp__devbrain__deep_search`, `factory/learning.py::get_review_lessons`, and `health_check` storage counts now query `devbrain.memory` as the canonical source. Dual-write to legacy tables (chunks/decisions/patterns/issues/raw_sessions) RETAINED as soft fallback during soak.

`raw_sessions.raw_content` is intentionally NOT migrated; `get_source_context` continues reading from raw_sessions for full transcript drill-down.

## Produced by
Factory job `38932c12` — converged in 4 rounds. The fix-loop caught and fixed THREE distinct issues across iterations on its own (no hand-fix from me):

- **`59a5190`** (initial): the read-switch + new tests
- **`734c45c`** (fix round 1): excluded auxiliary chunks from backfill + tightened read filters. Round 1 reviewer found that backfill copied auxiliary chunks created by store/_store_lessons/end_session alongside primary entity rows, causing post-switch deep_search to return duplicate results
- **`666856f`** (fix round 2): propagated `patterns.category` into `memory.applies_when` during backfill. Round 2 reviewer caught that the round-1 filter swap to `applies_when->>'category' = 'factory_review'` would leave historical lessons invisible because backfill_patterns wasn't populating that field
- **`abad204`** (fix round 3): backfill pattern embeddings from auxiliary chunks. Round 3 reviewer caught that legacy patterns rows didn't carry their own embedding (the auxiliary chunk did), and the new direct read path needed embeddings to drive vector search

Round 4 reviews: **0 BLOCKING / 0 WARNING on both reviewers**. Cleanest possible exit after a multi-cascade refactor.

## Scope reminder
- ✅ P2.a — table created (PR #42)
- ✅ P2.b — dual-writes live (PR #43)
- ✅ P2.c — historical backfill (PR #44)
- ✅ P2.d.i — read-switch (this PR)
- ⏳ P2.d.ii — drop legacy + remove dual-write fallback (deferred — needs 2-week soak + user authorization)

## Verification post-merge
- `mcp__devbrain__deep_search` should return memory-sourced results, including the 32K orphan chunks recovered via content attribution that were previously inaccessible.
- `mcp__devbrain__health_check` reports memory counts under `storage` (chunks/decisions/patterns/issues/session_summary) plus legacy counts under `storage.legacy.*` for soak-period observability.
- `factory/learning.py::get_review_lessons` reads patterns from memory; backfilled rows now have `applies_when={'category': 'factory_review'}` populated correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)