### PR TITLE
feat(projects): unassign-port + partial UNIQUE for port history

### DIFF
--- a/factory/project_cli.py
+++ b/factory/project_cli.py
@@ -540,6 +540,102 @@ def assign_port_cmd(slug, purpose, host, port_spec, size, accept_archived, notes
     )
 
 
+@click.command(name="unassign-port")
+@click.option("--slug", required=True, help="Project slug owning the port")
+@click.option("--purpose", required=True, help="Purpose name to retire (matches the original assignment)")
+@click.option("--notes", default=None,
+              help="Optional explanation for the retirement (appended to the row's notes).")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+def unassign_port_cmd(slug, purpose, notes, yes):
+    """Retire a port assignment from an active project, preserving history.
+
+    Sets `archived_at = now()` on the assignment row — the row is NOT deleted.
+    This preserves the project's port history: if the project is later spun
+    back up, agents can query its prior assignments via
+    `devbrain ports --project <slug> --include-archived` and decide whether
+    to reclaim the old port (if free) or pick a new one (if another project
+    has since claimed it).
+
+    Refuses if:
+    - The project doesn't exist.
+    - No active assignment exists for the given purpose (already retired
+      or never assigned).
+    """
+    from state_machine import FactoryDB
+    from config import DATABASE_URL
+    from port_registry import PortRange, format_port_range
+
+    db = FactoryDB(DATABASE_URL)
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, name FROM devbrain.projects WHERE slug = %s",
+            [slug],
+        )
+        proj = cur.fetchone()
+        if not proj:
+            click.echo(f"Error: no project with slug {slug!r}.", err=True)
+            sys.exit(1)
+        project_id, project_name = proj
+
+        cur.execute(
+            """
+            SELECT id, host, port_start, port_end, notes
+            FROM devbrain.port_assignments
+            WHERE project_id = %s AND purpose = %s AND archived_at IS NULL
+            """,
+            [project_id, purpose],
+        )
+        row = cur.fetchone()
+        if not row:
+            click.echo(
+                f"Error: project '{slug}' has no active assignment for purpose '{purpose}'.",
+                err=True,
+            )
+            sys.exit(1)
+        assignment_id, host, port_start, port_end, existing_notes = row
+
+    port_str = format_port_range(PortRange(port_start, port_end))
+
+    click.echo("")
+    click.echo("─" * 50)
+    click.echo(f"  Project: {slug} ({project_name})")
+    click.echo(f"  Purpose: {purpose}")
+    click.echo(f"  Host:    {host}")
+    click.echo(f"  Port:    {port_str}")
+    click.echo("  Action:  retire (archived_at = now)")
+    click.echo("           historical record preserved for future revival")
+    if notes:
+        click.echo(f"  Notes:   {notes}")
+    click.echo("─" * 50)
+
+    if not yes and not click.confirm("Retire this port assignment?", default=True):
+        click.echo("Aborted.")
+        sys.exit(0)
+
+    final_notes = existing_notes or ""
+    if notes:
+        sep = " | " if final_notes else ""
+        final_notes = f"{final_notes}{sep}retired: {notes}"
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE devbrain.port_assignments
+            SET archived_at = now(),
+                notes = %s
+            WHERE id = %s
+            """,
+            [final_notes or None, assignment_id],
+        )
+        conn.commit()
+
+    click.echo(
+        f"✅ Retired {host}:{port_str} from '{slug}' (purpose '{purpose}'). "
+        f"History preserved — view via `devbrain ports --project {slug}`."
+    )
+
+
 @click.command(name="reclaim-port")
 @click.option("--host", default="localhost", show_default=True)
 @click.option("--port", "port_spec", required=True, help="Port or range, e.g. 18000 or 20000-20100")
@@ -607,5 +703,6 @@ def register(cli_group: click.Group) -> None:
     cli_group.add_command(reactivate_project_cmd)
     cli_group.add_command(ports_cmd)
     cli_group.add_command(assign_port_cmd)
+    cli_group.add_command(unassign_port_cmd)
     cli_group.add_command(reclaim_port_cmd)
     cli_group.add_command(seed_ports_cmd)

--- a/migrations/013_port_assignments_partial_unique.sql
+++ b/migrations/013_port_assignments_partial_unique.sql
@@ -1,0 +1,39 @@
+-- DevBrain Port Registry — partial UNIQUE for project history
+-- ============================================================================
+--
+-- Migration 012 shipped `UNIQUE (project_id, purpose)` on port_assignments.
+-- That makes sense for ACTIVE assignments (one port per purpose at a time)
+-- but blocks a project from ever re-assigning the same purpose after a
+-- retirement.
+--
+-- Concrete scenario: project X is retired (rows flipped archived_at = now()).
+-- Project X is later spun back up. Agent runs `devbrain assign-port --slug X
+-- --purpose api ...` — fails because the archived row still satisfies
+-- (project_id=X, purpose=api) and blocks the new INSERT via UNIQUE.
+--
+-- Fix: drop the strict UNIQUE constraint and replace it with a partial
+-- UNIQUE INDEX that only enforces uniqueness on non-archived rows. Archived
+-- rows can stack up — they're the project's port history, queryable via
+-- `devbrain ports --project X --include-archived` (default).
+--
+-- This preserves historical attribution (a project can look up "what port
+-- did I use to use for purpose=api?") while letting the project re-assign
+-- that purpose to a different port post-revival.
+
+BEGIN;
+
+-- Drop the column-level UNIQUE constraint from migration 012.
+-- Postgres auto-names these as <table>_<column>_<column>_..._key.
+ALTER TABLE devbrain.port_assignments
+    DROP CONSTRAINT IF EXISTS port_assignments_project_id_purpose_key;
+
+-- Replace with a partial UNIQUE INDEX scoped to active assignments only.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_port_assignments_project_purpose_active
+    ON devbrain.port_assignments (project_id, purpose)
+    WHERE archived_at IS NULL;
+
+INSERT INTO devbrain.schema_migrations (filename, applied_at)
+VALUES ('013_port_assignments_partial_unique.sql', now())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes the port-lifecycle loop you flagged: when a port is retired from a project, the **historical association is preserved** so a future revival can query \"what port did I use to use for purpose=api?\" and decide whether to reclaim or pick a new one.

## Two changes

### 1. Migration 013 — partial UNIQUE

PR #61 shipped \`UNIQUE (project_id, purpose)\` on \`port_assignments\`. That blocks a project from ever re-assigning the same purpose after retirement (the archived row still satisfies the UNIQUE). Replaced with a **partial** UNIQUE INDEX that only enforces uniqueness on non-archived rows:

```sql
DROP CONSTRAINT port_assignments_project_id_purpose_key;
CREATE UNIQUE INDEX uq_port_assignments_project_purpose_active
    ON devbrain.port_assignments (project_id, purpose)
    WHERE archived_at IS NULL;
```

Archived rows can stack up — they're the project's history.

### 2. \`devbrain unassign-port\`

```bash
devbrain unassign-port --slug <project> --purpose <name> [--notes <text>] [--yes]
```

Sets \`archived_at = now()\` on the assignment row, **does not delete it**. Notes (if provided) are appended to existing notes with a \`\" | retired: <reason>\"\` marker so historical context survives.

Refuses if:
- Project doesn't exist
- No active assignment exists for the given purpose

## End-to-end test (against seeded 50tel-pbx)

```
$ devbrain unassign-port --slug 50tel-pbx --purpose metrics --notes "test" --yes
✅ Retired localhost:3000 from '50tel-pbx' (purpose 'metrics'). History preserved.

$ devbrain assign-port --slug 50tel-pbx --purpose metrics --port 9100 --yes
✅ Assigned localhost:9100 for 'metrics' on project '50tel-pbx'.

$ devbrain ports --project 50tel-pbx
host       port         project    status    purpose       notes
localhost  3000         50tel-pbx  active    metrics       (archived) Prometheus metrics endpoint | retired: test
localhost  9100         50tel-pbx  active    metrics       (no notes)
... (other ports)
```

Both rows visible. The agent reading this can see metrics WAS at 3000 (now archived) and IS at 9100. If 50tel-pbx is later renamed or spun back up and needs metrics again, the history is right there.

## Recovery flow this enables

When a project is reactivated and needs a port for a previously-retired purpose:

1. \`devbrain ports --project X\` → shows the archived row at port Y
2. Agent checks: \`devbrain ports --host Z\` → is port Y currently active for another project?
   - **Free**: \`devbrain assign-port --slug X --purpose Y --port Z --yes\`
   - **Taken**: agent surfaces the conflict to the human, picks a different port, OR initiates negotiation with the current owner

No automatic conflict resolution — the agent presents options, human decides. (The same trust model as \`reclaim-port\`.)

## Follow-ups (non-blocking)

- The \`reactivate-project\` command could optionally show retired port assignments at reactivation time as a hint to the operator
- A \`devbrain project-history --slug X\` view that combines project metadata + all port assignments + cross-references which retired ports are now claimed elsewhere — agent-friendlier than reading the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)