### PR TITLE
feat(tests): first three postulate tests (Atlas Step 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 - **Migration 015** — `devbrain.memory_ledger` hash-chained append-only audit table (SHA-256 row chain) + `_memory_ledger_record()` AFTER trigger on `devbrain.memory` (insert/update/delete) + `verify_chain(start_seq, end_seq)` SQL function returning the first chain divergence. Atlas Step 2. Tamper detection only — payload contents are NOT duplicated, only hashed.
 - **`pgcrypto` extension** added (was previously unused in the schema).
 - **`devbrain audit verify`** CLI command — wraps `verify_chain()` with project scoping, JSON output, and exit codes (0 intact / 1 broken / 2 operational failure) suitable for cron and CI smoke tests. Atlas Step 3.
+- **`tests/postulates/`** — first three AGM-style postulate tests covering the discipline layer. P1 (supersession cascades) and P2 (archived memory excluded from curator brief) ship as `xfail(strict=True)` pending the curator agent (Atlas Step 5); P3 (HIPAA cross-project memory isolation) is active today and asserts the substrate guarantee directly. Local-only for now — DB-available CI workflow is tracked separately. Atlas Step 4. See [tests/postulates/README.md](tests/postulates/README.md).
 
 ## [Unreleased] — Factory Hardening Sprint
 

--- a/tests/postulates/README.md
+++ b/tests/postulates/README.md
@@ -1,0 +1,67 @@
+# Postulate tests
+
+AGM-style postulate tests for DevBrain's discipline layer. One file
+per postulate, named `test_pN_*.py`. See
+`docs/plans/2026-04-29-phase-3-discipline-layer.md` §3.3 + §7 for
+the design.
+
+## Running
+
+These tests require a real Postgres (the substrate they exercise —
+`memory_dependencies`, `memory_ledger`, the trigger chain — does
+not have a useful in-memory mock). Start the local DB:
+
+```sh
+docker compose up -d devbrain-db
+```
+
+Set the password (read from your `~/devbrain/.env` or wherever you
+keep it) and run pytest from the repo root:
+
+```sh
+export DEVBRAIN_DB_PASSWORD=...   # or DEVBRAIN_TEST_DATABASE_URL=...
+pip install psycopg2-binary       # if not already installed
+python -m pytest tests/postulates/ -v
+```
+
+Connection defaults: `127.0.0.1:5433`, user `devbrain`, db
+`devbrain`. Override individually via `DEVBRAIN_DB_HOST`,
+`DEVBRAIN_DB_HOST_PORT`, `DEVBRAIN_DB_USER`, `DEVBRAIN_DB_NAME`, or
+collectively via `DEVBRAIN_TEST_DATABASE_URL`.
+
+## CI
+
+Not yet wired. The repo's `pytest` job runs a curated **no-DB**
+allow-list (see `.github/workflows/test.yml`) that deliberately
+excludes anything that touches Postgres. A DB-available workflow
+with a `pgvector/pgvector:pg17` service container is the planned
+follow-up — see the comment block in `test.yml` for the migration
+ordering caveat.
+
+## xfail policy
+
+Postulates whose enforcement layer hasn't shipped yet are marked
+`@pytest.mark.xfail(strict=True, reason=...)`. Strict mode means an
+unexpected pass (`XPASS`) fails the suite. That guarantees:
+
+- adding the enforcement layer (e.g. the curator agent) without
+  removing the marker fails CI loudly, forcing you back here to
+  own the postulate.
+- removing the enforcement layer in the future fails CI loudly.
+
+Today's xfailed postulates and what unblocks them:
+
+| Postulate | Unblocked by |
+|-----------|--------------|
+| P1 — supersession cascade re-eval | Atlas Step 5 (curator agent + cascade re-eval queue) |
+| P2 — archived memory excluded from curator brief | Atlas Step 5 (curator agent) |
+
+## Adding a new postulate
+
+1. Drop a one-paragraph postulate statement at the top of the
+   test file (mirrors the format in §3.3 of the plan).
+2. Write a deterministic fixture that asserts it.
+3. If the enforcement layer doesn't ship yet, mark it
+   `xfail(strict=True, reason=...)` with a pointer to the plan
+   step that lands it.
+4. Document the unblock condition in the table above.

--- a/tests/postulates/conftest.py
+++ b/tests/postulates/conftest.py
@@ -1,0 +1,129 @@
+"""Shared fixtures for the AGM-style postulate tests.
+
+These tests run against a real Postgres (devbrain-db on 127.0.0.1:5433
+by default). They are deliberately excluded from the no-DB CI subset
+in .github/workflows/test.yml — see tests/postulates/README.md for the
+local invocation. A DB-available CI workflow is tracked as follow-up
+work in that same comment.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+psycopg2 = pytest.importorskip("psycopg2")
+
+
+# Every postulate-test row is tagged with this prefix so the cleanup
+# fixture can wipe its own droppings without touching real data.
+TEST_TAG = "postulate_test_"
+
+
+def _database_url() -> str:
+    explicit = os.getenv("DEVBRAIN_TEST_DATABASE_URL")
+    if explicit:
+        return explicit
+    user = os.getenv("DEVBRAIN_DB_USER", "devbrain")
+    password = os.getenv("DEVBRAIN_DB_PASSWORD")
+    host = os.getenv("DEVBRAIN_DB_HOST", "127.0.0.1")
+    port = os.getenv("DEVBRAIN_DB_HOST_PORT", "5433")
+    name = os.getenv("DEVBRAIN_DB_NAME", "devbrain")
+    if not password:
+        pytest.skip(
+            "DEVBRAIN_DB_PASSWORD (or DEVBRAIN_TEST_DATABASE_URL) not set; "
+            "postulate tests require a real Postgres."
+        )
+    return f"postgresql://{user}:{password}@{host}:{port}/{name}"
+
+
+@pytest.fixture(scope="session")
+def database_url() -> str:
+    return _database_url()
+
+
+@pytest.fixture
+def conn(database_url):
+    """Per-test connection with autocommit OFF so cleanup is total."""
+    c = psycopg2.connect(database_url)
+    try:
+        # Annotate this session as a postulate test so audit ledger rows
+        # are easy to spot. Read by the trigger via current_setting().
+        with c.cursor() as cur:
+            cur.execute("SET devbrain.actor = 'postulate-test'")
+        c.commit()
+        yield c
+    finally:
+        c.rollback()
+        c.close()
+
+
+@pytest.fixture
+def project_factory(conn):
+    """Create disposable projects with a unique slug. Cleaned up at teardown."""
+    created: list[str] = []
+
+    def make(slug_hint: str = "p") -> dict:
+        slug = f"{TEST_TAG}{slug_hint}_{uuid.uuid4().hex[:8]}"
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.projects (slug, name) VALUES (%s, %s) "
+                "RETURNING id, slug",
+                (slug, f"Postulate Test {slug_hint}"),
+            )
+            row = cur.fetchone()
+        conn.commit()
+        created.append(row[0])
+        return {"id": row[0], "slug": row[1]}
+
+    yield make
+
+    # The test itself may have left the connection in an aborted-
+    # transaction state (e.g. an xfail test that probed a missing
+    # table). Roll back before cleanup so the DELETE statements run.
+    conn.rollback()
+
+    # Order: ledger rows first (no FK), then deps, then memory, then project.
+    with conn.cursor() as cur:
+        for pid in created:
+            cur.execute(
+                "DELETE FROM devbrain.memory_ledger "
+                "WHERE memory_id IN (SELECT id FROM devbrain.memory WHERE project_id = %s)",
+                (pid,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.memory_dependencies "
+                "WHERE from_memory_id IN (SELECT id FROM devbrain.memory WHERE project_id = %s) "
+                "   OR to_memory_id   IN (SELECT id FROM devbrain.memory WHERE project_id = %s)",
+                (pid, pid),
+            )
+            cur.execute("DELETE FROM devbrain.memory WHERE project_id = %s", (pid,))
+            cur.execute("DELETE FROM devbrain.projects WHERE id = %s", (pid,))
+    conn.commit()
+
+
+@pytest.fixture
+def memory_factory(conn):
+    """Insert a devbrain.memory row directly (bypassing the MCP server)."""
+    def make(
+        project_id: str,
+        *,
+        kind: str = "decision",
+        title: str | None = None,
+        content: str | None = None,
+        provenance_id: str | None = None,
+    ) -> dict:
+        title = title or f"{TEST_TAG}title_{uuid.uuid4().hex[:6]}"
+        content = content or f"{TEST_TAG}body_{uuid.uuid4().hex[:6]}"
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.memory (project_id, kind, title, content, provenance_id) "
+                "VALUES (%s, %s, %s, %s, %s) RETURNING id",
+                (project_id, kind, title, content, provenance_id),
+            )
+            row = cur.fetchone()
+        conn.commit()
+        return {"id": row[0], "title": title, "content": content, "kind": kind}
+
+    return make

--- a/tests/postulates/test_p1_supersession_cascades.py
+++ b/tests/postulates/test_p1_supersession_cascades.py
@@ -1,0 +1,81 @@
+"""P1 — Supersession cascades.
+
+POSTULATE
+---------
+When a memory M is superseded by M', every memory that has a
+'depends_on' edge to M is re-queued for curator re-evaluation
+within the same transaction.
+
+STATUS
+------
+xfail(strict=True) until the curator agent (Atlas Step 5 in
+docs/plans/2026-04-29-phase-3-discipline-layer.md §7) lands. The
+substrate that the test stands on (memory_dependencies edges) is
+already shipped in migration 014 — what's missing is the curator's
+re-evaluation queue.
+
+Strict mode means: the day the curator queue does start surfacing
+dependents, this test FLIPS GREEN and CI fails (XPASS). That forces
+us back here to remove the xfail marker and own the postulate
+properly. Without strict=True the test would silently keep "passing
+by failing" forever.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Curator cascade re-eval queue lands in Atlas Step 5; "
+    "see docs/plans/2026-04-29-phase-3-discipline-layer.md §4.",
+)
+def test_supersession_queues_dependent_for_reeval(
+    conn, project_factory, memory_factory
+):
+    project = project_factory("p1")
+    m_old = memory_factory(
+        project["id"], kind="pattern", content="use aiopg for async pg"
+    )
+    m_dep = memory_factory(
+        project["id"], kind="issue", content="aiopg connection pool deadlock fix"
+    )
+
+    # m_dep depends_on m_old
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            (m_dep["id"], m_old["id"]),
+        )
+    conn.commit()
+
+    # Supersede m_old with a new memory and record the supersedes edge.
+    m_new = memory_factory(
+        project["id"], kind="pattern", content="use asyncpg for async pg"
+    )
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET archived_at = now() WHERE id = %s",
+            (m_old["id"],),
+        )
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'supersedes', 'postulate-test')",
+            (m_new["id"], m_old["id"]),
+        )
+    conn.commit()
+
+    # The curator re-eval queue does not exist yet. When Step 5 lands
+    # this query needs to be replaced with the real reader.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT memory_id FROM devbrain.curator_reeval_queue "
+            "WHERE project_id = %s",
+            (project["id"],),
+        )
+        queued = [r[0] for r in cur.fetchall()]
+
+    assert m_dep["id"] in queued

--- a/tests/postulates/test_p2_archived_excluded.py
+++ b/tests/postulates/test_p2_archived_excluded.py
@@ -1,0 +1,57 @@
+"""P2 — Archived memory is excluded from the curator brief.
+
+POSTULATE
+---------
+A memory with archived_at IS NOT NULL must never appear in the
+curator's project brief, regardless of its strength or recency.
+
+STATUS
+------
+xfail(strict=True) until the curator agent (Atlas Step 5 in
+docs/plans/2026-04-29-phase-3-discipline-layer.md §4) ships. The
+substrate (archived_at column on devbrain.memory) is already in
+place from migration 010, so the *data* the curator will need to
+read is fully testable today — only the curator function itself is
+missing.
+
+When Step 5 lands this xfail flips XPASS and CI forces us back here
+to remove the marker.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Curator agent + brief assembly lands in Atlas Step 5; "
+    "see docs/plans/2026-04-29-phase-3-discipline-layer.md §4.",
+)
+def test_archived_memory_not_in_curator_brief(
+    conn, project_factory, memory_factory
+):
+    project = project_factory("p2")
+    live = memory_factory(
+        project["id"], kind="pattern", content="live pattern: prefer asyncpg"
+    )
+    stale = memory_factory(
+        project["id"], kind="pattern", content="stale pattern: prefer aiopg"
+    )
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET archived_at = now() WHERE id = %s",
+            (stale["id"],),
+        )
+    conn.commit()
+
+    # Curator entrypoint does not exist yet. Once Atlas Step 5 lands,
+    # replace this with the real `assemble_curator_brief(project_id)`
+    # call. Until then we import-fail and pytest treats the test as
+    # xfail.
+    from factory.curator import assemble_curator_brief  # type: ignore[import-not-found]
+
+    brief = assemble_curator_brief(project["id"])
+    brief_ids = {entry.memory_id for entry in brief.entries}
+
+    assert live["id"] in brief_ids
+    assert stale["id"] not in brief_ids

--- a/tests/postulates/test_p3_hipaa_isolation.py
+++ b/tests/postulates/test_p3_hipaa_isolation.py
@@ -1,0 +1,77 @@
+"""P3 — Cross-project memory isolation (HIPAA).
+
+POSTULATE
+---------
+A query scoped to project A must never return memory rows whose
+project_id resolves to a different project. This is the substrate
+guarantee that BrightBrain (HIPAA-bound) relies on to keep PHI from
+leaking into general-purpose projects via the memory store.
+
+STATUS
+------
+Active. The substrate enforces this today via the project_id NOT
+NULL FK plus the WHERE-clause discipline in every reader. This test
+documents and proves the invariant directly so any future change
+that breaks isolation (e.g. a "cross-project lessons" feature added
+without an opt-in flag) trips a postulate failure.
+
+See docs/plans/2026-04-29-phase-3-discipline-layer.md §3.3 for the
+postulate-then-test methodology.
+"""
+from __future__ import annotations
+
+
+def test_memory_query_scoped_to_project_excludes_other_projects(
+    conn, project_factory, memory_factory
+):
+    project_a = project_factory("a")
+    project_b = project_factory("b")
+
+    a_mem = memory_factory(
+        project_a["id"],
+        kind="decision",
+        title="phi-handling",
+        content="route PHI through encrypted column",
+    )
+    b_mem = memory_factory(
+        project_b["id"],
+        kind="decision",
+        title="non-phi",
+        content="route logs through stdout",
+    )
+
+    # The exact reader used by the curator brief / context loader is a
+    # straight WHERE clause on project_id. Reproduce it here.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.memory "
+            "WHERE project_id = %s AND archived_at IS NULL",
+            (project_a["id"],),
+        )
+        a_ids = {r[0] for r in cur.fetchall()}
+
+        cur.execute(
+            "SELECT id FROM devbrain.memory "
+            "WHERE project_id = %s AND archived_at IS NULL",
+            (project_b["id"],),
+        )
+        b_ids = {r[0] for r in cur.fetchall()}
+
+    assert a_mem["id"] in a_ids
+    assert b_mem["id"] not in a_ids
+    assert b_mem["id"] in b_ids
+    assert a_mem["id"] not in b_ids
+
+
+def test_memory_project_id_is_not_null(conn):
+    """The FK + NOT NULL together are the load-bearing constraint —
+    a regression that drops NOT NULL would let an unscoped row slip
+    into 'every project's' query results."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT is_nullable FROM information_schema.columns "
+            "WHERE table_schema = 'devbrain' AND table_name = 'memory' "
+            "AND column_name = 'project_id'"
+        )
+        is_nullable = cur.fetchone()[0]
+    assert is_nullable == "NO"


### PR DESCRIPTION
## Summary

Adds `tests/postulates/` — AGM-style postulate tests for the Phase 3 discipline layer per [docs/plans/2026-04-29-phase-3-discipline-layer.md](docs/plans/2026-04-29-phase-3-discipline-layer.md) §3.3 + §7 (PR #67). One file per postulate; each opens with a one-paragraph statement followed by a deterministic fixture that asserts the invariant.

This is **Atlas Step 4** in the Phase 3 implementation order. Builds on:
- PR #68 — `memory_dependencies` edge table (Step 1)
- PR #69 — `memory_ledger` + hash chain (Step 2)
- PR #70 — `devbrain audit verify` CLI (Step 3)

## Postulates included

| Postulate | Status | Unblocked by |
|-----------|--------|--------------|
| P1 — supersession cascades re-queue dependents for curator re-evaluation | `xfail(strict=True)` | Atlas Step 5 (curator agent) |
| P2 — archived memory must not appear in the curator brief | `xfail(strict=True)` | Atlas Step 5 (curator agent) |
| P3 — cross-project memory isolation (HIPAA) | **passing** | n/a — substrate enforces this today via `project_id` NOT NULL FK + WHERE-clause discipline |

`strict=True` means an unexpected pass fails CI. When Step 5 lands and either xfailed test starts passing, the developer is forced back here to remove the marker and own the postulate properly. Without strict mode the test would silently keep "passing by failing" forever.

## CI

**Not wired yet.** The repo's pytest job runs a curated no-DB allow-list (see `.github/workflows/test.yml`); postulate tests need a real Postgres. `tests/postulates/README.md` covers local invocation. A DB-available workflow with a `pgvector/pgvector:pg17` service container is tracked as the planned follow-up (per the comment block in `test.yml` referencing migrate-vs-schema-bootstrap ordering).

## Local run

```sh
docker compose up -d devbrain-db
export DEVBRAIN_DB_PASSWORD=...
python -m pytest tests/postulates/ -v
```

Result on this branch:
```
tests/postulates/test_p1_supersession_cascades.py::test_supersession_queues_dependent_for_reeval XFAIL
tests/postulates/test_p2_archived_excluded.py::test_archived_memory_not_in_curator_brief XFAIL
tests/postulates/test_p3_hipaa_isolation.py::test_memory_query_scoped_to_project_excludes_other_projects PASSED
tests/postulates/test_p3_hipaa_isolation.py::test_memory_project_id_is_not_null PASSED
2 passed, 2 xfailed
```

## Test plan

- [x] Locally: `python -m pytest tests/postulates/ -v` — 2 passed, 2 xfailed
- [x] Cleanup fixture removes all `postulate_test_%` rows even when a test xfails after starting an aborted Postgres transaction
- [x] No leftover projects/memory/ledger rows after a clean run
- [x] CHANGELOG.md updated under `[Unreleased] — Phase 3 / Atlas integrations`
- [ ] CI green (existing no-DB pytest job — postulate tests are NOT in the allow-list, so this PR shouldn't change that job's behavior)

## Next

After this lands, **Steps 5-7** (curator agent + eval agents + compliance rule engine) require Phase 3 agent-pipeline scaffolding that doesn't exist yet. Pausing for design check before continuing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)