### PR TITLE
feat(cli): devbrain audit verify — wrap verify_chain() (Atlas Step 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 - **`memory.ts` helpers** — `recordMemory` now returns the `memory.id` for downstream edge wiring (was `void`); new `resolveMemoryId(uuid)` and `recordMemoryDependency(...)` helpers.
 - **Migration 015** — `devbrain.memory_ledger` hash-chained append-only audit table (SHA-256 row chain) + `_memory_ledger_record()` AFTER trigger on `devbrain.memory` (insert/update/delete) + `verify_chain(start_seq, end_seq)` SQL function returning the first chain divergence. Atlas Step 2. Tamper detection only — payload contents are NOT duplicated, only hashed.
 - **`pgcrypto` extension** added (was previously unused in the schema).
+- **`devbrain audit verify`** CLI command — wraps `verify_chain()` with project scoping, JSON output, and exit codes (0 intact / 1 broken / 2 operational failure) suitable for cron and CI smoke tests. Atlas Step 3.
 
 ## [Unreleased] — Factory Hardening Sprint
 

--- a/factory/audit_cli.py
+++ b/factory/audit_cli.py
@@ -1,0 +1,279 @@
+"""Click subcommands for the devbrain audit workflow.
+
+Wired into factory/cli.py via late imports — keeps cli.py from importing
+the DB layer at module load time.
+
+Provides:
+
+- ``devbrain audit verify`` — walks devbrain.memory_ledger via the SQL-side
+  verify_chain() function and reports the first divergence (or success).
+
+Suitable for cron / CI: exits 0 when the requested range is intact, exits 1
+when a break is found, exits 2 on operational failure (DB unreachable,
+ledger table missing, etc.). The fail-then-exit pattern matches the
+existing devdoctor / migration runners.
+
+Phase 3 / Atlas Step 3 — see docs/plans/2026-04-29-phase-3-discipline-layer.md.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+import sys
+from typing import Any
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _connect():
+    """Return a fresh psycopg2 connection from FACTORY_CONFIG.
+
+    Imported lazily so `--help` doesn't load psycopg2 / config.
+    """
+    from config import DATABASE_URL  # type: ignore[import-not-found]
+    import psycopg2  # type: ignore[import-not-found]
+
+    return psycopg2.connect(DATABASE_URL)
+
+
+def _ensure_ledger_exists(conn) -> bool:
+    """Return True iff devbrain.memory_ledger exists in this database.
+
+    A missing ledger is operational-failure territory (migration 015
+    hasn't run), not "intact" or "broken". We return False and let the
+    caller print a helpful error.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'devbrain' AND table_name = 'memory_ledger'
+            """
+        )
+        return cur.fetchone() is not None
+
+
+def _project_slug_to_seq_range(conn, project_slug: str) -> tuple[int, int] | None:
+    """Resolve (min_seq, max_seq) for a project's ledger entries.
+
+    Returns None if the project has zero ledger entries (caller should
+    treat as 'intact-trivially').
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT MIN(seq), MAX(seq) FROM devbrain.memory_ledger WHERE project_slug = %s",
+            (project_slug,),
+        )
+        row = cur.fetchone()
+        if not row or row[0] is None:
+            return None
+        return int(row[0]), int(row[1])
+
+
+def _verify(
+    conn,
+    start_seq: int,
+    end_seq: int | None,
+) -> list[dict[str, Any]]:
+    """Call devbrain.verify_chain() and return any break rows."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT broken_at_seq, expected_hash, actual_hash, reason "
+            "FROM devbrain.verify_chain(%s, %s)",
+            (start_seq, end_seq),
+        )
+        cols = ("broken_at_seq", "expected_hash", "actual_hash", "reason")
+        return [dict(zip(cols, r, strict=False)) for r in cur.fetchall()]
+
+
+def _count_in_range(conn, start_seq: int, end_seq: int | None, project_slug: str | None) -> int:
+    where = ["seq >= %s"]
+    params: list[Any] = [start_seq]
+    if end_seq is not None:
+        where.append("seq <= %s")
+        params.append(end_seq)
+    if project_slug:
+        where.append("project_slug = %s")
+        params.append(project_slug)
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT COUNT(*) FROM devbrain.memory_ledger WHERE {' AND '.join(where)}",
+            params,
+        )
+        return int(cur.fetchone()[0])
+
+
+# ---------------------------------------------------------------------------
+# Command: devbrain audit verify
+# ---------------------------------------------------------------------------
+
+
+@click.group(name="audit")
+def audit_group() -> None:
+    """Audit the devbrain.memory_ledger hash chain for tamper detection."""
+
+
+@audit_group.command(name="verify")
+@click.option(
+    "--project",
+    "project_slug",
+    default=None,
+    help="Restrict verification to a single project's ledger entries.",
+)
+@click.option(
+    "--start-seq",
+    type=int,
+    default=None,
+    help="First seq to verify. Defaults to 1 (or the project's min seq when --project is set).",
+)
+@click.option(
+    "--end-seq",
+    type=int,
+    default=None,
+    help="Last seq to verify. Defaults to the latest seq.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit JSON instead of human-readable output. Suitable for cron / piping.",
+)
+def verify_cmd(
+    project_slug: str | None,
+    start_seq: int | None,
+    end_seq: int | None,
+    as_json: bool,
+) -> None:
+    """Verify the memory_ledger hash chain.
+
+    Exit codes:
+      0 — chain intact across the requested range
+      1 — chain break detected (see output for first broken seq)
+      2 — operational failure (DB unreachable, ledger table missing, …)
+    """
+    try:
+        conn = _connect()
+    except Exception as exc:
+        msg = f"Could not connect to DevBrain DB: {exc}"
+        if as_json:
+            click.echo(_json.dumps({"status": "operational_failure", "error": msg}))
+        else:
+            click.echo(f"✗ {msg}", err=True)
+        sys.exit(2)
+
+    try:
+        if not _ensure_ledger_exists(conn):
+            msg = (
+                "devbrain.memory_ledger does not exist. "
+                "Run `devbrain migrate` to apply migration 015."
+            )
+            if as_json:
+                click.echo(
+                    _json.dumps({"status": "operational_failure", "error": msg})
+                )
+            else:
+                click.echo(f"✗ {msg}", err=True)
+            sys.exit(2)
+
+        # Resolve the seq range. When --project is set without --start-seq,
+        # use the project's min so we don't waste effort verifying earlier
+        # rows from other projects.
+        if project_slug and start_seq is None:
+            range_ = _project_slug_to_seq_range(conn, project_slug)
+            if range_ is None:
+                # Project has zero ledger entries — trivially intact.
+                if as_json:
+                    click.echo(
+                        _json.dumps(
+                            {
+                                "status": "intact",
+                                "rows_verified": 0,
+                                "project": project_slug,
+                                "note": "no ledger entries for project",
+                            }
+                        )
+                    )
+                else:
+                    click.echo(
+                        f"✓ {project_slug}: no ledger entries (trivially intact)"
+                    )
+                sys.exit(0)
+            start_seq = range_[0]
+            if end_seq is None:
+                end_seq = range_[1]
+
+        if start_seq is None:
+            start_seq = 1
+
+        breaks = _verify(conn, start_seq, end_seq)
+        rows_verified = _count_in_range(conn, start_seq, end_seq, project_slug)
+
+        if not breaks:
+            if as_json:
+                click.echo(
+                    _json.dumps(
+                        {
+                            "status": "intact",
+                            "rows_verified": rows_verified,
+                            "start_seq": start_seq,
+                            "end_seq": end_seq,
+                            "project": project_slug,
+                        }
+                    )
+                )
+            else:
+                scope = f" for {project_slug}" if project_slug else ""
+                click.echo(
+                    f"✓ Ledger intact{scope} ({rows_verified} rows verified, "
+                    f"seq {start_seq}..{end_seq if end_seq is not None else 'latest'})"
+                )
+            sys.exit(0)
+
+        # Break(s) found.
+        if as_json:
+            click.echo(
+                _json.dumps(
+                    {
+                        "status": "broken",
+                        "breaks": breaks,
+                        "rows_verified": rows_verified,
+                        "start_seq": start_seq,
+                        "end_seq": end_seq,
+                        "project": project_slug,
+                    }
+                )
+            )
+        else:
+            for b in breaks:
+                click.echo(
+                    f"✗ Broken at seq {b['broken_at_seq']}: {b['reason']}\n"
+                    f"  expected: {b['expected_hash']}\n"
+                    f"  actual:   {b['actual_hash']}",
+                    err=True,
+                )
+        sys.exit(1)
+
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Public registration hook (called from factory/cli.py)
+# ---------------------------------------------------------------------------
+
+
+def register(cli_group: click.Group) -> None:
+    """Wire the audit-CLI command group onto the parent click group."""
+    cli_group.add_command(audit_group)

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -60,6 +60,17 @@ def _register_project_cli() -> None:
 _register_project_cli()
 
 
+def _register_audit_cli() -> None:
+    try:
+        import audit_cli
+        audit_cli.register(cli)
+    except ImportError as e:
+        logger.debug("audit_cli not available: %s", e)
+
+
+_register_audit_cli()
+
+
 def _resolve_cli_names(cli_arg: str) -> list[str]:
     """Resolve `--cli` option into the list of adapter names."""
     import dev_login as _dl


### PR DESCRIPTION
## Summary

**Atlas Step 3** of the Phase 3 plan ([PR #67](https://github.com/nooma-stack/devbrain/pull/67)). Wraps the SQL-side `verify_chain()` function (added in #69) behind a friendly CLI suitable for cron and CI smoke tests.

## What lands

- **`factory/audit_cli.py`** — `devbrain audit verify` Click command
  - `--project SLUG` — scope to one project's ledger entries (uses MIN/MAX seq for that project as default range)
  - `--start-seq` / `--end-seq` — explicit range override
  - `--json` — emit structured output instead of human-readable
- **`factory/cli.py`** — late-imported registration hook (mirrors the existing `project_cli` pattern; keeps `cli.py` lean and `--help` paths free of psycopg2 imports).

## Exit codes

| Code | Meaning |
|---|---|
| 0 | Ledger intact across the requested range |
| 1 | Chain break detected (first break printed/emitted) |
| 2 | Operational failure (DB unreachable, ledger table missing) |

## Verified locally

- `devbrain audit --help` and `devbrain audit verify --help` render correctly.
- Empty ledger → exit 0, "no rows" message.
- After memory writes (which trigger the ledger via #69's AFTER triggers) → exit 0, "N rows verified".
- Tamper `payload_hash` on a past row → exit 1, prints expected vs actual hex hashes and `reason='row_hash-mismatch'`.
- Bad DB creds → exit 2, `operational_failure` status with the underlying psycopg2 error.

## Stacks on

PR #69 (Atlas Step 2 — verify_chain SQL function), merged. Step 4 (postulate tests) consumes this CLI's exit codes as fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)