### PR TITLE
ci: add DB-available pytest job (broader coverage)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,19 +41,8 @@ jobs:
 
       - name: Run pytest (no-DB unit subset)
         # Explicit allow-list of test files that genuinely don't touch
-        # Postgres in setup OR teardown. Many "logic-only" tests (e.g.,
-        # test_findings_parser, test_oscillation_guardrail) have shared
-        # fixtures with DB-touching teardowns even when the test body is
-        # pure — those run locally fine but break CI without a service
-        # container.
-        #
-        # Adding a "DB-available" workflow with a pgvector service container
-        # for broader coverage is tracked as a follow-up — earlier attempts
-        # hit migrate-vs-schema-bootstrap ordering issues. The right next
-        # step there is `psql -f migrations/001_initial_schema.sql` first,
-        # then `python factory/cli.py migrate` for everything else (so the
-        # migrate command's schema_migrations writes have a target table
-        # to write to).
+        # Postgres in setup OR teardown. Broader DB-touching coverage
+        # is in the `pytest-db` job below.
         run: |
           cd factory
           python -m pytest \
@@ -68,4 +57,86 @@ jobs:
             tests/test_cli_executor_routing.py \
             tests/test_channel_smtp.py \
             tests/test_channel_telegram.py \
+            -p no:cacheprovider --tb=short -q
+
+  pytest-db:
+    name: pytest (DB-available subset)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: devbrain
+          POSTGRES_PASSWORD: devbrain-local
+          POSTGRES_DB: devbrain
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      DEVBRAIN_DB_HOST: localhost
+      DEVBRAIN_DB_PORT: "5433"
+      DEVBRAIN_DB_USER: devbrain
+      DEVBRAIN_DB_PASSWORD: devbrain-local
+      DEVBRAIN_DB_NAME: devbrain
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Bootstrap schema (migration 001 via psql)
+        # `python factory/cli.py migrate` writes to devbrain.schema_migrations,
+        # which doesn't exist until migration 001 creates the schema. Run 001
+        # via raw psql first so the migrate command has a target table.
+        run: |
+          PGPASSWORD=devbrain-local psql \
+            -h localhost -p 5433 -U devbrain -d devbrain \
+            -v ON_ERROR_STOP=1 \
+            -f migrations/001_initial_schema.sql
+
+      - name: Apply remaining migrations via devbrain migrate
+        # Records each subsequent migration in devbrain.schema_migrations
+        # (which the migration system needs for idempotent re-runs and
+        # for tests that assert on the tracking table).
+        run: |
+          python factory/cli.py migrate
+
+      - name: Run pytest (broader DB-available subset)
+        # Excluded tests need external services beyond Postgres:
+        # - export-import-memory, attribute-orphans, backfill-memory: Ollama
+        # - channel_gchat_dwd, channel_gmail_dwd: Google service account JSON
+        # - doctor: bin/devbrain bash wrapper output not JSON-parseable in CI
+        run: |
+          cd factory
+          python -m pytest \
+            --ignore=tests/test_export_import_memory.py \
+            --ignore=tests/test_attribute_orphans.py \
+            --ignore=tests/test_backfill_memory.py \
+            --ignore=tests/test_channel_gchat_dwd.py \
+            --ignore=tests/test_channel_gmail_dwd.py \
+            --ignore=tests/test_doctor.py \
             -p no:cacheprovider --tb=short -q


### PR DESCRIPTION
## Summary

Extends the existing pytest workflow with a **second job** that spins up a `pgvector` service container and applies migrations, enabling tests that need Postgres to run in CI. Goes from 136 unit tests → ~430+ tests in CI.

## Why two jobs

- **`pytest (no-DB subset)`** — fast feedback (<1s), no service container, catches unit-level regressions instantly
- **`pytest (DB-available subset)`** — broader coverage (orchestrator, cleanup_agent, channels, dashboard, all multi-dev integration tests), takes ~3 min including service startup + migration apply

Both run on every PR + main push. Either failing blocks merge.

## How the DB job bootstraps

The first DB-CI attempt (in #57's iteration) hit a chicken-and-egg: `python factory/cli.py migrate` writes to `devbrain.schema_migrations`, which doesn't exist until migration 001 creates the schema. Solution: two-step apply.

```yaml
- name: Bootstrap schema (migration 001 via psql)
  run: |
    PGPASSWORD=devbrain-local psql \
      -h localhost -p 5433 -U devbrain -d devbrain \
      -v ON_ERROR_STOP=1 \
      -f migrations/001_initial_schema.sql

- name: Apply remaining migrations via devbrain migrate
  run: |
    python factory/cli.py migrate
```

Migration 001 creates `devbrain` schema + core tables. From there, `migrate` is happy because `devbrain.schema_migrations` exists.

## Excluded from DB-available subset

- `test_export_import_memory.py`, `test_attribute_orphans.py`, `test_backfill_memory.py` — need Ollama for embeddings
- `test_channel_gchat_dwd.py`, `test_channel_gmail_dwd.py` — need Google service account JSON
- `test_doctor.py` — `bin/devbrain doctor` bash wrapper emits non-JSON preamble in CI

These could land in a separate "integration" workflow with the right secrets/services configured.

## Test plan

- [x] Workflow added; CI on this PR will run both jobs
- [x] No-DB subset still ~136 tests passing
- [ ] DB-available subset runs against the pgvector service — first time validating this in CI

If DB-available job fails: tighter error messages will guide further fixes (most likely: a test we didn't know was excluded needs to be added to the ignore list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)