### PR TITLE
feat(factory): orchestrator + cleanup_agent pass dev_id explicitly

### DIFF
--- a/factory/cleanup_agent.py
+++ b/factory/cleanup_agent.py
@@ -580,7 +580,7 @@ class CleanupAgent:
                 f"{diagnosis['description']}\n\n"
                 f"Please apply a minimal, targeted fix to resolve the blocking issues."
             )
-            result = run_cli(cli_name, prompt, cwd=project_root)
+            result = run_cli(cli_name, prompt, cwd=project_root, dev_id=job.submitted_by)
             if result.success:
                 return True, f"Targeted fix applied via {cli_name}. stdout: {result.stdout[:500]}"
             else:

--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -869,7 +869,8 @@ Store the final plan in DevBrain using the store tool with type="decision"."""
         logger.info("Planning with %s...", cli)
         result = run_cli(cli, prompt, cwd=project_root,
                          env_override={"DEVBRAIN_PROJECT": job.project_slug},
-                         phase="planning")
+                         phase="planning",
+                         dev_id=job.submitted_by)
 
         self.db.store_artifact(
             job_id=job.id,
@@ -1175,7 +1176,8 @@ IMPORTANT: Follow existing code patterns in the repo. Read similar files before 
         logger.info("Implementing with %s...", cli)
         result = run_cli(cli, prompt, cwd=project_root,
                          env_override={"DEVBRAIN_PROJECT": job.project_slug},
-                         phase="implementing")
+                         phase="implementing",
+                         dev_id=job.submitted_by)
 
         self.db.store_artifact(
             job_id=job.id,
@@ -1318,7 +1320,8 @@ The prose above the block is what humans read; the block is the machine contract
         logger.info("Architecture review with %s...", arch_cli)
         arch_result = run_cli(arch_cli, arch_prompt, cwd=project_root,
                               env_override={"DEVBRAIN_PROJECT": job.project_slug},
-                              phase="review_arch")
+                              phase="review_arch",
+                              dev_id=job.submitted_by)
 
         # Parse the JSON findings block once for the artifact flag AND
         # derived counts. Partial-parses (invalid_severity dropped from
@@ -1423,7 +1426,8 @@ The prose above the block is what humans read; the block is the machine contract
         logger.info("Security review with %s...", sec_cli)
         sec_result = run_cli(sec_cli, sec_prompt, cwd=project_root,
                              env_override={"DEVBRAIN_PROJECT": job.project_slug},
-                             phase="review_security")
+                             phase="review_security",
+                             dev_id=job.submitted_by)
 
         sec_findings, sec_parse_err = _parse_findings_json(sec_result.stdout)
         if sec_findings is not None:
@@ -1730,7 +1734,8 @@ IMPORTANT: Fix ONLY the listed findings. Do not expand scope. Do not "improve" s
         logger.info("Fix loop attempt %d with %s...", job.error_count + 1, cli)
         result = run_cli(cli, fix_prompt, cwd=project_root,
                          env_override={"DEVBRAIN_PROJECT": job.project_slug},
-                         phase="fix")
+                         phase="fix",
+                         dev_id=job.submitted_by)
 
         self.db.store_artifact(
             job_id=job.id,


### PR DESCRIPTION
## Summary

Phase 4 left run_cli call sites in orchestrator and cleanup_agent unchanged — multi-dev credential routing activated only via the `DEVBRAIN_DEV_ID` env var (set by `devbrain login` via tmux setenv). That works in-tmux but is fragile outside (factory invoked from a non-tmux shell, etc.).

This PR makes routing explicit at every spawn site:

```python
result = run_cli(cli, prompt, cwd=project_root,
                 env_override={"DEVBRAIN_PROJECT": job.project_slug},
                 phase="planning",
                 dev_id=job.submitted_by)   # ← new
```

## Sites updated (6)

- `orchestrator.py:870` — planning
- `orchestrator.py:1176` — implementing
- `orchestrator.py:1319` — architecture review
- `orchestrator.py:1424` — security review
- `orchestrator.py:1731` — fix loop
- `cleanup_agent.py:583` — recovery

## Test plan

- [x] 56 orchestrator + cleanup_agent tests still pass (`pytest tests/test_orchestrator_*.py tests/test_cleanup_agent*.py`)
- [x] 121 multi-dev tests still pass (no regression)
- [x] CI (no-DB unit subset, just merged in #57) will run on this PR

## Decisions Made Under Autonomous Execution

- **Two commits in this PR** rather than one because the first attempt's orchestrator.py edits were lost mid-session (working tree got reset by a concurrent process). Commit 1 (76b0021) shipped the cleanup_agent.py edit; commit 2 (fa6b9de) re-applies the orchestrator.py edits via a python script that asserts uniqueness of each multi-line pattern. PR description retains the canonical "all 6 sites" framing.
- **No new tests for run_cli call shape** — the existing orchestrator + cleanup tests exercise these paths with mocked subprocess, and Phase 4's test_cli_executor_routing.py already covers the dev_id-routing logic itself. Adding "run_cli was called with dev_id=alice" assertions would be redundant.

## DevBrain Store Payload (Patrick to ingest)

```yaml
store_payload:
  type: decision
  project: devbrain
  title: "Orchestrator + cleanup_agent route via explicit dev_id (follow-up #2)"
  content: |
    Closes the multi-dev wiring loop: every factory run_cli call site now
    passes dev_id=job.submitted_by explicitly. No longer depends on
    DEVBRAIN_DEV_ID env var being set in the orchestrator's environment.
    
    6 sites changed:
    - orchestrator.py: planning, implementing, review_arch, review_security, fix
    - cleanup_agent.py: recovery
    
    Backward-compat: dev_id is a kwarg on run_cli (added in PR #54). Sites
    that don't pass dev_id continue to work via env-var fallback.
  tags: ["multi-dev", "factory", "orchestrator", "cleanup-agent", "follow-up", "explicit-routing"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)