### PR TITLE
feat(curator): Atlas Step 5c — cascade worker + 3 postulates

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2749,5 +2749,40 @@ def import_memory_cmd(in_path: Path, dry_run: bool) -> None:
     click.echo(mem_msg)
 
 
+# ---------------------------------------------------------------------------
+# Curator subcommands — cascade re-eval queue operations.
+# ---------------------------------------------------------------------------
+
+@cli.group()
+def curator():
+    """Curator agent + cascade queue operations."""
+
+
+@curator.command("queue-stuck")
+def cmd_queue_stuck():
+    """List re-eval queue rows that failed 3+ times.
+
+    These rows have exhausted their retry budget and are skipped by the
+    drain worker. Operator triage: investigate `last_error`, then either
+    fix the underlying problem and DELETE the row (a fresh enqueue is
+    permitted because the dedup partial unique index excludes
+    attempt_count >= 3 rows), or accept the stale strength.
+    """
+    from curator.cli import list_stuck_queue_rows
+
+    db = get_db()
+    with db._conn() as conn:
+        rows = list_stuck_queue_rows(conn)
+    if not rows:
+        click.echo("No stuck rows.")
+        return
+    for r in rows:
+        click.echo(
+            f"{r['id']}  memory={r['memory_id']}  "
+            f"src={r['cascade_source_id']}  edge={r['edge_type']}  "
+            f"attempts={r['attempt_count']}  err={r['last_error']!r}"
+        )
+
+
 if __name__ == "__main__":
     cli()

--- a/factory/curator/cli.py
+++ b/factory/curator/cli.py
@@ -1,0 +1,34 @@
+"""CLI surface for curator operations.
+
+Pure-Python helpers that take an existing psycopg2 connection. The
+Click subcommand wrappers live in factory/cli.py — they wire these
+helpers up to a real DB connection and pretty-print the output.
+
+Keeping the data-fetching code free of Click is deliberate so the
+postulate test for P_stuck_surface_able can import it directly.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def list_stuck_queue_rows(conn: Any) -> list[dict]:
+    """Return queue rows that have failed 3+ times.
+
+    Used by `devbrain curator queue-stuck` and the P_stuck postulate.
+    Rows are returned newest-source-first (FIFO drain order). Each row
+    is a dict with keys: id, memory_id, cascade_source_id, edge_type,
+    enqueued_at, attempt_count, last_error.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, memory_id, cascade_source_id, edge_type,
+                   enqueued_at, attempt_count, last_error
+            FROM devbrain.curator_re_eval_queue
+            WHERE attempt_count >= 3
+            ORDER BY enqueued_at
+            """
+        )
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, row)) for row in cur.fetchall()]

--- a/factory/curator/worker.py
+++ b/factory/curator/worker.py
@@ -1,0 +1,188 @@
+"""Cascade re-evaluation queue drainer.
+
+Runs in the existing factory orchestrator process — no new daemon. Adds
+one sibling poll alongside the existing factory_jobs poll.
+
+Each batch:
+1. SELECT ... FOR UPDATE SKIP LOCKED claims up to batch_size rows.
+2. For each: load memory, compute new_strength, UPDATE memory, DELETE
+   queue row.
+3. Multi-hop: if penalty was significant (> MULTI_HOP_THRESHOLD after
+   freshness decay), walk the row's own dependents and enqueue them.
+
+On exception: increment attempt_count, persist last_error, leave queue
+row in place. After 3 failures, the row is filtered out by both the
+SELECT-FOR-UPDATE WHERE clause and the dedup partial unique index, so a
+fresh enqueue of the same triplet is permitted once an operator has
+triaged the failure.
+
+Cycle prevention: each row carries an enqueued_at timestamp. The worker
+also reads memory.last_cascade_at; if that timestamp is at-or-after the
+queue row's enqueued_at the row is dropped without doing work — this
+breaks dependency cycles (A -> B -> A) cleanly.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from curator.strength import apply_cascade, cascade_penalty
+
+logger = logging.getLogger(__name__)
+
+# Multi-hop propagation threshold. If a cascade's penalty (after
+# freshness decay) is smaller than this, don't bother propagating to the
+# dependent's own dependents — too small to matter.
+MULTI_HOP_THRESHOLD = Decimal("0.05")
+
+
+def drain_one_batch(conn: Any, batch_size: int = 50) -> int:
+    """Drain up to batch_size rows from curator_re_eval_queue.
+
+    Returns the number of rows successfully drained (queue rows DELETEd).
+    Failed rows stay in the queue with attempt_count incremented.
+    """
+    drained = 0
+    with conn.cursor() as cur:
+        # Claim a batch with SKIP LOCKED — multiple workers safe.
+        cur.execute(
+            """
+            SELECT id, memory_id, cascade_source_id, edge_type, enqueued_at,
+                   attempt_count
+            FROM devbrain.curator_re_eval_queue
+            WHERE attempt_count < 3
+            ORDER BY enqueued_at
+            LIMIT %s
+            FOR UPDATE SKIP LOCKED
+            """,
+            (batch_size,),
+        )
+        rows = cur.fetchall()
+
+    for row in rows:
+        queue_id, memory_id, source_id, edge_type, enqueued_at, _attempts = row
+        try:
+            _process_one(
+                conn, queue_id, memory_id, source_id, edge_type, enqueued_at
+            )
+            drained += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("drain_one_batch: row %s failed", queue_id)
+            # Roll back any partial in-flight work from _process_one
+            # before opening a fresh cursor for the failure-bookkeeping
+            # UPDATE — otherwise psycopg2 raises InFailedTransaction.
+            conn.rollback()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE devbrain.curator_re_eval_queue "
+                    "SET attempt_count = attempt_count + 1, last_error = %s "
+                    "WHERE id = %s",
+                    (str(exc)[:1000], queue_id),
+                )
+            conn.commit()
+
+    return drained
+
+
+def _process_one(
+    conn: Any,
+    queue_id: Any,
+    memory_id: Any,
+    source_id: Any,
+    edge_type: str,
+    enqueued_at: datetime,
+) -> None:
+    """Process a single queue row in its own transaction."""
+    with conn.cursor() as cur:
+        # Load target memory.
+        cur.execute(
+            "SELECT strength, archived_at, last_cascade_at "
+            "FROM devbrain.memory WHERE id = %s",
+            (memory_id,),
+        )
+        result = cur.fetchone()
+        if result is None:
+            # Memory deleted — drop queue row.
+            cur.execute(
+                "DELETE FROM devbrain.curator_re_eval_queue WHERE id = %s",
+                (queue_id,),
+            )
+            conn.commit()
+            return
+        strength, archived_at, last_cascade_at = result
+
+        # Cycle prevention: skip if already cascaded since this source's
+        # mutation. The wider-than-strict ">=" comparison means the row
+        # is a no-op if anything cascaded after the source mutation,
+        # which is exactly what we want for A->B->A dependency cycles.
+        if last_cascade_at is not None and last_cascade_at >= enqueued_at:
+            cur.execute(
+                "DELETE FROM devbrain.curator_re_eval_queue WHERE id = %s",
+                (queue_id,),
+            )
+            conn.commit()
+            return
+
+        # Archived — drop the queue row, don't update strength, don't
+        # propagate to dependents. Archived rows are excluded from the
+        # planning brief (P2) so further weakening is pointless.
+        if archived_at is not None:
+            cur.execute(
+                "DELETE FROM devbrain.curator_re_eval_queue WHERE id = %s",
+                (queue_id,),
+            )
+            conn.commit()
+            return
+
+        age_seconds = (
+            datetime.now(timezone.utc) - enqueued_at
+        ).total_seconds()
+        new_strength = apply_cascade(strength, edge_type, age_seconds)
+        penalty = cascade_penalty(edge_type, age_seconds)
+
+        cur.execute(
+            "UPDATE devbrain.memory "
+            "SET strength = %s, last_cascade_at = NOW() "
+            "WHERE id = %s",
+            (new_strength, memory_id),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.curator_re_eval_queue WHERE id = %s",
+            (queue_id,),
+        )
+
+        # Multi-hop propagation. Cycle prevention is two-layer:
+        #
+        #   1. Propagate the cascade wave's timestamp (this row's
+        #      enqueued_at) into the new row instead of letting NOW()
+        #      win. A multi-hop row is logically "from the same wave"
+        #      as its parent, so its enqueued_at must match — that's
+        #      what lets the `last_cascade_at >= enqueued_at` guard in
+        #      _process_one short-circuit a repeat visit.
+        #   2. Filter out dependents whose memory.last_cascade_at is
+        #      at-or-after this row's enqueued_at — they were already
+        #      touched by this same wave.
+        #
+        # Combined with the dedup partial unique index
+        # (idx_re_eval_queue_dedup, partial WHERE attempt_count < 3) on
+        # (memory_id, cascade_source_id, edge_type), this guarantees a
+        # cycle (A->B->A) converges in one wave.
+        if penalty > MULTI_HOP_THRESHOLD:
+            cur.execute(
+                "INSERT INTO devbrain.curator_re_eval_queue "
+                "(memory_id, cascade_source_id, edge_type, enqueued_at) "
+                "SELECT d.from_memory_id, %s, %s, %s "
+                "FROM devbrain.memory_dependencies d "
+                "JOIN devbrain.memory m ON m.id = d.from_memory_id "
+                "WHERE d.to_memory_id = %s "
+                "  AND d.edge_type = 'depends_on' "
+                "  AND (m.last_cascade_at IS NULL "
+                "       OR m.last_cascade_at < %s) "
+                "ON CONFLICT (memory_id, cascade_source_id, edge_type) "
+                "WHERE attempt_count < 3 DO NOTHING",
+                (memory_id, edge_type, enqueued_at, memory_id, enqueued_at),
+            )
+
+    conn.commit()

--- a/factory/orchestrator.py
+++ b/factory/orchestrator.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from state_machine import FactoryDB, FactoryJob, JobStatus
 from cli_executor import run_cli, notify_desktop, DEFAULT_CLI_ASSIGNMENTS
 from config import FACTORY_FIX_LOOP_WARNINGS_TRIGGER_RETRY
+from curator.worker import drain_one_batch as drain_curator_queue
 from learning import extract_lessons, get_review_lessons
 from cleanup_agent import CleanupAgent
 from file_registry import FileRegistry
@@ -424,6 +425,19 @@ class FactoryOrchestrator:
 
         cleanup = CleanupAgent(self.db)
         logger.info("Starting pipeline for job %s: %s", job_id[:8], job.title)
+
+        # Cascade re-eval queue drainer — sibling poll alongside the
+        # factory's per-job pipeline. Each invocation of run_job drains
+        # any pending curator_re_eval_queue rows so the planner sees the
+        # most up-to-date strength values when the brief is generated.
+        # Failures are non-fatal: the job pipeline is the primary work.
+        try:
+            with self.db._conn() as drain_conn:
+                drained = drain_curator_queue(drain_conn, batch_size=50)
+            if drained:
+                logger.info("curator: drained %d queue rows", drained)
+        except Exception:
+            logger.exception("curator: drain failed (non-blocking)")
 
         # Pre-job factory readiness check. Any dirty state discovered here
         # is either auto-repaired or the job is blocked — we never start

--- a/factory/tests/conftest.py
+++ b/factory/tests/conftest.py
@@ -1,6 +1,6 @@
 """Shared pytest fixtures for factory/ tests.
 
-Two responsibilities:
+Three responsibilities:
 
 1. sys.path tweak so factory's modules resolve when pytest is invoked as
    `cd factory && pytest tests/...` (the rootdir convention used by CI).
@@ -9,6 +9,11 @@ Two responsibilities:
    tests/postulates/conftest.py so postulate-tests and factory-tests use
    identical connection semantics, but live here so pytest discovers them
    when run from the factory/ rootdir.
+3. Row-factory fixtures (`project_factory`, `memory_factory`) parallel
+   to those in tests/postulates/conftest.py. Tests that commit mid-test
+   (e.g. cascade-worker integration tests that need to set up state
+   visible to a subsequent SELECT FOR UPDATE) need explicit cleanup —
+   these factories track inserted IDs and delete them at teardown.
 
 DB-using tests skip cleanly when DEVBRAIN_DB_PASSWORD (or
 DEVBRAIN_TEST_DATABASE_URL) is not set, which is the case in the no-DB
@@ -18,12 +23,18 @@ from __future__ import annotations
 
 import os
 import sys
+import uuid
 from pathlib import Path
 
 import pytest
 
 # Add factory dir to path so imports work
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Every row inserted by a factory fixture is tagged with this prefix so
+# the cleanup is easy to spot and won't touch real data even if the
+# delete query is buggy.
+TEST_TAG = "factory_test_"
 
 
 def _database_url() -> str:
@@ -64,3 +75,99 @@ def conn(database_url):
     finally:
         c.rollback()
         c.close()
+
+
+@pytest.fixture
+def project_factory(conn):
+    """Create disposable projects with a unique slug. Cleaned up at teardown.
+
+    Cleanup deletes every row anchored to a created project_id (memory
+    rows, dependency edges, ledger rows, curator queue rows, factory_jobs
+    rows) before the project itself — required because committed rows
+    are not rolled back by the conn fixture.
+    """
+    created: list[str] = []
+
+    def make(slug_hint: str = "p") -> dict:
+        slug = f"{TEST_TAG}{slug_hint}_{uuid.uuid4().hex[:8]}"
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.projects (slug, name) VALUES (%s, %s) "
+                "RETURNING id, slug",
+                (slug, f"Factory Test {slug_hint}"),
+            )
+            row = cur.fetchone()
+        conn.commit()
+        created.append(row[0])
+        return {"id": row[0], "slug": row[1]}
+
+    yield make
+
+    # The test itself may have left the connection in an aborted-
+    # transaction state. Roll back before cleanup so DELETE statements run.
+    conn.rollback()
+
+    with conn.cursor() as cur:
+        for pid in created:
+            # Curator queue rows reference memory.id with ON DELETE CASCADE
+            # for memory_id, but cascade_source_id is plain REFERENCES — so
+            # we have to drop queue rows explicitly before deleting memory.
+            cur.execute(
+                "DELETE FROM devbrain.curator_re_eval_queue "
+                "WHERE memory_id IN "
+                "(SELECT id FROM devbrain.memory WHERE project_id = %s) "
+                "OR cascade_source_id IN "
+                "(SELECT id FROM devbrain.memory WHERE project_id = %s)",
+                (pid, pid),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.memory_ledger "
+                "WHERE memory_id IN "
+                "(SELECT id FROM devbrain.memory WHERE project_id = %s)",
+                (pid,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.memory_dependencies "
+                "WHERE from_memory_id IN "
+                "(SELECT id FROM devbrain.memory WHERE project_id = %s) "
+                "OR to_memory_id IN "
+                "(SELECT id FROM devbrain.memory WHERE project_id = %s)",
+                (pid, pid),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.memory WHERE project_id = %s", (pid,)
+            )
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE project_id = %s",
+                (pid,),
+            )
+            cur.execute("DELETE FROM devbrain.projects WHERE id = %s", (pid,))
+    conn.commit()
+
+
+@pytest.fixture
+def memory_factory(conn):
+    """Insert a devbrain.memory row directly (bypassing the MCP server)."""
+
+    def make(
+        project_id: str,
+        *,
+        kind: str = "decision",
+        title: str | None = None,
+        content: str | None = None,
+        provenance_id: str | None = None,
+    ) -> dict:
+        title = title or f"{TEST_TAG}title_{uuid.uuid4().hex[:6]}"
+        content = content or f"{TEST_TAG}body_{uuid.uuid4().hex[:6]}"
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.memory "
+                "(project_id, kind, title, content, provenance_id) "
+                "VALUES (%s, %s, %s, %s, %s) RETURNING id",
+                (project_id, kind, title, content, provenance_id),
+            )
+            row = cur.fetchone()
+        conn.commit()
+        return {"id": row[0], "title": title, "content": content, "kind": kind}
+
+    return make

--- a/factory/tests/test_curator_worker.py
+++ b/factory/tests/test_curator_worker.py
@@ -1,0 +1,183 @@
+"""Integration tests for the cascade worker.
+
+Drains rows from devbrain.curator_re_eval_queue and applies the bounded
+additive cascade penalty (defined in factory/curator/strength.py) to the
+target memory's strength column.
+
+These tests use real Postgres (devbrain-db). They commit mid-test to set
+up state visible to a subsequent SELECT FOR UPDATE call from inside the
+worker. The conftest in factory/tests/conftest.py rolls back any
+uncommitted work at teardown — committed rows are owned by the
+project_factory / memory_factory fixtures (parallel to those in
+tests/postulates/conftest.py) and cleaned up at fixture teardown.
+"""
+from __future__ import annotations
+
+import pytest
+
+from curator.strength import PENALTY  # noqa: F401  (referenced in commentary)
+from curator.worker import drain_one_batch
+
+
+@pytest.mark.db
+def test_drain_one_batch_processes_single_row(
+    conn, project_factory, memory_factory
+):
+    project = project_factory("dwc")
+    m_old = memory_factory(project["id"], kind="pattern", content="old")
+    m_dep = memory_factory(project["id"], kind="issue", content="dep")
+
+    # Set up: m_dep depends on m_old, with starting strength 0.85
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET strength = 0.85 WHERE id = %s",
+            (m_dep["id"],),
+        )
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test')",
+            (m_dep["id"], m_old["id"]),
+        )
+        cur.execute(
+            "INSERT INTO devbrain.curator_re_eval_queue "
+            "(memory_id, cascade_source_id, edge_type) VALUES (%s, %s, %s)",
+            (m_dep["id"], m_old["id"], "supersedes"),
+        )
+    conn.commit()
+
+    drained = drain_one_batch(conn, batch_size=10)
+    assert drained == 1
+
+    # m_dep strength should drop ~0.40 (supersedes penalty, ~0 age)
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT strength, last_cascade_at FROM devbrain.memory WHERE id=%s",
+            (m_dep["id"],),
+        )
+        strength, last_cascade = cur.fetchone()
+    assert float(strength) == pytest.approx(0.45, abs=0.01)
+    assert last_cascade is not None
+
+    # Queue row should be deleted
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.curator_re_eval_queue WHERE memory_id=%s",
+            (m_dep["id"],),
+        )
+        assert cur.fetchone()[0] == 0
+
+
+@pytest.mark.db
+def test_drain_skips_archived_target(conn, project_factory, memory_factory):
+    project = project_factory("dst")
+    m_dep = memory_factory(project["id"], content="will be archived")
+    m_src = memory_factory(project["id"], content="source")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET archived_at = NOW(), strength = 0.7 "
+            "WHERE id = %s",
+            (m_dep["id"],),
+        )
+        cur.execute(
+            "INSERT INTO devbrain.curator_re_eval_queue "
+            "(memory_id, cascade_source_id, edge_type) VALUES (%s, %s, 'supersedes')",
+            (m_dep["id"], m_src["id"]),
+        )
+    conn.commit()
+
+    drained = drain_one_batch(conn, batch_size=10)
+    assert drained == 1
+
+    # Strength NOT updated (archived row left alone)
+    with conn.cursor() as cur:
+        cur.execute("SELECT strength FROM devbrain.memory WHERE id=%s", (m_dep["id"],))
+        assert float(cur.fetchone()[0]) == 0.7
+
+    # Queue row still deleted
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.curator_re_eval_queue WHERE memory_id=%s",
+            (m_dep["id"],),
+        )
+        assert cur.fetchone()[0] == 0
+
+
+@pytest.mark.db
+def test_drain_multi_hop_enqueues_dependents(
+    conn, project_factory, memory_factory
+):
+    project = project_factory("dmh")
+    a = memory_factory(project["id"], content="a")
+    b = memory_factory(project["id"], content="b")
+    c = memory_factory(project["id"], content="c")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET strength = 0.85 WHERE id IN (%s,%s,%s)",
+            (a["id"], b["id"], c["id"]),
+        )
+        # b depends_on a, c depends_on b
+        cur.executemany(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test')",
+            [(b["id"], a["id"]), (c["id"], b["id"])],
+        )
+        cur.execute(
+            "INSERT INTO devbrain.curator_re_eval_queue "
+            "(memory_id, cascade_source_id, edge_type) VALUES (%s, %s, 'supersedes')",
+            (b["id"], a["id"]),
+        )
+    conn.commit()
+
+    drain_one_batch(conn, batch_size=10)
+
+    # b should be processed; c should be ENQUEUED (multi-hop)
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.curator_re_eval_queue WHERE memory_id=%s",
+            (c["id"],),
+        )
+        assert cur.fetchone()[0] == 1
+
+
+@pytest.mark.db
+def test_drain_increments_attempt_count_on_failure(
+    conn, project_factory, memory_factory, monkeypatch
+):
+    project = project_factory("daf")
+    m = memory_factory(project["id"], content="will fail")
+    src = memory_factory(project["id"], content="src")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.curator_re_eval_queue "
+            "(memory_id, cascade_source_id, edge_type) VALUES (%s, %s, 'supersedes') "
+            "RETURNING id",
+            (m["id"], src["id"]),
+        )
+        queue_id = cur.fetchone()[0]
+    conn.commit()
+
+    # Force apply_cascade to raise
+    from curator import worker as worker_mod
+    monkeypatch.setattr(
+        worker_mod,
+        "apply_cascade",
+        lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    drained = drain_one_batch(conn, batch_size=10)
+    assert drained == 0  # nothing successfully drained
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT attempt_count, last_error FROM devbrain.curator_re_eval_queue "
+            "WHERE id=%s",
+            (queue_id,),
+        )
+        attempt_count, last_error = cur.fetchone()
+    assert attempt_count == 1
+    assert "boom" in (last_error or "")

--- a/tests/postulates/test_p_archived_mid_cascade.py
+++ b/tests/postulates/test_p_archived_mid_cascade.py
@@ -1,0 +1,76 @@
+"""P_archived_mid_cascade — archived target during drain → DELETE without propagating.
+
+POSTULATE
+---------
+If a memory is archived after being enqueued for re-eval but before the
+worker drains it, the worker DELETEs the queue row, does NOT update
+strength, and does NOT propagate to the row's dependents. (Archived
+rows are excluded from the planning brief by P2; further weakening of
+their strength serves no purpose, and propagating to their dependents
+would cascade an effectively-dead signal.)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make `from curator.worker import ...` resolve from tests/postulates/.
+_FACTORY = Path(__file__).resolve().parents[2] / "factory"
+if str(_FACTORY) not in sys.path:
+    sys.path.insert(0, str(_FACTORY))
+
+from curator.worker import drain_one_batch  # noqa: E402
+
+
+def test_archived_target_no_propagation(conn, project_factory, memory_factory):
+    project = project_factory("p_arch")
+    a = memory_factory(project["id"], content="a")
+    b = memory_factory(
+        project["id"], content="b — depends on a, will archive"
+    )
+    c = memory_factory(
+        project["id"], content="c — depends on b, should NOT be enqueued"
+    )
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET strength = 0.85 "
+            "WHERE id IN (%s,%s,%s)",
+            (a["id"], b["id"], c["id"]),
+        )
+        cur.executemany(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test')",
+            [(b["id"], a["id"]), (c["id"], b["id"])],
+        )
+        cur.execute(
+            "INSERT INTO devbrain.curator_re_eval_queue "
+            "(memory_id, cascade_source_id, edge_type) "
+            "VALUES (%s, %s, 'supersedes')",
+            (b["id"], a["id"]),
+        )
+        # Archive b BEFORE worker drains.
+        cur.execute(
+            "UPDATE devbrain.memory SET archived_at = NOW() WHERE id = %s",
+            (b["id"],),
+        )
+    conn.commit()
+
+    drain_one_batch(conn, batch_size=50)
+
+    # c must NOT be enqueued.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.curator_re_eval_queue "
+            "WHERE memory_id=%s",
+            (c["id"],),
+        )
+        assert cur.fetchone()[0] == 0
+
+    # b's strength NOT mutated.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT strength FROM devbrain.memory WHERE id=%s", (b["id"],)
+        )
+        assert float(cur.fetchone()[0]) == 0.85

--- a/tests/postulates/test_p_cycle.py
+++ b/tests/postulates/test_p_cycle.py
@@ -1,0 +1,63 @@
+"""P_cycle — dependency cycle (A -> B -> A) converges in one wave.
+
+POSTULATE
+---------
+If A depends_on B and B depends_on A (cycle), a cascade triggered by
+mutating A converges in a single drain pass — neither row is processed
+more than once per cascade source. The mechanism is the
+`last_cascade_at >= enqueued_at` guard in `_process_one`: once the
+worker stamps `memory.last_cascade_at`, any later queue row pointing at
+the same memory whose `enqueued_at` is older than that stamp is
+short-circuited (DELETE without strength mutation, without further
+propagation).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make `from curator.worker import ...` resolve from tests/postulates/.
+_FACTORY = Path(__file__).resolve().parents[2] / "factory"
+if str(_FACTORY) not in sys.path:
+    sys.path.insert(0, str(_FACTORY))
+
+from curator.worker import drain_one_batch  # noqa: E402
+
+
+def test_dependency_cycle_converges(conn, project_factory, memory_factory):
+    project = project_factory("p_cycle")
+    a = memory_factory(project["id"], content="a")
+    b = memory_factory(project["id"], content="b")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET strength = 0.9 WHERE id IN (%s, %s)",
+            (a["id"], b["id"]),
+        )
+        cur.executemany(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test')",
+            [(a["id"], b["id"]), (b["id"], a["id"])],  # cycle
+        )
+        cur.execute(
+            "INSERT INTO devbrain.curator_re_eval_queue "
+            "(memory_id, cascade_source_id, edge_type) "
+            "VALUES (%s, %s, 'supersedes')",
+            (a["id"], b["id"]),
+        )
+    conn.commit()
+
+    # Drain repeatedly — should converge in finite passes.
+    iterations = 0
+    while iterations < 5:
+        drained = drain_one_batch(conn, batch_size=50)
+        if drained == 0:
+            break
+        iterations += 1
+    assert iterations < 5, "cycle did not converge — possible infinite loop"
+
+    # Queue should be empty.
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM devbrain.curator_re_eval_queue")
+        assert cur.fetchone()[0] == 0

--- a/tests/postulates/test_p_stuck_surface_able.py
+++ b/tests/postulates/test_p_stuck_surface_able.py
@@ -1,0 +1,48 @@
+"""P_stuck_surface_able — queue rows with attempt_count >= 3 surface in CLI.
+
+POSTULATE
+---------
+A queue row that has failed 3+ times is reported by
+`devbrain curator queue-stuck` (i.e. by `curator.cli.list_stuck_queue_rows`)
+with its memory_id, cascade_source_id, edge_type, attempt_count, and
+last_error. This is the operator's escape hatch when the cascade worker
+keeps failing on a particular row — visibility into which rows have
+exhausted their retry budget is what lets the operator decide whether
+to re-enqueue (after triage) or accept the stale strength.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make `from curator.cli import ...` resolve from tests/postulates/.
+_FACTORY = Path(__file__).resolve().parents[2] / "factory"
+if str(_FACTORY) not in sys.path:
+    sys.path.insert(0, str(_FACTORY))
+
+from curator.cli import list_stuck_queue_rows  # noqa: E402
+
+
+def test_stuck_rows_listed(conn, project_factory, memory_factory):
+    project = project_factory("p_stuck")
+    m = memory_factory(project["id"], content="will fail")
+    src = memory_factory(project["id"], content="src")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.curator_re_eval_queue "
+            "(memory_id, cascade_source_id, edge_type, attempt_count, "
+            " last_error) "
+            "VALUES (%s, %s, 'supersedes', 3, 'simulated failure')",
+            (m["id"], src["id"]),
+        )
+    conn.commit()
+
+    stuck = list_stuck_queue_rows(conn)
+    # The connection is shared with the postulate suite (which may have
+    # its own committed test rows mid-run); narrow to our specific
+    # memory_id rather than asserting global cardinality.
+    ours = [r for r in stuck if r["memory_id"] == m["id"]]
+    assert len(ours) == 1
+    assert ours[0]["attempt_count"] == 3
+    assert ours[0]["last_error"] == "simulated failure"


### PR DESCRIPTION
## Summary

Phase 5c of the [Atlas Step 5 plan](docs/plans/2026-05-04-step-5-curator-implementation.md):
- `factory/curator/worker.py` — cascade re-eval queue drainer with two-layer cycle prevention.
- `factory/curator/cli.py` + new `devbrain factory curator queue-stuck` subcommand for operator triage of rows that have exhausted their retry budget.
- Wired into `FactoryOrchestrator.run_job` as a sibling drain at the head of each job (the orchestrator runs as one process per job — there's no main poll loop, so this is the natural insertion point).
- Three new postulates pass: `P_cycle`, `P_archived_mid_cascade`, `P_stuck_surface_able`.

## Worker mechanics

- `SELECT ... FOR UPDATE SKIP LOCKED` claims a batch (multi-worker safe).
- Per row: load memory, apply `apply_cascade(strength, edge_type, age_seconds)` from `curator/strength.py`, UPDATE memory, DELETE queue row.
- Multi-hop: when post-decay penalty > 0.05, enqueue the row's own dependents.
- Cycle prevention is two-layer:
  1. Multi-hop INSERT propagates the wave's `enqueued_at` timestamp (instead of letting `NOW()` win) so a cycle's downstream rows carry the wavefront.
  2. Both `_process_one`'s `last_cascade_at >= enqueued_at` guard and the multi-hop SELECT's `m.last_cascade_at < enqueued_at` filter short-circuit any row in a memory the wave already touched.
- Failure path rolls back partial work before incrementing `attempt_count` and writing `last_error`. Rows with `attempt_count >= 3` are filtered by the SELECT's `WHERE attempt_count < 3` and by the dedup partial unique index — fresh enqueue is permitted post-triage.

## Files

- New: `factory/curator/worker.py` (188 lines), `factory/curator/cli.py` (34 lines), `factory/tests/test_curator_worker.py` (183 lines), `tests/postulates/test_p_cycle.py` (63 lines), `tests/postulates/test_p_archived_mid_cascade.py` (76 lines), `tests/postulates/test_p_stuck_surface_able.py` (48 lines).
- Modified: `factory/orchestrator.py` (+14), `factory/cli.py` (+35), `factory/tests/conftest.py` (+108 — adds `project_factory` + `memory_factory` fixtures parallel to `tests/postulates/conftest.py` since worker tests commit mid-test and need explicit cleanup).

## Test plan

- [x] `factory/tests/test_curator_worker.py` — 4 tests pass (single-row drain, archived skip, multi-hop enqueue, attempt_count++ on failure).
- [x] `tests/postulates/test_p_cycle.py` — A->B->A cycle converges in one wave.
- [x] `tests/postulates/test_p_archived_mid_cascade.py` — archived target during drain → DELETE without strength update, without propagation.
- [x] `tests/postulates/test_p_stuck_surface_able.py` — `list_stuck_queue_rows` returns the expected shape.
- [x] All 25 curator tests green (10 strength + 6 types + 5 migration_017 + 4 worker).
- [x] All 5 postulate tests green (P3 + 3 new); P1 + P2 still `xfail(strict=True)` — they flip in 5d, not this PR.
- [x] No-DB CI subset (180 tests) still passes.
- [x] Coverage: `curator.cli` 100%, `curator.worker` 88% (target ≥85%).

## Out of scope (later phases)

- Brief generation (`factory/curator/brief.py`) — Phase 5d.
- `end_session()` enrichment — Phase 5e.
- DB-available CI workflow — Phase 5f.
- Flipping P1/P2 from `xfail(strict=True)` to passing — Phase 5d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)