### PR TITLE
feat(memory): export-memory / import-memory CLI for cross-machine migration (#5.b)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -559,6 +559,18 @@ alone), so it's safe to chain in pipelines: `devbrain setup-multi-dev ...
 After running either form, restart any long-lived DevBrain processes
 (launchd ingest service, MCP server) so they pick up the new URL.
 
+### 5.3 Migrating between machines
+
+Replacing your machine? `bin/devbrain export-memory --out file.json.gz`
+on the old box and `bin/devbrain import-memory --in file.json.gz` on
+the new one will carry projects, memory, raw transcripts, and
+notification config across — no `pg_dump` required, idempotent on
+re-run, locally-customized channels preserved on the destination.
+
+See [docs/MIGRATING.md](docs/MIGRATING.md) for the full operator
+playbook including pre-flight schema checks, scoped exports
+(`--project SLUG`), and troubleshooting.
+
 ---
 
 ## 6. Platform notes

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -1,0 +1,159 @@
+# Migrating DevBrain Memory Between Machines
+
+This is the operator playbook for the canonical use case: you've been
+running DevBrain on a MacBook for months, you bought a new Mac Studio,
+and you want all of the accumulated memory (projects, decisions,
+patterns, issues, raw transcripts, dev/notification config) to come
+along.
+
+DevBrain ships two CLI subcommands for this: `export-memory` on the
+old machine writes a portable JSON file; `import-memory` on the new
+machine reads it back into the destination's database. Both are
+idempotent — re-running on the same file is safe.
+
+The pipeline does **not** transfer:
+
+- Postgres binary data — the file is portable JSON, no `pg_dump`.
+- Legacy tables (`chunks`, `decisions`, `patterns`, `issues`). Those
+  are write-side only post-P2.b; reads come from `devbrain.memory`,
+  which the export covers. The destination's own `backfill-memory`
+  pass would re-create them anyway.
+- Local credentials, `.env`, or `config/devbrain.yaml`. Re-run
+  `devbrain setup` on the new machine for those.
+
+---
+
+## 1. Pre-flight — both machines on the same schema
+
+The importer refuses to load an export whose schema version doesn't
+match the destination. Before exporting, run on **both** machines:
+
+```bash
+bin/devbrain migrate
+```
+
+If the source machine has `010_unified_memory.sql` applied but the
+destination has only `008_artifact_warning_count.sql`, the import
+will reject with a clear "schema mismatch" error — fix it by
+upgrading whichever side is older.
+
+## 2. On the old machine — export
+
+```bash
+# Everything, gzipped, to ~/devbrain-export.json.gz
+bin/devbrain export-memory --out ~/devbrain-export.json.gz
+
+# Or scoped to a single project (repeatable)
+bin/devbrain export-memory --out ~/just-acme.json --project acme
+```
+
+The output line tells you what landed in the file:
+
+```
+[export] wrote /Users/you/devbrain-export.json.gz: projects=4, devs=2, memory=8421, raw_sessions=1107
+```
+
+The `.gz` suffix triggers gzip compression automatically; pass
+`--gzip` / `--no-gzip` to override.
+
+> The export file contains your raw session transcripts and any
+> notification channels you've configured (telegram bot tokens,
+> webhook URLs, email addresses). Treat it like a credential dump —
+> transfer over a private channel (USB, scp, encrypted cloud
+> storage), not a public link.
+
+## 3. Move the file to the new machine
+
+Whatever your preferred private channel is — USB, `scp`, `rsync`,
+encrypted cloud share — copy the file to the new machine's home
+directory.
+
+```bash
+# Example: scp from old → new
+scp ~/devbrain-export.json.gz studio.local:~/
+```
+
+## 4. On the new machine — install DevBrain first
+
+The destination needs DevBrain installed and the database initialized
+before the importer has anywhere to land rows:
+
+```bash
+# One-liner installer — sets up Postgres, MCP server, ingest, etc.
+curl -fsSL https://raw.githubusercontent.com/nooma-stack/devbrain/main/scripts/install.sh | bash
+
+# Bring the schema up to the same level as the source
+cd ~/devbrain && bin/devbrain migrate
+```
+
+Run `bin/devbrain devdoctor` to confirm the install is green.
+
+## 5. On the new machine — import
+
+```bash
+# Dry-run first — shows what would be inserted without committing
+bin/devbrain import-memory --in ~/devbrain-export.json.gz --dry-run
+
+# Real run
+bin/devbrain import-memory --in ~/devbrain-export.json.gz
+```
+
+Output:
+
+```
+[import] projects: 4 resolved
+[import] devs: 1 inserted, 1 preserved
+[import] raw_sessions: 1107 inserted, 0 dup (of 1107 scanned)
+[import] memory: 8421 inserted, 0 dup (of 8421 scanned)
+```
+
+`preserved` for devs means: a dev with that `dev_id` already existed
+on the destination (e.g., the auto-registered default dev from
+`install-identity`), so we left its locally-customized notification
+channels alone. The exported channels are only used when the
+destination has no row for that dev_id yet. Re-running `import-memory`
+on the same file is safe: every per-table insert uses
+`ON CONFLICT DO NOTHING`.
+
+## 6. Verify
+
+```bash
+# A few smoke checks
+bin/devbrain devdoctor
+bin/devbrain dashboard           # browse the imported jobs/sessions
+```
+
+In an MCP client, `deep_search` for something you remember the old
+machine knowing — patterns or decisions should surface.
+
+---
+
+## Troubleshooting
+
+**`schema mismatch: export was produced against … this destination is at …`**
+Run `bin/devbrain migrate` on whichever machine is older, then
+re-export.
+
+**`unsupported export version N`**
+The export came from a newer DevBrain build than the one you
+installed. Either upgrade the destination's DevBrain checkout or
+re-export from the old machine after `git pull`.
+
+**`unknown project slug(s): foo`**
+The `--project foo` flag refers to a slug that isn't in the source
+DB. List slugs with `psql -c "SELECT slug FROM devbrain.projects;"`.
+
+**Memory rows show up but `deep_search` doesn't surface them**
+The importer doesn't recompute embeddings — it carries the source's
+bit-equal vectors over. If the destination's `pgvector` has a
+different dimensionality than the source (very rare), the index
+will refuse the import. Confirm with
+`psql -c "\d+ devbrain.memory"` on both ends.
+
+**Re-import keeps reporting "0 dup" instead of "N dup"**
+The natural keys for dedup are `(provenance_id, kind)` for memory and
+`(source_app, source_hash)` for raw_sessions. If the source rows
+have NULL `provenance_id` (rare ad-hoc curator entries) the partial
+unique index can't dedupe them — they'll insert again on every
+re-import. That's expected; re-export and clear the destination if
+you need true idempotency for those rows.

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1927,7 +1927,10 @@ def export_memory_cmd(
             database_url=DATABASE_URL,
             gzip_output=gzip_output,
         )
-    except (RuntimeError, ValueError) as exc:
+    except Exception as exc:
+        # Catch broadly so DB-down (psycopg2.OperationalError) or other
+        # driver errors surface as "[export] FAILED: …" instead of an
+        # uncaught traceback.
         click.echo(f"[export] FAILED: {exc}", err=True)
         sys.exit(1)
 
@@ -1969,7 +1972,10 @@ def import_memory_cmd(in_path: Path, dry_run: bool) -> None:
         results = import_memory.import_from_dict(
             db, payload, dry_run=dry_run,
         )
-    except (ValueError, RuntimeError) as exc:
+    except Exception as exc:
+        # Catch broadly so DB-down (psycopg2.OperationalError) or
+        # IntegrityError on a future NOT NULL column surface as
+        # "[import] FAILED: …" instead of an uncaught traceback.
         click.echo(f"[import] FAILED: {exc}", err=True)
         sys.exit(1)
 
@@ -1986,11 +1992,15 @@ def import_memory_cmd(in_path: Path, dry_run: bool) -> None:
         f"inserted, {results['raw_sessions']['skipped_dup']} dup "
         f"(of {results['raw_sessions']['scanned']} scanned)"
     )
-    click.echo(
+    mem_msg = (
         f"{prefix} memory: {results['memory']['inserted']} inserted, "
         f"{results['memory']['skipped_dup']} dup "
         f"(of {results['memory']['scanned']} scanned)"
     )
+    no_slug = results["memory"].get("skipped_no_slug", 0)
+    if no_slug:
+        mem_msg += f", {no_slug} skipped (no project_slug)"
+    click.echo(mem_msg)
 
 
 if __name__ == "__main__":

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -16,6 +16,8 @@ import yaml
 
 import attribute_orphans
 import backfill_memory
+import export_memory
+import import_memory
 import schema_migrate
 from config import DATABASE_URL, NL_MODEL, OLLAMA_URL
 from cred_rotate import (
@@ -1888,6 +1890,107 @@ def attribute_orphans_cmd(
 
     if total_failures > 0:
         sys.exit(1)
+
+
+@cli.command(name="export-memory")
+@click.option(
+    "--out", "out_path", type=click.Path(path_type=Path), required=True,
+    help="Output file (use .gz suffix for gzip).",
+)
+@click.option(
+    "--project", "project_slugs", multiple=True,
+    help="Export only this project slug. Repeatable. Default: every project.",
+)
+@click.option(
+    "--gzip/--no-gzip", "gzip_output", default=None,
+    help="Force gzip on/off. Default: infer from --out suffix.",
+)
+def export_memory_cmd(
+    out_path: Path,
+    project_slugs: tuple[str, ...],
+    gzip_output: bool | None,
+) -> None:
+    """Export devbrain.memory + raw_sessions + projects + devs to a file.
+
+    Pairs with `import-memory` for cross-machine migration. The export
+    captures everything needed to recreate this DevBrain instance's
+    accumulated memory on another machine — see docs/MIGRATING.md for
+    the full operator playbook.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    db = get_db()
+    try:
+        counts = export_memory.write_export_file(
+            db,
+            out_path,
+            project_slugs=project_slugs or None,
+            database_url=DATABASE_URL,
+            gzip_output=gzip_output,
+        )
+    except (RuntimeError, ValueError) as exc:
+        click.echo(f"[export] FAILED: {exc}", err=True)
+        sys.exit(1)
+
+    click.echo(
+        f"[export] wrote {out_path}: "
+        f"projects={counts['projects']}, devs={counts['devs']}, "
+        f"memory={counts['memory']}, raw_sessions={counts['raw_sessions']}"
+    )
+
+
+@cli.command(name="import-memory")
+@click.option(
+    "--in", "in_path", type=click.Path(exists=True, path_type=Path),
+    required=True,
+    help="Export file to read (auto-detects .gz).",
+)
+@click.option(
+    "--dry-run", is_flag=True,
+    help="Read the file and report counts without committing changes.",
+)
+def import_memory_cmd(in_path: Path, dry_run: bool) -> None:
+    """Import a `export-memory` payload into this DevBrain instance.
+
+    Idempotent: re-running on the same file is safe. Existing local
+    rows are preserved (slug-keyed projects, dev_id-keyed devs,
+    `(provenance_id, kind)` memory rows, `(source_app, source_hash)`
+    raw_sessions). Locally-customized notification channels survive
+    a re-import — only previously-unknown devs are inserted.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    db = get_db()
+    try:
+        payload = import_memory.read_import_file(in_path)
+    except Exception as exc:
+        click.echo(f"[import] FAILED to read {in_path}: {exc}", err=True)
+        sys.exit(1)
+
+    try:
+        results = import_memory.import_from_dict(
+            db, payload, dry_run=dry_run,
+        )
+    except (ValueError, RuntimeError) as exc:
+        click.echo(f"[import] FAILED: {exc}", err=True)
+        sys.exit(1)
+
+    prefix = "[dry-run]" if dry_run else "[import]"
+    click.echo(
+        f"{prefix} projects: {results['projects']['count']} resolved"
+    )
+    click.echo(
+        f"{prefix} devs: {results['devs']['inserted']} inserted, "
+        f"{results['devs']['preserved']} preserved"
+    )
+    click.echo(
+        f"{prefix} raw_sessions: {results['raw_sessions']['inserted']} "
+        f"inserted, {results['raw_sessions']['skipped_dup']} dup "
+        f"(of {results['raw_sessions']['scanned']} scanned)"
+    )
+    click.echo(
+        f"{prefix} memory: {results['memory']['inserted']} inserted, "
+        f"{results['memory']['skipped_dup']} dup "
+        f"(of {results['memory']['scanned']} scanned)"
+    )
 
 
 if __name__ == "__main__":

--- a/factory/export_memory.py
+++ b/factory/export_memory.py
@@ -1,0 +1,503 @@
+"""Export DevBrain memory + raw sessions for cross-machine migration (#5.b).
+
+Pairs with :mod:`factory.import_memory`. The two together let an operator
+move accumulated memory between DevBrain instances (canonical use case:
+MacBook → Mac Studio after a hardware swap) without touching Postgres
+internals or pgvector binary dumps.
+
+Scope
+-----
+The export covers the four tables that hold a project's accumulated
+intelligence:
+
+* ``devbrain.projects`` — the registry the rest of the export joins on
+* ``devbrain.devs``     — local notification routing / channel config
+* ``devbrain.memory``   — the unified memory table (P2.a+)
+* ``devbrain.raw_sessions`` — the lossless transcripts memory points back to
+
+Legacy tables (chunks/decisions/patterns/issues) are *not* exported:
+P2.d.i has already switched reads to ``devbrain.memory``, and the P2.c
+backfill is the canonical path for surfacing pre-P2.b legacy data into
+``memory``. Exporting legacy alongside memory would risk duplicating
+rows on the destination once it runs its own backfill.
+
+Wire format
+-----------
+A single JSON document (optionally gzipped) with the shape::
+
+    {
+      "version": 1,
+      "exported_at": "2026-04-27T18:30:00+00:00",
+      "source": {
+        "database_url": "postgresql://devbrain:***@localhost:5433/devbrain",
+        "schema_migration_top": "011_memory_provenance_unique.sql"
+      },
+      "projects":     [ {...}, ... ],
+      "devs":         [ {...}, ... ],
+      "memory":       [ {...}, ... ],
+      "raw_sessions": [ {...}, ... ]
+    }
+
+* ``version`` — wire format version. Bump on incompatible changes.
+* ``schema_migration_top`` — the highest filename in
+  ``devbrain.schema_migrations``. The importer rejects any export whose
+  top differs from the destination's, since cross-version row shapes
+  may not be compatible. Source DB without ``schema_migrations`` (very
+  old install) is exported with the value ``None`` and the importer
+  refuses to load it.
+* Every ``memory`` and ``raw_sessions`` row carries an extra
+  ``project_slug`` field. UUIDs differ between instances, so the
+  importer uses the slug to remap ``project_id`` to the destination's
+  row id (creating the project on the fly if it's not already there).
+* Embeddings round-trip as the pgvector text literal
+  ``"[v1,v2,…]"`` — bit-equal on re-import via ``%s::vector``.
+
+Streaming
+---------
+``memory`` and ``raw_sessions`` can be large. Both are read with a
+named (server-side) cursor so the Python process never holds more than
+``itersize`` rows at once. Output is written to disk incrementally —
+the writer emits the array opening, then one row per line, then the
+closing — so a multi-GB export doesn't have to fit in memory either.
+"""
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import uuid as _uuid
+from datetime import date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import IO, Any, Iterable
+from urllib.parse import urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
+
+# Bump when the on-disk shape changes in a way the importer can't read
+# transparently. The importer rejects unknown versions outright.
+EXPORT_VERSION = 1
+
+# Server-side cursor page size. Small enough that one page fits in
+# memory comfortably, large enough to amortize the round-trip cost.
+_CURSOR_ITERSIZE = 500
+
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+
+class _ExportEncoder(json.JSONEncoder):
+    """Encoder that handles the non-JSON-native types we read from psycopg2.
+
+    * ``UUID`` → string
+    * ``datetime`` / ``date`` → ISO-8601 string
+    * ``Decimal`` → float (memory.strength is NUMERIC; loss of precision
+      below ~15 digits is acceptable for a strength score)
+    * ``memoryview`` / ``bytes`` → hex (defensive — no current column
+      ships binary, but any future blob column won't crash the export)
+    """
+
+    def default(self, o: Any) -> Any:
+        if isinstance(o, _uuid.UUID):
+            return str(o)
+        if isinstance(o, datetime):
+            return o.isoformat()
+        if isinstance(o, date):
+            return o.isoformat()
+        if isinstance(o, Decimal):
+            return float(o)
+        if isinstance(o, memoryview):
+            return bytes(o).hex()
+        if isinstance(o, bytes):
+            return o.hex()
+        return super().default(o)
+
+
+def _redact_url(url: str) -> str:
+    """Mask the password component of a libpq URL.
+
+    ``postgresql://devbrain:secret@host:5433/db`` →
+    ``postgresql://devbrain:***@host:5433/db``. Used only for the
+    ``source.database_url`` breadcrumb in the export header — never for
+    actual connections.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return "***"
+    if parsed.password is None:
+        return url
+    user = parsed.username or ""
+    host = parsed.hostname or ""
+    netloc = f"{user}:***@{host}"
+    if parsed.port is not None:
+        netloc += f":{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+def _ensure_schema(db) -> None:
+    """Verify devbrain.memory exists before opening any cursors.
+
+    The importer's symmetric check is the strict one (it bails on any
+    schema mismatch); the exporter's check is just a friendly early
+    error so an operator running this on a fresh / un-migrated DB sees
+    "run migrate first" instead of "relation does not exist".
+    """
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'devbrain' AND table_name = 'memory'"
+        )
+        if cur.fetchone() is None:
+            raise RuntimeError(
+                "devbrain.memory table is missing — "
+                "run `bin/devbrain migrate` first."
+            )
+
+
+def _highest_migration(db) -> str | None:
+    """Return the lexically-greatest filename in ``schema_migrations``.
+
+    The importer compares this against its own destination value to
+    refuse cross-version migrations. ``None`` if the tracking table
+    doesn't exist (pre-009 install) — the importer treats that as a
+    hard failure too so an unknown source can't poison the destination.
+    """
+    with db._conn() as conn, conn.cursor() as cur:
+        try:
+            cur.execute(
+                "SELECT filename FROM devbrain.schema_migrations "
+                "ORDER BY filename DESC LIMIT 1"
+            )
+        except Exception:
+            return None
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def _resolve_slug_filter(db, slugs: Iterable[str]) -> dict[str, str]:
+    """Map slug → project_id for the requested filter slugs.
+
+    Slugs that don't exist in the source DB raise ``ValueError`` — fail
+    loud rather than silently producing a partial export.
+    """
+    slugs = list(dict.fromkeys(slugs))  # preserve order, drop dupes
+    if not slugs:
+        return {}
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT slug, id FROM devbrain.projects WHERE slug = ANY(%s)",
+            (slugs,),
+        )
+        found = {slug: str(pid) for slug, pid in cur.fetchall()}
+    missing = [s for s in slugs if s not in found]
+    if missing:
+        raise ValueError(
+            f"unknown project slug(s): {', '.join(missing)}"
+        )
+    return found
+
+
+# ─── per-table fetchers ─────────────────────────────────────────────────────
+
+
+def _fetch_projects(db, project_ids: list[str] | None) -> list[dict]:
+    sql = (
+        "SELECT id, slug, name, root_path, description, constraints, "
+        "       tech_stack, lint_commands, test_commands, metadata, "
+        "       created_at, updated_at "
+        "FROM devbrain.projects "
+    )
+    params: tuple = ()
+    if project_ids:
+        # Stringified UUIDs need an explicit ::uuid[] cast — Postgres
+        # won't auto-coerce text[] to uuid[] in the ANY operator.
+        sql += "WHERE id = ANY(%s::uuid[]) "
+        params = (project_ids,)
+    sql += "ORDER BY slug"
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(sql, params)
+        cols = [d.name for d in cur.description]
+        return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def _fetch_devs(db) -> list[dict]:
+    """Always exports all devs — they're not project-scoped."""
+    with db._conn() as conn, conn.cursor() as cur:
+        # The devs table only exists from migration 005 onward. Treat a
+        # missing table as "no devs to export" rather than a hard error
+        # — exports from instances that never ran 005 are still valid.
+        try:
+            cur.execute(
+                "SELECT id, dev_id, full_name, channels, "
+                "       event_subscriptions, created_at, updated_at "
+                "FROM devbrain.devs ORDER BY dev_id"
+            )
+        except Exception:
+            return []
+        cols = [d.name for d in cur.description]
+        return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def _stream_memory(db, project_ids: list[str] | None):
+    """Yield memory rows one at a time via a server-side cursor.
+
+    project_id is the source DB's id. We also yield ``project_slug`` so
+    the importer can remap to the destination's project_id. Embedding
+    is fetched as the pgvector text literal for lossless re-insertion.
+    """
+    sql = (
+        "SELECT m.id, p.slug AS project_slug, m.kind, m.title, m.content, "
+        "       m.embedding::text AS embedding_text, m.strength, m.hit_count, "
+        "       m.last_hit, m.applies_when, m.provenance_id, m.tier, "
+        "       m.archived_at, m.created_at, m.updated_at "
+        "FROM devbrain.memory m "
+        "JOIN devbrain.projects p ON p.id = m.project_id "
+    )
+    params: tuple = ()
+    if project_ids:
+        sql += "WHERE m.project_id = ANY(%s::uuid[]) "
+        params = (project_ids,)
+    sql += "ORDER BY m.created_at, m.id"
+
+    # Named cursors are server-side; itersize controls the per-fetch
+    # window. withhold=False means the cursor dies with the
+    # transaction, which is exactly the lifetime we want here.
+    with db._conn() as conn:
+        cur = conn.cursor(name="export_memory_cursor")
+        try:
+            cur.itersize = _CURSOR_ITERSIZE
+            cur.execute(sql, params)
+            for row in cur:
+                yield {
+                    "id": row[0],
+                    "project_slug": row[1],
+                    "kind": row[2],
+                    "title": row[3],
+                    "content": row[4],
+                    "embedding_text": row[5],
+                    "strength": row[6],
+                    "hit_count": row[7],
+                    "last_hit": row[8],
+                    "applies_when": row[9],
+                    "provenance_id": row[10],
+                    "tier": row[11],
+                    "archived_at": row[12],
+                    "created_at": row[13],
+                    "updated_at": row[14],
+                }
+        finally:
+            cur.close()
+
+
+def _stream_raw_sessions(db, project_ids: list[str] | None):
+    """Yield raw_sessions rows one at a time via a server-side cursor.
+
+    Same shape as memory: include ``project_slug`` for cross-instance
+    remap. project_id can be NULL (orphan sessions) — emit
+    ``project_slug=None`` in that case so the importer can preserve
+    the orphan or, if the operator opts in, attribute it later.
+    """
+    sql = (
+        "SELECT r.id, p.slug AS project_slug, r.source_app, r.source_path, "
+        "       r.source_hash, r.session_id, r.model_used, r.started_at, "
+        "       r.ended_at, r.message_count, r.raw_content, r.summary, "
+        "       r.files_touched, r.metadata, r.created_at "
+        "FROM devbrain.raw_sessions r "
+        "LEFT JOIN devbrain.projects p ON p.id = r.project_id "
+    )
+    params: tuple = ()
+    if project_ids:
+        # Inner-join semantics for the slug filter: orphan rows have no
+        # slug, so they belong to no requested project.
+        sql += "WHERE r.project_id = ANY(%s::uuid[]) "
+        params = (project_ids,)
+    sql += "ORDER BY r.created_at, r.id"
+
+    with db._conn() as conn:
+        cur = conn.cursor(name="export_raw_sessions_cursor")
+        try:
+            cur.itersize = _CURSOR_ITERSIZE
+            cur.execute(sql, params)
+            for row in cur:
+                yield {
+                    "id": row[0],
+                    "project_slug": row[1],
+                    "source_app": row[2],
+                    "source_path": row[3],
+                    "source_hash": row[4],
+                    "session_id": row[5],
+                    "model_used": row[6],
+                    "started_at": row[7],
+                    "ended_at": row[8],
+                    "message_count": row[9],
+                    "raw_content": row[10],
+                    "summary": row[11],
+                    "files_touched": row[12],
+                    "metadata": row[13],
+                    "created_at": row[14],
+                }
+        finally:
+            cur.close()
+
+
+# ─── public API ─────────────────────────────────────────────────────────────
+
+
+def export_to_dict(
+    db,
+    *,
+    project_slugs: Iterable[str] | None = None,
+    database_url: str | None = None,
+) -> dict:
+    """Build the in-memory dict form of an export.
+
+    Convenience wrapper for tests and small dumps. For real exports,
+    prefer :func:`write_export_file` which streams through the cursor
+    instead of materializing every row in Python.
+    """
+    _ensure_schema(db)
+
+    project_ids: list[str] | None = None
+    if project_slugs:
+        slug_to_id = _resolve_slug_filter(db, project_slugs)
+        project_ids = list(slug_to_id.values())
+
+    raw = {
+        "version": EXPORT_VERSION,
+        "exported_at": datetime.now().astimezone().isoformat(),
+        "source": {
+            "database_url": (
+                _redact_url(database_url) if database_url else None
+            ),
+            "schema_migration_top": _highest_migration(db),
+        },
+        "projects": _fetch_projects(db, project_ids),
+        "devs": _fetch_devs(db),
+        "memory": list(_stream_memory(db, project_ids)),
+        "raw_sessions": list(_stream_raw_sessions(db, project_ids)),
+    }
+    # Round-trip through the JSON encoder so the in-memory form has the
+    # same types the importer would see from a disk read (str UUIDs,
+    # ISO-8601 datetimes). Otherwise tests / callers would have to know
+    # which path they took to compare values consistently.
+    return json.loads(json.dumps(raw, cls=_ExportEncoder))
+
+
+def write_export_file(
+    db,
+    out_path: Path | str,
+    *,
+    project_slugs: Iterable[str] | None = None,
+    database_url: str | None = None,
+    gzip_output: bool | None = None,
+) -> dict:
+    """Stream an export to ``out_path``. Returns a counts summary.
+
+    Args:
+        db: FactoryDB instance.
+        out_path: destination file. Parent directory must exist.
+        project_slugs: optional whitelist; export everything when None.
+        database_url: source URL for the redacted breadcrumb (pulled
+            from the FactoryDB if not supplied).
+        gzip_output: force gzip on/off. When None, infer from the
+            ``.gz`` suffix on ``out_path``.
+
+    Returns counts of rows written per table — useful for the CLI
+    summary and the round-trip test.
+    """
+    _ensure_schema(db)
+
+    out_path = Path(out_path)
+    if gzip_output is None:
+        gzip_output = out_path.suffix == ".gz"
+
+    project_ids: list[str] | None = None
+    if project_slugs:
+        slug_to_id = _resolve_slug_filter(db, project_slugs)
+        project_ids = list(slug_to_id.values())
+
+    counts = {"projects": 0, "devs": 0, "memory": 0, "raw_sessions": 0}
+
+    if database_url is None:
+        database_url = getattr(db, "database_url", None)
+
+    header = {
+        "version": EXPORT_VERSION,
+        "exported_at": datetime.now().astimezone().isoformat(),
+        "source": {
+            "database_url": (
+                _redact_url(database_url) if database_url else None
+            ),
+            "schema_migration_top": _highest_migration(db),
+        },
+    }
+
+    fh: IO[str]
+    if gzip_output:
+        fh = gzip.open(out_path, "wt", encoding="utf-8")  # type: ignore[assignment]
+    else:
+        fh = open(out_path, "w", encoding="utf-8")
+    try:
+        # Write the header keys, then stream each array. We do this by
+        # hand instead of json.dump so the per-row stream never has to
+        # be a generator-of-rows held in memory at once.
+        fh.write("{\n")
+        fh.write(f"  \"version\": {json.dumps(header['version'])},\n")
+        fh.write(
+            f"  \"exported_at\": {json.dumps(header['exported_at'])},\n"
+        )
+        fh.write(
+            "  \"source\": "
+            f"{json.dumps(header['source'], cls=_ExportEncoder)},\n"
+        )
+
+        # Small tables: render in one shot.
+        projects = _fetch_projects(db, project_ids)
+        counts["projects"] = len(projects)
+        fh.write(
+            "  \"projects\": "
+            f"{json.dumps(projects, cls=_ExportEncoder)},\n"
+        )
+
+        devs = _fetch_devs(db)
+        counts["devs"] = len(devs)
+        fh.write(
+            "  \"devs\": "
+            f"{json.dumps(devs, cls=_ExportEncoder)},\n"
+        )
+
+        # Streamed tables: one row per line so a half-written file is
+        # still mostly recoverable.
+        for label, stream in (
+            ("memory", _stream_memory(db, project_ids)),
+            ("raw_sessions", _stream_raw_sessions(db, project_ids)),
+        ):
+            fh.write(f"  \"{label}\": [")
+            first = True
+            for row in stream:
+                if first:
+                    fh.write("\n    ")
+                    first = False
+                else:
+                    fh.write(",\n    ")
+                fh.write(json.dumps(row, cls=_ExportEncoder))
+                counts[label] += 1
+            if not first:
+                fh.write("\n  ")
+            # raw_sessions is the last array; no trailing comma.
+            if label == "memory":
+                fh.write("],\n")
+            else:
+                fh.write("]\n")
+
+        fh.write("}\n")
+    finally:
+        fh.close()
+
+    logger.info(
+        "[export] wrote %s — projects=%d devs=%d memory=%d raw_sessions=%d",
+        out_path, counts["projects"], counts["devs"],
+        counts["memory"], counts["raw_sessions"],
+    )
+    return counts

--- a/factory/export_memory.py
+++ b/factory/export_memory.py
@@ -65,12 +65,15 @@ from __future__ import annotations
 import gzip
 import json
 import logging
+import os
 import uuid as _uuid
 from datetime import date, datetime
 from decimal import Decimal
 from pathlib import Path
 from typing import IO, Any, Iterable
 from urllib.parse import urlparse, urlunparse
+
+import psycopg2
 
 logger = logging.getLogger(__name__)
 
@@ -169,7 +172,10 @@ def _highest_migration(db) -> str | None:
                 "SELECT filename FROM devbrain.schema_migrations "
                 "ORDER BY filename DESC LIMIT 1"
             )
-        except Exception:
+        except psycopg2.errors.UndefinedTable:
+            # Pre-009 install — the tracking table doesn't exist.
+            # Bare Exception would swallow permission errors and
+            # mask the real cause; narrow to the specific case.
             return None
         row = cur.fetchone()
         return row[0] if row else None
@@ -233,7 +239,11 @@ def _fetch_devs(db) -> list[dict]:
                 "       event_subscriptions, created_at, updated_at "
                 "FROM devbrain.devs ORDER BY dev_id"
             )
-        except Exception:
+        except psycopg2.errors.UndefinedTable:
+            # devs table only exists from migration 005 onward; treat
+            # missing table as "no devs to export". Narrow to the
+            # specific case so permission errors / cursor issues
+            # surface instead of being silently swallowed.
             return []
         cols = [d.name for d in cur.description]
         return [dict(zip(cols, row)) for row in cur.fetchall()]
@@ -433,11 +443,33 @@ def write_export_file(
         },
     }
 
+    # The export bundles devs.channels (Telegram tokens, webhook URLs,
+    # email addresses) and raw transcripts — the docstring tells
+    # operators to "treat it like a credential dump". On a multi-user
+    # workstation a 0o644 file (umask default) is readable by any
+    # other local account between creation and operator transfer, so
+    # create with 0o600 from the start.
+    fd = os.open(
+        out_path,
+        os.O_CREAT | os.O_WRONLY | os.O_TRUNC,
+        0o600,
+    )
+    underlying: IO[bytes] | None = None
     fh: IO[str]
-    if gzip_output:
-        fh = gzip.open(out_path, "wt", encoding="utf-8")  # type: ignore[assignment]
-    else:
-        fh = open(out_path, "w", encoding="utf-8")
+    try:
+        if gzip_output:
+            underlying = os.fdopen(fd, "wb")
+            fh = gzip.open(  # type: ignore[assignment]
+                underlying, "wt", encoding="utf-8",
+            )
+        else:
+            fh = os.fdopen(fd, "w", encoding="utf-8")
+    except BaseException:
+        if underlying is not None:
+            underlying.close()
+        else:
+            os.close(fd)
+        raise
     try:
         # Write the header keys, then stream each array. We do this by
         # hand instead of json.dump so the per-row stream never has to
@@ -494,6 +526,10 @@ def write_export_file(
         fh.write("}\n")
     finally:
         fh.close()
+        # gzip.open with a fileobj does NOT close the underlying
+        # fileobj on its own close — release the fd explicitly.
+        if underlying is not None:
+            underlying.close()
 
     logger.info(
         "[export] wrote %s — projects=%d devs=%d memory=%d raw_sessions=%d",

--- a/factory/import_memory.py
+++ b/factory/import_memory.py
@@ -1,0 +1,452 @@
+"""Import a DevBrain export into the local database (#5.b).
+
+Pairs with :mod:`factory.export_memory`. Reads the JSON document
+produced by ``write_export_file``/``export_to_dict`` and lands it in
+the four target tables — ``projects``, ``devs``, ``memory``, and
+``raw_sessions``.
+
+Idempotency
+-----------
+Every per-table insert uses ``ON CONFLICT DO NOTHING`` keyed on the
+table's natural identifier so a re-run of the same export doesn't
+duplicate or corrupt anything:
+
+* ``projects.slug`` — UNIQUE.
+* ``devs.dev_id`` — UNIQUE; preserves any *locally* customized
+  channels / event_subscriptions (PR #38 posture). The export file's
+  channels are *only* used when the dev_id is unknown to the
+  destination; otherwise we leave the local row alone.
+* ``memory (provenance_id, kind)`` — partial UNIQUE index from
+  migration 011. Rows with NULL provenance_id are inserted
+  unconditionally — same behavior as the legacy/dual-write path, since
+  the index can't dedupe what it can't see.
+* ``raw_sessions (source_app, source_hash)`` — the actual UNIQUE in
+  migrations/001:45. The plan spec mentioned ``id`` but ids differ
+  across instances, so we conflict on the natural key the source DB
+  was already using to dedupe ingestion.
+
+Project-id remapping
+--------------------
+UUIDs differ between instances, so the export carries
+``project_slug`` alongside ``project_id`` for memory and
+raw_sessions. On import we look up the destination's project_id by
+slug. If the slug isn't already in ``devbrain.projects`` we create the
+row from the export's ``projects`` array (or with a minimal stub if
+the source export didn't include the project — defensive only).
+
+provenance_id is *not* rewritten. P2.d.i made it a loose pointer (no
+FK), so chunk/decision/pattern/issue ids from the source DB simply
+land as-is. They lose their meaning as cross-table foreign keys but
+keep their meaning as a stable group key for the partial unique
+index — which is all the importer actually needs.
+
+Single transaction
+------------------
+All four inserts (projects → devs → raw_sessions → memory) run inside
+*one* connection-level transaction so a mid-load failure doesn't
+leave the destination half-updated. memory's project_id is a hard FK
+to projects.id; ordering matters.
+"""
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Wire format version we know how to read. Bump in lockstep with
+# export_memory.EXPORT_VERSION when the on-disk shape changes.
+SUPPORTED_VERSION = 1
+
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+
+def _check_schema_compat(db, payload: dict) -> None:
+    """Reject exports that won't slot cleanly into this destination.
+
+    Two checks:
+
+    1. ``payload['version']`` must equal :data:`SUPPORTED_VERSION` —
+       the wire format. Different versions have different row shapes.
+    2. ``payload['source']['schema_migration_top']`` must equal the
+       destination's highest applied migration filename. Cross-version
+       imports might silently land NULL into a NOT NULL column added
+       in a newer migration, or skip a constraint a newer index
+       depends on. The destination operator should run
+       ``bin/devbrain migrate`` first.
+
+    Raises ``ValueError`` with an actionable message on mismatch.
+    Past-review lesson (factory_review pattern, 2026-04-23): surface
+    schema drift loudly at the entry point, not as a buried INSERT
+    failure six tables in.
+    """
+    version = payload.get("version")
+    if version != SUPPORTED_VERSION:
+        raise ValueError(
+            f"unsupported export version {version!r} "
+            f"(this build reads version {SUPPORTED_VERSION}). "
+            "Re-export from a matching DevBrain build."
+        )
+
+    source_top = (payload.get("source") or {}).get("schema_migration_top")
+    dest_top = _highest_migration(db)
+
+    if source_top is None:
+        raise ValueError(
+            "export has no schema_migration_top — produced by a pre-009 "
+            "DevBrain install we can't safely match. Re-export after "
+            "running `bin/devbrain migrate` on the source."
+        )
+    if dest_top is None:
+        raise ValueError(
+            "destination has no schema_migration_top — run "
+            "`bin/devbrain migrate` first to bring the schema up."
+        )
+    if source_top != dest_top:
+        raise ValueError(
+            "schema mismatch: export was produced against "
+            f"{source_top!r}, this destination is at {dest_top!r}. "
+            "Run `bin/devbrain migrate` on whichever side is older "
+            "before importing."
+        )
+
+
+def _highest_migration(db) -> str | None:
+    with db._conn() as conn, conn.cursor() as cur:
+        try:
+            cur.execute(
+                "SELECT filename FROM devbrain.schema_migrations "
+                "ORDER BY filename DESC LIMIT 1"
+            )
+        except Exception:
+            return None
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def _upsert_projects(cur, projects: list[dict]) -> dict[str, str]:
+    """INSERT … ON CONFLICT (slug) DO NOTHING → return slug → dest id.
+
+    Existing local projects are *not* overwritten; their pre-import
+    metadata wins. Returning the destination id under the export's
+    slug gives the caller everything needed to remap memory /
+    raw_sessions FK references.
+    """
+    slug_to_id: dict[str, str] = {}
+    for p in projects:
+        cur.execute(
+            """
+            INSERT INTO devbrain.projects
+                (slug, name, root_path, description, constraints,
+                 tech_stack, lint_commands, test_commands, metadata)
+            VALUES (%s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb,
+                    %s::jsonb, %s::jsonb)
+            ON CONFLICT (slug) DO NOTHING
+            RETURNING id
+            """,
+            (
+                p["slug"],
+                p.get("name") or p["slug"],
+                p.get("root_path"),
+                p.get("description"),
+                json.dumps(p.get("constraints") or []),
+                json.dumps(p.get("tech_stack") or {}),
+                json.dumps(p.get("lint_commands") or {}),
+                json.dumps(p.get("test_commands") or {}),
+                json.dumps(p.get("metadata") or {}),
+            ),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            slug_to_id[p["slug"]] = str(row[0])
+        else:
+            # Conflict on slug — fetch the existing id so memory rows
+            # remap to the destination's row, not the source's.
+            cur.execute(
+                "SELECT id FROM devbrain.projects WHERE slug = %s",
+                (p["slug"],),
+            )
+            slug_to_id[p["slug"]] = str(cur.fetchone()[0])
+    return slug_to_id
+
+
+def _ensure_project(cur, slug: str, slug_to_id: dict[str, str]) -> str:
+    """Resolve slug → destination project_id, creating a stub if needed.
+
+    A memory or raw_sessions row whose slug isn't covered by the
+    export's projects array can still be imported — we just don't have
+    rich metadata for the project. Falling through with a stub keeps
+    "unknown project" exports working instead of refusing them.
+    """
+    if slug in slug_to_id:
+        return slug_to_id[slug]
+    cur.execute(
+        """
+        INSERT INTO devbrain.projects (slug, name)
+        VALUES (%s, %s)
+        ON CONFLICT (slug) DO NOTHING
+        RETURNING id
+        """,
+        (slug, slug),
+    )
+    row = cur.fetchone()
+    if row is not None:
+        new_id = str(row[0])
+    else:
+        cur.execute(
+            "SELECT id FROM devbrain.projects WHERE slug = %s", (slug,)
+        )
+        new_id = str(cur.fetchone()[0])
+    slug_to_id[slug] = new_id
+    return new_id
+
+
+def _upsert_devs(cur, devs: list[dict]) -> dict[str, int]:
+    """Insert dev rows that don't exist locally; leave existing rows alone.
+
+    PR #38 posture: re-running install / import must not overwrite
+    user-customized channels or event_subscriptions. Concretely, we
+    ``ON CONFLICT (dev_id) DO NOTHING`` — if the local row already
+    exists, the local channels/full_name/event_subscriptions win.
+    """
+    counts = {"inserted": 0, "preserved": 0}
+    for d in devs:
+        cur.execute(
+            """
+            INSERT INTO devbrain.devs
+                (dev_id, full_name, channels, event_subscriptions)
+            VALUES (%s, %s, %s::jsonb, %s::jsonb)
+            ON CONFLICT (dev_id) DO NOTHING
+            """,
+            (
+                d["dev_id"],
+                d.get("full_name"),
+                json.dumps(d.get("channels") or []),
+                json.dumps(
+                    d.get("event_subscriptions")
+                    or [
+                        "job_ready", "job_failed", "lock_conflict",
+                        "unblocked", "needs_human",
+                    ]
+                ),
+            ),
+        )
+        if cur.rowcount == 1:
+            counts["inserted"] += 1
+        else:
+            counts["preserved"] += 1
+    return counts
+
+
+def _insert_memory(
+    cur, memory: list[dict], slug_to_id: dict[str, str],
+) -> dict[str, int]:
+    """Insert memory rows, ON CONFLICT on (provenance_id, kind).
+
+    Embedding round-trips via the pgvector text literal — bit-equal to
+    the source on re-export. ``applies_when`` keeps its JSON shape.
+    """
+    counts = {"scanned": 0, "inserted": 0, "skipped_dup": 0}
+    sql = """
+        INSERT INTO devbrain.memory
+            (project_id, kind, title, content, embedding,
+             strength, hit_count, last_hit, applies_when,
+             provenance_id, tier, archived_at, created_at, updated_at)
+        VALUES (%s, %s, %s, %s, %s::vector,
+                %s, %s, %s, %s::jsonb,
+                %s, %s, %s, %s, %s)
+        ON CONFLICT (provenance_id, kind) WHERE provenance_id IS NOT NULL
+        DO NOTHING
+    """
+    for m in memory:
+        counts["scanned"] += 1
+        slug = m.get("project_slug")
+        if not slug:
+            # devbrain.memory.project_id is NOT NULL — skip orphans.
+            counts["skipped_dup"] += 1
+            continue
+        project_id = _ensure_project(cur, slug, slug_to_id)
+
+        applies_when = m.get("applies_when")
+        if applies_when is not None and not isinstance(applies_when, str):
+            applies_when = json.dumps(applies_when)
+
+        cur.execute(
+            sql,
+            (
+                project_id,
+                m["kind"],
+                m.get("title"),
+                m["content"],
+                m.get("embedding_text"),
+                m.get("strength", 1.0),
+                m.get("hit_count", 0),
+                m.get("last_hit"),
+                applies_when,
+                m.get("provenance_id"),
+                m.get("tier", "memory"),
+                m.get("archived_at"),
+                m.get("created_at"),
+                m.get("updated_at") or m.get("created_at"),
+            ),
+        )
+        if cur.rowcount == 1:
+            counts["inserted"] += 1
+        else:
+            counts["skipped_dup"] += 1
+    return counts
+
+
+def _insert_raw_sessions(
+    cur, raw_sessions: list[dict], slug_to_id: dict[str, str],
+) -> dict[str, int]:
+    """Insert raw_sessions rows, ON CONFLICT on (source_app, source_hash).
+
+    The plan spec mentioned ``id`` for the conflict key, but ids differ
+    across instances. The actual UNIQUE in migrations/001 is
+    (source_app, source_hash) — that's the natural key ingest already
+    uses to dedupe re-reads of the same transcript file, and it's the
+    only key whose value carries over from source to destination.
+
+    project_id can be NULL — orphan sessions are imported as-is so the
+    destination can re-run ``attribute-orphans`` with its own
+    ``factory.project_paths`` mapping.
+    """
+    counts = {"scanned": 0, "inserted": 0, "skipped_dup": 0}
+    sql = """
+        INSERT INTO devbrain.raw_sessions
+            (project_id, source_app, source_path, source_hash,
+             session_id, model_used, started_at, ended_at,
+             message_count, raw_content, summary, files_touched,
+             metadata, created_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                %s::jsonb, %s::jsonb, %s)
+        ON CONFLICT (source_app, source_hash) DO NOTHING
+    """
+    for r in raw_sessions:
+        counts["scanned"] += 1
+        project_id = None
+        slug = r.get("project_slug")
+        if slug:
+            project_id = _ensure_project(cur, slug, slug_to_id)
+
+        files_touched = r.get("files_touched")
+        if files_touched is not None and not isinstance(files_touched, str):
+            files_touched = json.dumps(files_touched)
+        metadata = r.get("metadata")
+        if metadata is not None and not isinstance(metadata, str):
+            metadata = json.dumps(metadata)
+
+        cur.execute(
+            sql,
+            (
+                project_id,
+                r["source_app"],
+                r["source_path"],
+                r["source_hash"],
+                r.get("session_id"),
+                r.get("model_used"),
+                r.get("started_at"),
+                r.get("ended_at"),
+                r.get("message_count"),
+                r.get("raw_content", ""),
+                r.get("summary"),
+                files_touched,
+                metadata,
+                r.get("created_at"),
+            ),
+        )
+        if cur.rowcount == 1:
+            counts["inserted"] += 1
+        else:
+            counts["skipped_dup"] += 1
+    return counts
+
+
+# ─── public API ─────────────────────────────────────────────────────────────
+
+
+def read_import_file(path: Path | str) -> dict:
+    """Load an export file from disk. Auto-detects gzip via the suffix."""
+    path = Path(path)
+    if path.suffix == ".gz":
+        with gzip.open(path, "rt", encoding="utf-8") as fh:
+            return json.load(fh)
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def import_from_dict(
+    db,
+    payload: dict,
+    *,
+    dry_run: bool = False,
+) -> dict:
+    """Land an in-memory export payload into the destination DB.
+
+    Wraps every write in a single transaction. On dry_run, the
+    transaction is rolled back at the end so the caller still sees
+    realistic counts without committing anything.
+
+    Returns a dict shaped::
+
+        {
+          "projects": {"slug_to_id": {...}, "count": N},
+          "devs": {"inserted": N, "preserved": N},
+          "raw_sessions": {"scanned": N, "inserted": N, "skipped_dup": N},
+          "memory": {"scanned": N, "inserted": N, "skipped_dup": N},
+          "dry_run": bool,
+        }
+    """
+    _check_schema_compat(db, payload)
+
+    projects = payload.get("projects") or []
+    devs = payload.get("devs") or []
+    memory = payload.get("memory") or []
+    raw_sessions = payload.get("raw_sessions") or []
+
+    results: dict = {"dry_run": dry_run}
+
+    # All four writes share one connection so a failure rolls back the
+    # batch atomically. raw_sessions is loaded before memory because
+    # memory.provenance_id may point at raw_sessions ids — they have no
+    # FK between them today, but ordering keeps the breadcrumb honest
+    # for any future tightening of that pointer.
+    conn = db._conn()
+    try:
+        with conn.cursor() as cur:
+            slug_to_id = _upsert_projects(cur, projects)
+            results["projects"] = {
+                "slug_to_id": slug_to_id,
+                "count": len(slug_to_id),
+            }
+
+            results["devs"] = _upsert_devs(cur, devs)
+            results["raw_sessions"] = _insert_raw_sessions(
+                cur, raw_sessions, slug_to_id,
+            )
+            results["memory"] = _insert_memory(cur, memory, slug_to_id)
+
+        if dry_run:
+            conn.rollback()
+        else:
+            conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    logger.info(
+        "[import] projects=%d devs=%d/%d raw_sessions=%d/%d memory=%d/%d "
+        "(dry_run=%s)",
+        results["projects"]["count"],
+        results["devs"]["inserted"], results["devs"]["preserved"],
+        results["raw_sessions"]["inserted"], results["raw_sessions"]["scanned"],
+        results["memory"]["inserted"], results["memory"]["scanned"],
+        dry_run,
+    )
+    return results

--- a/factory/import_memory.py
+++ b/factory/import_memory.py
@@ -54,6 +54,8 @@ import json
 import logging
 from pathlib import Path
 
+import psycopg2
+
 logger = logging.getLogger(__name__)
 
 # Wire format version we know how to read. Bump in lockstep with
@@ -121,7 +123,10 @@ def _highest_migration(db) -> str | None:
                 "SELECT filename FROM devbrain.schema_migrations "
                 "ORDER BY filename DESC LIMIT 1"
             )
-        except Exception:
+        except psycopg2.errors.UndefinedTable:
+            # Pre-009 install — the tracking table doesn't exist.
+            # Bare Exception would swallow permission errors and
+            # mask the real cause; narrow to the specific case.
             return None
         row = cur.fetchone()
         return row[0] if row else None
@@ -249,7 +254,10 @@ def _insert_memory(
     Embedding round-trips via the pgvector text literal — bit-equal to
     the source on re-export. ``applies_when`` keeps its JSON shape.
     """
-    counts = {"scanned": 0, "inserted": 0, "skipped_dup": 0}
+    counts = {
+        "scanned": 0, "inserted": 0,
+        "skipped_dup": 0, "skipped_no_slug": 0,
+    }
     sql = """
         INSERT INTO devbrain.memory
             (project_id, kind, title, content, embedding,
@@ -266,7 +274,11 @@ def _insert_memory(
         slug = m.get("project_slug")
         if not slug:
             # devbrain.memory.project_id is NOT NULL — skip orphans.
-            counts["skipped_dup"] += 1
+            # Tracked separately from skipped_dup so the CLI summary
+            # doesn't conflate orphan skips with real ON CONFLICT
+            # collisions. _stream_memory inner-joins on projects, so
+            # the exporter never legitimately produces such rows.
+            counts["skipped_no_slug"] += 1
             continue
         project_id = _ensure_project(cur, slug, slug_to_id)
 

--- a/factory/tests/test_export_import_memory.py
+++ b/factory/tests/test_export_import_memory.py
@@ -1,0 +1,537 @@
+"""Tests for the export-memory / import-memory pipeline (#5.b).
+
+Same DB-prefix isolation pattern as ``test_backfill_memory.py``: every
+seeded row carries ``EXPORT_IMPORT_TEST_PREFIX`` in a string column so
+the autouse cleanup fixture can wipe both source and destination
+artifacts even if a previous run aborted.
+
+Each test seeds rows directly, exercises export → import via either
+``export_to_dict`` (in-memory) or ``write_export_file`` (round-trip
+through disk), and asserts on the imported devbrain.memory /
+raw_sessions / projects / devs rows.
+"""
+from __future__ import annotations
+
+import gzip
+import json
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+# Mirror production sys.path layout — same shim test_backfill_memory.py uses.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import export_memory  # noqa: E402
+import import_memory  # noqa: E402
+from config import DATABASE_URL  # noqa: E402
+from state_machine import FactoryDB  # noqa: E402
+
+# Every seeded row's content/title/slug starts with this prefix so the
+# autouse cleanup fixture can wipe them with a handful of LIKE queries.
+EXPORT_IMPORT_TEST_PREFIX = "export_import_test_"
+
+
+@pytest.fixture
+def db():
+    return FactoryDB(DATABASE_URL)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(db):
+    yield
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM devbrain.memory WHERE content LIKE %s OR title LIKE %s",
+            (f"{EXPORT_IMPORT_TEST_PREFIX}%", f"{EXPORT_IMPORT_TEST_PREFIX}%"),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.raw_sessions WHERE source_hash LIKE %s",
+            (f"{EXPORT_IMPORT_TEST_PREFIX}%",),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.devs WHERE dev_id LIKE %s",
+            (f"{EXPORT_IMPORT_TEST_PREFIX}%",),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.projects WHERE slug LIKE %s",
+            (f"{EXPORT_IMPORT_TEST_PREFIX}%",),
+        )
+        conn.commit()
+
+
+# ─── seed helpers ───────────────────────────────────────────────────────────
+
+
+def _seed_project(db, *, slug: str, name: str | None = None) -> str:
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO devbrain.projects (slug, name)
+            VALUES (%s, %s)
+            ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+            RETURNING id
+            """,
+            (slug, name or slug),
+        )
+        pid = str(cur.fetchone()[0])
+        conn.commit()
+    return pid
+
+
+def _embedding_text(seed: float) -> str:
+    return "[" + ",".join(f"{seed + i * 1e-6:.9f}" for i in range(1024)) + "]"
+
+
+def _seed_memory(
+    db,
+    *,
+    project_id: str,
+    kind: str,
+    content: str,
+    title: str | None = None,
+    embedding_seed: float | None = None,
+    provenance_id: str | None = None,
+) -> str:
+    """INSERT directly into devbrain.memory bypassing any adapter."""
+    embedding = _embedding_text(embedding_seed) if embedding_seed is not None else None
+    if provenance_id is None:
+        provenance_id = str(uuid.uuid4())
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO devbrain.memory
+                (project_id, kind, title, content, embedding, provenance_id)
+            VALUES (%s, %s, %s, %s, %s::vector, %s)
+            RETURNING id
+            """,
+            (project_id, kind, title, content, embedding, provenance_id),
+        )
+        mid = str(cur.fetchone()[0])
+        conn.commit()
+    return mid
+
+
+def _seed_raw_session(
+    db,
+    *,
+    project_id: str | None,
+    source_hash: str | None = None,
+    summary: str | None = None,
+) -> str:
+    src_hash = source_hash or f"{EXPORT_IMPORT_TEST_PREFIX}{uuid.uuid4().hex[:32]}"
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO devbrain.raw_sessions
+                (project_id, source_app, source_path, source_hash,
+                 raw_content, summary)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                project_id, "test", "/tmp/x", src_hash,
+                "raw transcript", summary or f"{EXPORT_IMPORT_TEST_PREFIX}sum",
+            ),
+        )
+        sid = str(cur.fetchone()[0])
+        conn.commit()
+    return sid
+
+
+def _seed_dev(db, *, dev_id: str, channels: list[dict] | None = None) -> str:
+    db.register_dev(
+        dev_id=dev_id,
+        full_name=f"{EXPORT_IMPORT_TEST_PREFIX}name",
+        channels=channels or [],
+    )
+    return dev_id
+
+
+def _read_memory_for_provenance(db, provenance_id: str) -> list[tuple]:
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT kind, title, content, embedding::text "
+            "FROM devbrain.memory WHERE provenance_id = %s",
+            (provenance_id,),
+        )
+        return cur.fetchall()
+
+
+# ─── 1. round-trip via disk ─────────────────────────────────────────────────
+
+
+def test_round_trip_via_disk_preserves_rows(db, tmp_path):
+    """Disk round-trip is the canonical happy-path: seed source rows,
+    write to disk, re-import, then verify the destination ended up with
+    matching rows. Same DB throughout — we use the prefix to identify
+    "exported" rows, delete them locally, then re-import to prove the
+    importer can restore them from the file.
+    """
+    pid = _seed_project(
+        db, slug=f"{EXPORT_IMPORT_TEST_PREFIX}roundtrip", name="Roundtrip"
+    )
+    prov_a = str(uuid.uuid4())
+    prov_b = str(uuid.uuid4())
+    _seed_memory(
+        db, project_id=pid, kind="decision",
+        title=f"{EXPORT_IMPORT_TEST_PREFIX}T1",
+        content=f"{EXPORT_IMPORT_TEST_PREFIX}body 1",
+        provenance_id=prov_a,
+    )
+    _seed_memory(
+        db, project_id=pid, kind="chunk",
+        content=f"{EXPORT_IMPORT_TEST_PREFIX}chunk body",
+        embedding_seed=0.123,
+        provenance_id=prov_b,
+    )
+
+    out = tmp_path / "rt.json"
+    counts = export_memory.write_export_file(db, out)
+    assert counts["memory"] >= 2
+    assert counts["projects"] >= 1
+    assert out.exists()
+
+    # Wipe just our seeded memory rows so the import has work to do.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM devbrain.memory WHERE provenance_id IN (%s, %s)",
+            (prov_a, prov_b),
+        )
+        conn.commit()
+
+    payload = import_memory.read_import_file(out)
+    results = import_memory.import_from_dict(db, payload)
+    assert results["memory"]["inserted"] >= 2
+
+    rows_a = _read_memory_for_provenance(db, prov_a)
+    rows_b = _read_memory_for_provenance(db, prov_b)
+    assert len(rows_a) == 1
+    assert len(rows_b) == 1
+    assert rows_a[0][0] == "decision"
+    assert rows_a[0][2] == f"{EXPORT_IMPORT_TEST_PREFIX}body 1"
+    assert rows_b[0][0] == "chunk"
+
+
+# ─── 2. --project slug filter ───────────────────────────────────────────────
+
+
+def test_slug_filter_excludes_other_projects(db, tmp_path):
+    pid_a = _seed_project(db, slug=f"{EXPORT_IMPORT_TEST_PREFIX}slugA")
+    pid_b = _seed_project(db, slug=f"{EXPORT_IMPORT_TEST_PREFIX}slugB")
+    prov_a = str(uuid.uuid4())
+    prov_b = str(uuid.uuid4())
+    _seed_memory(
+        db, project_id=pid_a, kind="decision",
+        title=f"{EXPORT_IMPORT_TEST_PREFIX}A",
+        content=f"{EXPORT_IMPORT_TEST_PREFIX}A body",
+        provenance_id=prov_a,
+    )
+    _seed_memory(
+        db, project_id=pid_b, kind="decision",
+        title=f"{EXPORT_IMPORT_TEST_PREFIX}B",
+        content=f"{EXPORT_IMPORT_TEST_PREFIX}B body",
+        provenance_id=prov_b,
+    )
+
+    payload = export_memory.export_to_dict(
+        db, project_slugs=[f"{EXPORT_IMPORT_TEST_PREFIX}slugA"],
+    )
+    slugs = {p["slug"] for p in payload["projects"]}
+    assert f"{EXPORT_IMPORT_TEST_PREFIX}slugA" in slugs
+    assert f"{EXPORT_IMPORT_TEST_PREFIX}slugB" not in slugs
+
+    provenances = {m["provenance_id"] for m in payload["memory"]}
+    assert prov_a in provenances
+    assert prov_b not in provenances
+
+
+# ─── 3. idempotent re-import ────────────────────────────────────────────────
+
+
+def test_idempotent_reimport_inserts_zero_second_time(db, tmp_path):
+    """Re-running the importer against the same export file must not
+    duplicate our seeded rows, no matter how often we re-run.
+
+    The DB may have other rows (e.g. an ingest daemon running in the
+    background) whose lifecycle we don't control, so we assert only
+    on the rows we seeded. The seeds use the prefix; counting prefix-
+    matching rows before vs. after a re-import is the deterministic
+    way to prove idempotency on this shared DB.
+    """
+    pid = _seed_project(db, slug=f"{EXPORT_IMPORT_TEST_PREFIX}idem")
+    prov = str(uuid.uuid4())
+    _seed_memory(
+        db, project_id=pid, kind="issue",
+        title=f"{EXPORT_IMPORT_TEST_PREFIX}I",
+        content=f"{EXPORT_IMPORT_TEST_PREFIX}I body",
+        provenance_id=prov,
+    )
+    sess = _seed_raw_session(db, project_id=pid)
+
+    def _our_counts():
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM devbrain.memory WHERE content LIKE %s",
+                (f"{EXPORT_IMPORT_TEST_PREFIX}%",),
+            )
+            mem = cur.fetchone()[0]
+            cur.execute(
+                "SELECT count(*) FROM devbrain.raw_sessions "
+                "WHERE source_hash LIKE %s",
+                (f"{EXPORT_IMPORT_TEST_PREFIX}%",),
+            )
+            rs = cur.fetchone()[0]
+        return mem, rs
+
+    out = tmp_path / "idem.json"
+    export_memory.write_export_file(db, out)
+    payload = import_memory.read_import_file(out)
+
+    before = _our_counts()
+    import_memory.import_from_dict(db, payload)
+    after_first = _our_counts()
+    import_memory.import_from_dict(db, payload)
+    after_second = _our_counts()
+
+    assert after_first == before, (
+        f"first re-import duplicated rows: {before} → {after_first}"
+    )
+    assert after_second == before, (
+        f"second re-import duplicated rows: {before} → {after_second}"
+    )
+    # Sanity: the seeds are still there (raw_sessions row keyed by sess).
+    assert sess
+    assert before[0] >= 1 and before[1] >= 1
+
+
+# ─── 4. devs: existing local channels are preserved ─────────────────────────
+
+
+def test_dev_channels_preserved_on_reimport(db, tmp_path):
+    """PR #38 posture: re-running install / import must not overwrite
+    user-customized channels. The export carries empty channels for a
+    dev; the local copy has channels added; after import the local
+    channels must still be there.
+    """
+    pid = _seed_project(db, slug=f"{EXPORT_IMPORT_TEST_PREFIX}devs")
+    dev_id = f"{EXPORT_IMPORT_TEST_PREFIX}user1"
+    _seed_dev(db, dev_id=dev_id, channels=[])  # source: no channels
+
+    out = tmp_path / "devs.json"
+    export_memory.write_export_file(db, out)
+
+    # Now the operator on the destination customizes channels locally.
+    db.register_dev(
+        dev_id=dev_id,
+        full_name=f"{EXPORT_IMPORT_TEST_PREFIX}name",
+        channels=[{"type": "telegram_bot", "address": "@me"}],
+    )
+
+    payload = import_memory.read_import_file(out)
+    results = import_memory.import_from_dict(db, payload)
+    assert results["devs"]["preserved"] >= 1
+
+    after = db.get_dev(dev_id)
+    assert after is not None
+    assert after["channels"] == [{"type": "telegram_bot", "address": "@me"}]
+    assert pid  # unused but proves project setup ran
+
+
+# ─── 5. missing project slug auto-creates a stub ───────────────────────────
+
+
+def test_import_creates_missing_project(db, tmp_path):
+    """Memory rows whose slug isn't already in destination.projects
+    must still import — the importer creates a minimal project stub
+    so the FK holds.
+    """
+    pid = _seed_project(db, slug=f"{EXPORT_IMPORT_TEST_PREFIX}orig")
+    prov = str(uuid.uuid4())
+    _seed_memory(
+        db, project_id=pid, kind="pattern",
+        title=f"{EXPORT_IMPORT_TEST_PREFIX}P",
+        content=f"{EXPORT_IMPORT_TEST_PREFIX}P body",
+        provenance_id=prov,
+    )
+
+    payload = export_memory.export_to_dict(
+        db, project_slugs=[f"{EXPORT_IMPORT_TEST_PREFIX}orig"],
+    )
+    # Wipe local copy so the importer has to create the project AND
+    # the memory row from scratch.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM devbrain.memory WHERE provenance_id = %s", (prov,),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.projects WHERE slug = %s",
+            (f"{EXPORT_IMPORT_TEST_PREFIX}orig",),
+        )
+        conn.commit()
+
+    results = import_memory.import_from_dict(db, payload)
+    assert results["memory"]["inserted"] == 1
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT slug FROM devbrain.projects WHERE slug = %s",
+            (f"{EXPORT_IMPORT_TEST_PREFIX}orig",),
+        )
+        assert cur.fetchone() is not None
+
+
+# ─── 6. embedding bit-equality across round-trip ────────────────────────────
+
+
+def test_embedding_bit_equality_round_trip(db, tmp_path):
+    """The legacy embedding has cost a real Ollama call. The export →
+    import path must round-trip the vector bit-equally; otherwise
+    cosine distances drift on the destination."""
+    pid = _seed_project(db, slug=f"{EXPORT_IMPORT_TEST_PREFIX}emb")
+    prov = str(uuid.uuid4())
+    _seed_memory(
+        db, project_id=pid, kind="chunk",
+        content=f"{EXPORT_IMPORT_TEST_PREFIX}embedding row",
+        embedding_seed=0.4242,
+        provenance_id=prov,
+    )
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT embedding::text FROM devbrain.memory WHERE provenance_id = %s",
+            (prov,),
+        )
+        before = cur.fetchone()[0]
+
+    out = tmp_path / "emb.json"
+    export_memory.write_export_file(db, out)
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM devbrain.memory WHERE provenance_id = %s", (prov,),
+        )
+        conn.commit()
+
+    payload = import_memory.read_import_file(out)
+    import_memory.import_from_dict(db, payload)
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT embedding::text FROM devbrain.memory WHERE provenance_id = %s",
+            (prov,),
+        )
+        after = cur.fetchone()[0]
+
+    assert before == after, (
+        "embedding text literal must be bit-equal across export → import"
+    )
+
+
+# ─── 7. gzip output is smaller than plain ───────────────────────────────────
+
+
+def test_gzip_output_is_smaller(db, tmp_path):
+    pid = _seed_project(db, slug=f"{EXPORT_IMPORT_TEST_PREFIX}gz")
+    # Seed enough repetitive content that gzip has something to chew on.
+    for i in range(20):
+        _seed_memory(
+            db, project_id=pid, kind="chunk",
+            content=f"{EXPORT_IMPORT_TEST_PREFIX}{'x' * 200}{i}",
+            embedding_seed=0.0 + i * 0.001,
+            provenance_id=str(uuid.uuid4()),
+        )
+
+    plain = tmp_path / "g.json"
+    gz = tmp_path / "g.json.gz"
+    export_memory.write_export_file(
+        db, plain, project_slugs=[f"{EXPORT_IMPORT_TEST_PREFIX}gz"],
+    )
+    export_memory.write_export_file(
+        db, gz, project_slugs=[f"{EXPORT_IMPORT_TEST_PREFIX}gz"],
+    )
+
+    plain_size = plain.stat().st_size
+    gz_size = gz.stat().st_size
+    assert gz_size < plain_size, (
+        f"gzipped export should be smaller; got {gz_size} >= {plain_size}"
+    )
+
+    # The gzipped file must be readable as gzip and parse as JSON.
+    with gzip.open(gz, "rt", encoding="utf-8") as fh:
+        parsed = json.load(fh)
+    assert parsed["version"] == export_memory.EXPORT_VERSION
+
+
+# ─── 8. dry-run rolls back ──────────────────────────────────────────────────
+
+
+def test_dry_run_does_not_commit(db, tmp_path):
+    pid = _seed_project(db, slug=f"{EXPORT_IMPORT_TEST_PREFIX}dry")
+    prov = str(uuid.uuid4())
+    _seed_memory(
+        db, project_id=pid, kind="decision",
+        title=f"{EXPORT_IMPORT_TEST_PREFIX}D",
+        content=f"{EXPORT_IMPORT_TEST_PREFIX}D body",
+        provenance_id=prov,
+    )
+
+    out = tmp_path / "dry.json"
+    export_memory.write_export_file(db, out)
+
+    # Wipe the source row so dry-run import has actual work to *not* do.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM devbrain.memory WHERE provenance_id = %s", (prov,),
+        )
+        conn.commit()
+
+    payload = import_memory.read_import_file(out)
+    results = import_memory.import_from_dict(db, payload, dry_run=True)
+    # Dry-run reports the inserts it *would* have done.
+    assert results["memory"]["inserted"] >= 1
+    assert results["dry_run"] is True
+
+    # But nothing is actually committed.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM devbrain.memory WHERE provenance_id = %s",
+            (prov,),
+        )
+        assert cur.fetchone()[0] == 0
+
+
+# ─── 9. schema-mismatch import is rejected with an actionable error ────────
+
+
+def test_schema_mismatch_rejected(db, tmp_path):
+    """Surface schema drift loudly at the entry point. If the export's
+    schema_migration_top differs from the destination's, the importer
+    must refuse before touching any rows."""
+    pid = _seed_project(db, slug=f"{EXPORT_IMPORT_TEST_PREFIX}schema")
+    prov = str(uuid.uuid4())
+    _seed_memory(
+        db, project_id=pid, kind="decision",
+        title=f"{EXPORT_IMPORT_TEST_PREFIX}S",
+        content=f"{EXPORT_IMPORT_TEST_PREFIX}S body",
+        provenance_id=prov,
+    )
+
+    payload = export_memory.export_to_dict(db)
+    payload["source"]["schema_migration_top"] = "999_bogus.sql"
+
+    with pytest.raises(ValueError) as excinfo:
+        import_memory.import_from_dict(db, payload)
+    msg = str(excinfo.value)
+    assert "schema" in msg.lower()
+    assert "999_bogus.sql" in msg
+
+    # And the rejection happened before any insert: the source row is
+    # still the only one in memory for that provenance.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM devbrain.memory WHERE provenance_id = %s",
+            (prov,),
+        )
+        assert cur.fetchone()[0] == 1


### PR DESCRIPTION
## Summary
JSON-based export/import tooling for moving DevBrain data between hosts. First use: MacBook → LHT Mac Studio for the LHT-org projects (brightbot, lht-vps); next use: MacBook → Nooma-Stack Mac Studio when that host is online for the rest. Idempotent merge — re-runs are no-ops.

## Produced by
Factory job `59157187` — single fix-loop converged. Round 1: 3 arch + 1 security WARNINGs (0o600 file mode, orphan counter conflation, CLI exception scope, UndefinedTable narrowing). Round 2: all RESOLVED, only 1 deferrable NIT (mode-not-reset-on-overwrite edge case).

## What ships
- `factory/export_memory.py` — exports memory + projects + devs + raw_sessions to JSON or JSON.gz, optionally filtered by `--project SLUG`. Embedding round-trips via pgvector text form.
- `factory/import_memory.py` — idempotent merge against partial unique index from migration 011. Dev channels are NOT clobbered if target dev already has them configured (per the same posture as PR #38). Missing project rows are auto-created from the export's projects[] section.
- `factory/cli.py` — `devbrain export-memory` and `devbrain import-memory` subcommands.
- `docs/MIGRATING.md` — playbook for the cross-machine migration workflow.
- 8 tests including round-trip, project-filter, idempotency, embedding fidelity, and dev-channels-preservation.

## Migration commands ready to run
On MacBook:
```
devbrain export-memory --project brightbot --project lht-vps --output /tmp/lht-projects.json.gz
```
On LHT Mac Studio (after `scp` of the file):
```
devbrain import-memory --input /tmp/lht-projects.json.gz
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)