### PR TITLE
feat(memory): memory_dependencies edge table + store tool depends_on/supersedes (Atlas Step 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased] — Phase 3 / Atlas integrations
+
+### Added
+- **Migration 014** — `devbrain.memory_dependencies` typed-edge table (`cites` / `depends_on` / `supersedes` / `contradicts`) with backfill from legacy `decisions.superseded_by` chain. Atlas Step 1 of the Phase 3 design ([docs/plans/2026-04-29-phase-3-discipline-layer.md](docs/plans/2026-04-29-phase-3-discipline-layer.md), PR #67).
+- **MCP `store` tool** — accepts `depends_on` and `supersedes` UUID arrays. Resolves either `memory.id` or legacy `decisions/patterns/issues.id` (best-effort lookup) and inserts edges into `memory_dependencies`. Idempotent via the unique `(from_memory_id, to_memory_id, edge_type)` constraint.
+- **`memory.ts` helpers** — `recordMemory` now returns the `memory.id` for downstream edge wiring (was `void`); new `resolveMemoryId(uuid)` and `recordMemoryDependency(...)` helpers.
+
 ## [Unreleased] — Factory Hardening Sprint
 
 Eleven PRs landed 2026-04-23 → 2026-04-25 hardening the dev-factory pipeline: per-job worktrees, reviewer calibration, ff-only sync, structured JSON findings, schema-migration plumbing, and install-time identity registration.

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -9,7 +9,7 @@ import { join, resolve } from 'path'
 import { z } from 'zod'
 import { query } from './db.js'
 import { embed, toSqlVector } from './embeddings.js'
-import { recordMemory } from './memory.js'
+import { recordMemory, recordMemoryDependency, resolveMemoryId } from './memory.js'
 import { summarizeSession } from './summarize.js'
 
 // Factory orchestrator runner path
@@ -556,8 +556,20 @@ server.tool(
     fix_applied: z.string().optional().describe('Fix applied (for issues)'),
     prevention: z.string().optional().describe('How to prevent recurrence (for issues)'),
     example_code: z.string().optional().describe('Example code (for patterns)'),
+    depends_on: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'UUIDs of memories this one depends on. Invalidating any of those should re-evaluate this. Accepts either memory.id or a legacy decision/pattern/issue id from search results.',
+      ),
+    supersedes: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'UUIDs of memories this one replaces. Used for retracting a prior decision when storing its replacement. Accepts either memory.id or legacy id.',
+      ),
   },
-  async ({ type, project, title, content, category, tags, rationale, alternatives, root_cause, fix_applied, prevention, example_code }) => {
+  async ({ type, project, title, content, category, tags, rationale, alternatives, root_cause, fix_applied, prevention, example_code, depends_on, supersedes }) => {
     const projectId = await resolveProjectId(project)
     if (!projectId) {
       return { content: [{ type: 'text', text: `Project "${project}" not found.` }] }
@@ -607,7 +619,7 @@ server.tool(
     // We dual-write here (the canonical legacy row) — NOT the
     // auxiliary chunk insert below — so each store() lands exactly one
     // memory row per logical entity.
-    await recordMemory({
+    const memoryId = await recordMemory({
       projectId,
       kind: type,
       title,
@@ -615,6 +627,40 @@ server.tool(
       embeddingSql: vectorStr,
       provenanceId: recordId,
     })
+
+    // Atlas / Phase 3 dependency edges. Each agent-supplied UUID may be
+    // either a memory.id directly or a legacy provenance id; resolve and
+    // insert. Failures are logged but never block the store. Skipped if
+    // the dual-write didn't return a new memory.id (best-effort path).
+    const edgeNotes: string[] = []
+    if (memoryId && (depends_on?.length || supersedes?.length)) {
+      for (const target of depends_on ?? []) {
+        const toId = await resolveMemoryId(target)
+        if (!toId) {
+          edgeNotes.push(`depends_on: could not resolve "${target.slice(0, 8)}"`)
+          continue
+        }
+        await recordMemoryDependency({
+          fromMemoryId: memoryId,
+          toMemoryId: toId,
+          edgeType: 'depends_on',
+          createdBy: 'mcp:store',
+        })
+      }
+      for (const target of supersedes ?? []) {
+        const toId = await resolveMemoryId(target)
+        if (!toId) {
+          edgeNotes.push(`supersedes: could not resolve "${target.slice(0, 8)}"`)
+          continue
+        }
+        await recordMemoryDependency({
+          fromMemoryId: memoryId,
+          toMemoryId: toId,
+          edgeType: 'supersedes',
+          createdBy: 'mcp:store',
+        })
+      }
+    }
 
     // Also create an embedded chunk for the record. Kept for legacy
     // search compatibility; no dual-write from here (would duplicate
@@ -625,7 +671,15 @@ server.tool(
       [projectId, type, recordId, `${title}\n\n${content}`, vectorStr],
     )
 
-    return { content: [{ type: 'text', text: `Stored ${type} "${title}" (${recordId.slice(0, 8)}).` }] }
+    const baseMsg = `Stored ${type} "${title}" (${recordId.slice(0, 8)}).`
+    const edgeSummary = (() => {
+      const parts: string[] = []
+      if (depends_on?.length) parts.push(`depends_on=${depends_on.length}`)
+      if (supersedes?.length) parts.push(`supersedes=${supersedes.length}`)
+      return parts.length ? ` Edges: ${parts.join(', ')}.` : ''
+    })()
+    const noteSummary = edgeNotes.length ? ` (${edgeNotes.join('; ')})` : ''
+    return { content: [{ type: 'text', text: baseMsg + edgeSummary + noteSummary }] }
   },
 )
 

--- a/mcp-server/src/memory.ts
+++ b/mcp-server/src/memory.ts
@@ -45,14 +45,27 @@ export interface RecordMemoryArgs {
   provenanceId?: string | null
 }
 
-export async function recordMemory(args: RecordMemoryArgs): Promise<void> {
+export async function recordMemory(args: RecordMemoryArgs): Promise<string | null> {
   try {
-    await query(
-      `INSERT INTO devbrain.memory
-           (project_id, kind, title, content, embedding, provenance_id)
-       VALUES ($1, $2, $3, $4, $5::vector, $6)
-       ON CONFLICT (provenance_id, kind) WHERE provenance_id IS NOT NULL
-       DO NOTHING`,
+    // Single round-trip: try to insert; on conflict (existing row for this
+    // provenance), fall through to a SELECT for the existing id. The CTE
+    // approach is cheaper than insert-then-select-on-conflict and handles
+    // the no-provenance case too (when provenance_id is NULL the partial
+    // unique index doesn't fire, so the INSERT path always succeeds).
+    const result = await query<{ id: string }>(
+      `WITH inserted AS (
+         INSERT INTO devbrain.memory
+             (project_id, kind, title, content, embedding, provenance_id)
+         VALUES ($1, $2, $3, $4, $5::vector, $6)
+         ON CONFLICT (provenance_id, kind) WHERE provenance_id IS NOT NULL
+         DO NOTHING
+         RETURNING id
+       )
+       SELECT id FROM inserted
+       UNION ALL
+       SELECT id FROM devbrain.memory
+       WHERE provenance_id = $6 AND kind = $2 AND NOT EXISTS (SELECT 1 FROM inserted)
+       LIMIT 1`,
       [
         args.projectId,
         args.kind,
@@ -62,11 +75,81 @@ export async function recordMemory(args: RecordMemoryArgs): Promise<void> {
         args.provenanceId ?? null,
       ],
     )
+    return result.rows[0]?.id ?? null
   } catch (err) {
     // Best-effort: never let a memory failure surface to the caller.
     // The legacy write is the contract; this is shadow-write phase.
     console.error(
       `[memory] dual-write failed (kind=${args.kind}, provenance_id=${args.provenanceId ?? 'null'}): ${err}`,
+    )
+    return null
+  }
+}
+
+/**
+ * Resolve a UUID to a `devbrain.memory.id`.
+ *
+ * Accepts either:
+ *   - a memory.id directly (returns it unchanged if it exists), or
+ *   - a legacy provenance UUID (decision/pattern/issue id), in which case
+ *     we look up the corresponding memory row.
+ *
+ * Returns null on miss. Used by the `store` tool to wire up `depends_on`
+ * and `supersedes` edges from agent-supplied UUIDs that may have come
+ * from search results pointing at either the memory or the legacy table.
+ */
+export async function resolveMemoryId(uuid: string): Promise<string | null> {
+  try {
+    const result = await query<{ id: string }>(
+      `SELECT id FROM devbrain.memory WHERE id = $1
+         UNION ALL
+       SELECT id FROM devbrain.memory WHERE provenance_id = $1
+       LIMIT 1`,
+      [uuid],
+    )
+    return result.rows[0]?.id ?? null
+  } catch (err) {
+    console.error(`[memory] resolveMemoryId(${uuid}) failed: ${err}`)
+    return null
+  }
+}
+
+/**
+ * Insert a typed dependency edge between two memory rows.
+ *
+ * Idempotent via the (from_memory_id, to_memory_id, edge_type) unique
+ * constraint. Caller responsibility: ensure both memory IDs are valid
+ * (use resolveMemoryId first); silently skips self-loops and handles
+ * conflicts as no-ops. Best-effort like recordMemory — failures are
+ * logged but never raised to the caller.
+ */
+export async function recordMemoryDependency(args: {
+  fromMemoryId: string
+  toMemoryId: string
+  edgeType: 'cites' | 'depends_on' | 'supersedes' | 'contradicts'
+  confidence?: number
+  createdBy?: string
+  metadata?: Record<string, unknown>
+}): Promise<void> {
+  if (args.fromMemoryId === args.toMemoryId) return
+  try {
+    await query(
+      `INSERT INTO devbrain.memory_dependencies
+           (from_memory_id, to_memory_id, edge_type, confidence, created_by, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (from_memory_id, to_memory_id, edge_type) DO NOTHING`,
+      [
+        args.fromMemoryId,
+        args.toMemoryId,
+        args.edgeType,
+        args.confidence ?? 1.0,
+        args.createdBy ?? 'mcp:store',
+        args.metadata ? JSON.stringify(args.metadata) : null,
+      ],
+    )
+  } catch (err) {
+    console.error(
+      `[memory] recordMemoryDependency(${args.edgeType}, ${args.fromMemoryId}→${args.toMemoryId}) failed: ${err}`,
     )
   }
 }

--- a/migrations/014_memory_dependencies.sql
+++ b/migrations/014_memory_dependencies.sql
@@ -1,0 +1,83 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 014: memory_dependencies — typed edges between memory rows
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Phase 3 / Atlas Step 1 (see docs/plans/2026-04-29-phase-3-discipline-layer.md
+-- and PR #67 for the full design). Adds the edge table + indexes + backfills
+-- supersession edges from the legacy decisions.superseded_by chain.
+--
+-- Empty for graph traversal until either:
+--   1. callers pass `depends_on` / `supersedes` to the MCP `store` tool (lands
+--      in this PR — wires through to INSERTs below this migration), or
+--   2. the curator agent (Phase 3) starts inferring `cites` edges from
+--      memory body text (deferred).
+
+CREATE TABLE IF NOT EXISTS devbrain.memory_dependencies (
+    id              BIGSERIAL PRIMARY KEY,
+    from_memory_id  UUID NOT NULL REFERENCES devbrain.memory(id) ON DELETE CASCADE,
+    to_memory_id    UUID NOT NULL REFERENCES devbrain.memory(id) ON DELETE CASCADE,
+    edge_type       TEXT NOT NULL CHECK (edge_type IN ('cites', 'depends_on', 'supersedes', 'contradicts')),
+        -- 'cites'        → narrative reference, weakest signal
+        -- 'depends_on'   → invalidating to_memory should re-evaluate from_memory
+        -- 'supersedes'   → from_memory replaces to_memory (terminal)
+        -- 'contradicts'  → surfaced as an integrity issue
+    confidence      REAL NOT NULL DEFAULT 1.0 CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by      TEXT,                       -- 'curator' / 'agent' / 'manual' / 'migration:014'
+    metadata        JSONB,
+    -- Self-loops are nonsense; the trinity (from, to, type) must be unique so
+    -- repeated curator passes are idempotent.
+    CONSTRAINT chk_no_self_loop CHECK (from_memory_id <> to_memory_id),
+    CONSTRAINT uq_memory_dep_triplet UNIQUE (from_memory_id, to_memory_id, edge_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_dep_from
+    ON devbrain.memory_dependencies (from_memory_id);
+CREATE INDEX IF NOT EXISTS idx_memory_dep_to
+    ON devbrain.memory_dependencies (to_memory_id);
+CREATE INDEX IF NOT EXISTS idx_memory_dep_type
+    ON devbrain.memory_dependencies (edge_type);
+
+COMMENT ON TABLE devbrain.memory_dependencies IS
+    'Phase 3 / Atlas Step 1. Typed edges between memory rows. Drives the curator agent''s cascade re-evaluation when a memory is superseded. See docs/plans/2026-04-29-phase-3-discipline-layer.md.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Backfill from legacy decisions.superseded_by
+-- ─────────────────────────────────────────────────────────────────────────────
+-- decisions.superseded_by points FROM the old (superseded) row TO the new
+-- (superseding) row. The new edge_type='supersedes' edge is from NEW to OLD
+-- (matches the design: from_memory replaces to_memory).
+--
+-- Decisions land in devbrain.memory via Phase 2 dual-writes with
+-- memory.provenance_id = decisions.id and memory.kind = 'decision'. Use that
+-- to walk both endpoints onto memory rows.
+--
+-- ON CONFLICT DO NOTHING because uq_memory_dep_triplet makes this idempotent
+-- on re-runs of the migration in dev.
+
+INSERT INTO devbrain.memory_dependencies (
+    from_memory_id, to_memory_id, edge_type, confidence, created_by, metadata
+)
+SELECT
+    new_m.id,
+    old_m.id,
+    'supersedes',
+    1.0,
+    'migration:014',
+    jsonb_build_object(
+        'legacy_old_decision_id', old_d.id,
+        'legacy_new_decision_id', new_d.id
+    )
+FROM devbrain.decisions old_d
+JOIN devbrain.decisions new_d ON old_d.superseded_by = new_d.id
+JOIN devbrain.memory new_m
+    ON new_m.provenance_id = new_d.id AND new_m.kind = 'decision'
+JOIN devbrain.memory old_m
+    ON old_m.provenance_id = old_d.id AND old_m.kind = 'decision'
+WHERE old_d.superseded_by IS NOT NULL
+  AND new_m.id <> old_m.id
+ON CONFLICT (from_memory_id, to_memory_id, edge_type) DO NOTHING;
+
+-- Track this migration in schema_migrations (009 introduced the tracker).
+INSERT INTO devbrain.schema_migrations (filename, applied_at)
+VALUES ('014_memory_dependencies.sql', now())
+ON CONFLICT (filename) DO NOTHING;


### PR DESCRIPTION
## Summary

**Atlas Step 1** of the Phase 3 plan (design doc in #67 / `docs/plans/2026-04-29-phase-3-discipline-layer.md`).

Adds the substrate for cascade re-evaluation on supersession and citation tracking. This PR just lays the table + wires the MCP store tool to populate it; the curator agent (Step 5 in the plan) will consume the edges later.

## What lands

### Migration
- `migrations/014_memory_dependencies.sql` — typed-edge table (`cites` / `depends_on` / `supersedes` / `contradicts`), confidence float, unique `(from_memory_id, to_memory_id, edge_type)` for idempotency, and a self-loop CHECK.
- **Backfill** walks the legacy `decisions.superseded_by` chain inside the same migration and writes `supersedes` edges between the corresponding memory rows. ON CONFLICT DO NOTHING keeps re-runs safe.
- Self-records into `schema_migrations` (012/013 convention).

### MCP API
- `store` tool accepts new optional `depends_on?: string[]` and `supersedes?: string[]` arrays. Each entry can be either a memory.id or a legacy decision/pattern/issue id from search results — the helper resolves either form.
- `recordMemory` now returns the `memory.id` (was void) so callers can wire edges. The end_session caller is unchanged in behavior.
- New helpers in `mcp-server/src/memory.ts`: `resolveMemoryId(uuid)` and `recordMemoryDependency(...)`. Both best-effort, log-and-swallow on failure to match the existing dual-write pattern.

### Test
- Migration applied cleanly to local `devbrain-db` (CREATE TABLE, 3 indexes, COMMENT, backfill, schema_migrations bookkeeping). Backfill inserted 0 supersession edges in the local dev DB simply because no `decisions.superseded_by` chains exist there yet — the SQL itself is verified against the schema.
- TypeScript typecheck clean.

## Not in this PR
Curator-driven cascade re-evaluation (Step 2 in plan §7). The edges sit dormant until that ships. This PR is deliberately just the substrate so steps 2–7 can stack.

## Stacks on
PR #67 (design doc). This PR can merge before or after — the design doc isn't a code dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)