### PR TITLE
feat(curator): Atlas Step 5b — strength.py pure formula

### DIFF
--- a/factory/curator/strength.py
+++ b/factory/curator/strength.py
@@ -1,0 +1,56 @@
+"""Cascade strength formula — pure functions, no DB dependency.
+
+Forward-compat: callable from Phase 6 cognify offline for batch reweighting
+(playbook §9). Do NOT add DB calls here. Do NOT add LLM calls here.
+
+The formula:
+    new_strength = max(0, old_strength - cascade_penalty(edge_type, age_seconds))
+
+where cascade_penalty is the per-edge-type base penalty modulated by a 24h
+half-life freshness decay. Bounded subtraction keeps multi-hop cascades
+from compounding to zero through dep depth alone — a 4-hop cascade
+through bounded penalties stays sensible.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+# Per-edge-type base penalty. Tuned conservatively — penalties are deliberately
+# small so a single cascade rarely zeroes out a memory. The end_session
+# judgment agent provides additional adjustments on top.
+PENALTY: dict[str, float] = {
+    "supersedes": 0.40,    # upstream replaced — strongest signal
+    "archived_at": 0.25,   # upstream archived — moderate
+    "applies_when": 0.10,  # upstream's context changed — light touch
+}
+
+
+def freshness_decay(age_seconds: float) -> float:
+    """Penalty fades with time. Half-life = 24 hours.
+
+    At 0s: 1.0 (full penalty)
+    At 24h: 0.5 (half penalty)
+    At 48h: 0.25
+    At 1 week: ~0.0014
+    """
+    return 0.5 ** (age_seconds / 86400)
+
+
+def cascade_penalty(edge_type: str, age_seconds: float) -> Decimal:
+    """Base penalty modulated by freshness decay.
+
+    Raises KeyError if edge_type is not in PENALTY.
+    """
+    base = PENALTY[edge_type]
+    return Decimal(str(base * freshness_decay(age_seconds)))
+
+
+def apply_cascade(
+    strength: Decimal, edge_type: str, age_seconds: float
+) -> Decimal:
+    """Apply a cascade penalty, clamped at zero.
+
+    Pure function — call this from anywhere (worker, cognify, postulate test).
+    """
+    new = strength - cascade_penalty(edge_type, age_seconds)
+    return max(Decimal("0"), new)

--- a/factory/tests/test_curator_strength.py
+++ b/factory/tests/test_curator_strength.py
@@ -1,0 +1,64 @@
+"""Unit tests for curator strength formula (pure functions)."""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from curator.strength import (
+    PENALTY,
+    apply_cascade,
+    cascade_penalty,
+    freshness_decay,
+)
+
+
+def test_penalty_constants_ordered():
+    """supersedes > archived_at > applies_when."""
+    assert PENALTY["supersedes"] > PENALTY["archived_at"] > PENALTY["applies_when"]
+
+
+def test_freshness_decay_at_zero_seconds_is_one():
+    assert freshness_decay(0) == 1.0
+
+
+def test_freshness_decay_at_24h_is_half():
+    assert freshness_decay(86400) == pytest.approx(0.5, rel=1e-9)
+
+
+def test_freshness_decay_at_48h_is_quarter():
+    assert freshness_decay(86400 * 2) == pytest.approx(0.25, rel=1e-9)
+
+
+def test_cascade_penalty_zero_age_supersedes():
+    p = cascade_penalty("supersedes", 0)
+    assert p == Decimal(str(PENALTY["supersedes"]))
+
+
+def test_cascade_penalty_decays_with_age():
+    p_now = cascade_penalty("supersedes", 0)
+    p_24h = cascade_penalty("supersedes", 86400)
+    assert p_24h < p_now
+    assert p_24h == pytest.approx(p_now / 2, rel=1e-6)
+
+
+def test_cascade_penalty_unknown_edge_type_raises():
+    with pytest.raises(KeyError):
+        cascade_penalty("not_an_edge", 0)
+
+
+def test_apply_cascade_subtracts_penalty():
+    new = apply_cascade(Decimal("0.85"), "supersedes", 0)
+    assert new == Decimal("0.85") - cascade_penalty("supersedes", 0)
+
+
+def test_apply_cascade_clamped_at_zero():
+    new = apply_cascade(Decimal("0.10"), "supersedes", 0)
+    assert new == Decimal("0")
+    assert new >= Decimal("0")  # never negative
+
+
+def test_apply_cascade_strong_memory_survives():
+    # 0.85 strength, applies_when (lightest) cascade — should retain meaningful strength
+    new = apply_cascade(Decimal("0.85"), "applies_when", 0)
+    assert new > Decimal("0.5")


### PR DESCRIPTION
## Summary

Phase 5b of Atlas Step 5 (Curator). Pure-function cascade penalty formula with 24-hour freshness decay — no DB, no LLM, no async. Builds on Phase 5a's substrate (migration 017 + curator/types.py + DB test fixtures, merged in `798f187` on main).

## What's in this PR

- `factory/curator/strength.py` — three pure functions:
  - `freshness_decay(age_seconds)` — exponential decay, half-life 24h
  - `cascade_penalty(edge_type, age_seconds)` — base penalty × decay; raises `KeyError` for unknown edges
  - `apply_cascade(strength, edge_type, age_seconds)` — bounded subtraction, clamped at zero
- `factory/tests/test_curator_strength.py` — 10 tests, **100% coverage** on `curator/strength.py` (no missing lines)

## Formula

```
new_strength = max(0, old_strength - cascade_penalty(edge_type, age_seconds))
```

Per-edge-type base penalty constants (tuned conservatively, ordered by severity):

| Edge type     | Base penalty | Rationale                                   |
|---------------|--------------|---------------------------------------------|
| `supersedes`  | 0.40         | upstream replaced — strongest signal        |
| `archived_at` | 0.25         | upstream archived — moderate                |
| `applies_when`| 0.10         | upstream's context changed — light touch    |

Bounded additive subtraction (vs. multiplicative) keeps multi-hop cascades sensible — a 4-hop cascade through bounded penalties stays within reasonable territory and doesn't compound to zero through dep depth alone.

## Forward-compat

The pure-function design is intentional: Phase 6 cognify can call these offline for batch reweighting (per playbook §9) without taking on a DB or LLM dependency. No state, no I/O.

## Test plan

- [x] TDD: failing test written first (`ModuleNotFoundError: No module named 'curator.strength'`)
- [x] Implementation passes all 10 tests
- [x] 100% coverage on `curator/strength.py` (`pytest --cov=curator.strength --cov-report=term-missing` → no missing lines)
- [x] No-DB CI subset + curator tests: **196 passed** (180 baseline + 6 curator types from 5a + 10 strength from 5b)
- [x] Only 2 files changed (strength.py + test_curator_strength.py)

## Scope discipline

This PR contains **only** the pure formula. Out of scope (and not touched):
- `worker.py` — Task 5c (separate PR)
- `brief.py` — Task 5d (separate PR)
- Migration 017 — already merged in Phase 5a (`798f187`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)