### PR TITLE
chore(projects): drop PBX-specific example from create-project prompt

### DIFF
--- a/factory/project_cli.py
+++ b/factory/project_cli.py
@@ -79,7 +79,7 @@ def _interactive_collect_ports(
     collected: list[dict] = []
     while True:
         purpose = click.prompt(
-            "Port purpose (e.g., api, web, postgres, redis, asterisk_rtp). Empty to finish",
+            "Port purpose (e.g., api, web, postgres, redis). Empty to finish",
             default="",
             show_default=False,
         ).strip()


### PR DESCRIPTION
Tiny fix — `devbrain create-project`'s purpose prompt listed `asterisk_rtp` as an example, which is 50Tel PBX-specific. Replaced with the generic `api, web, postgres, redis`. Range support is still discoverable via the next prompt ("How many ports does '<purpose>' need?").