### PR TITLE
feat(curator): Atlas Step 5d — brief generator + state machine integration; flip P2

### DIFF
--- a/docs/plans/2026-05-04-step-5-curator-implementation.md
+++ b/docs/plans/2026-05-04-step-5-curator-implementation.md
@@ -1564,15 +1564,147 @@ gh pr create --title "feat(curator): Atlas Step 5d — brief generator + flip P1
 
 ---
 
-## Phase 5e — `end_session()` enrichment
+## Phase 5e — `store()` cascade enqueue + `end_session()` enrichment + drain trigger
+
+> **Three concerns in one phase, all in the MCP server layer:**
+>
+> 1. **`store()` cascade detection + enqueue** — when an agent calls `store()`
+>    with a cascading mutation (writes a `supersedes` edge, sets `archived_at`,
+>    or mutates `applies_when`), detect affected dependents from
+>    `memory_dependencies` and INSERT into `devbrain.curator_re_eval_queue`.
+>    Without this, the queue is always empty in normal operation.
+> 2. **`end_session()` enrichment** — accepts `cascade_decisions`,
+>    `new_relationships`, `lesson_candidates` from the calling agent.
+> 3. **`end_session()` drain trigger** — after applying judgment from
+>    enrichment payload, drain the queue. Honors the design promise that
+>    ripple effects propagate from anywhere (chat sessions + factory jobs),
+>    not just at factory job startup.
+>
+> **Architecture (per locked design + Patrick's option E refinement on 2026-05-04):**
+>
+> | Trigger | When | Action |
+> |---|---|---|
+> | Mid-session `store()` | Agent writes a cascading mutation | **Enqueue** affected dependents (5e-NEW-1) |
+> | `end_session()` | Agent ends session | Apply judgment payload (5e-1..6) + **Drain** queue (5e-NEW-2) |
+> | Factory job `QUEUED → PLANNING` | New factory job submitted | Drain queue (already shipped in 5c) |
+>
+> Without enqueue (5e-NEW-1), the drain triggers (factory + end_session)
+> have nothing to do. They land together.
 
 **Files:**
 - Create: `factory/curator/end_session.py`
 - Modify: `mcp-server/src/index.ts` — add new optional params to `end_session` tool schema
-- Modify: `mcp-server/src/memory.ts` (or wherever `end_session` impl lives) — plumb new params to DB
+- Modify: `mcp-server/src/memory.ts` (or wherever `store` + `end_session` impls live) — add cascade detection + enqueue to `store()`; plumb `end_session()` enrichment + drain trigger
 - Test: `factory/tests/test_curator_end_session.py`
+- Test: `factory/tests/test_store_cascade_enqueue.py` (NEW — covers 5e-NEW-1)
 - Postulate: `tests/postulates/test_p_end_session_isolation.py`
 - Postulate: `tests/postulates/test_p_end_session_idempotent.py`
+
+### Task 5e-NEW-1: `store()` cascade detection + enqueue
+
+When `store()` is called, after the memory row is inserted/updated, detect
+whether the mutation should cascade and enqueue affected dependents.
+
+**Three cascade triggers** (matches the `edge_type` CHECK on `curator_re_eval_queue`):
+
+1. **Writing a `supersedes` edge** — the new row has `supersedes=[old_id]`
+   in its params; `old_id` is the cascade source. Walk
+   `memory_dependencies` to find all rows where
+   `to_memory_id=old_id AND edge_type='depends_on'`. Enqueue each as
+   `(memory_id=dependent, cascade_source_id=old_id, edge_type='supersedes')`.
+2. **Setting `archived_at`** — `store()` archived a memory. The archived
+   memory_id is the cascade source. Walk dependents, enqueue with
+   `edge_type='archived_at'`.
+3. **Mutating `applies_when`** — `store()` updated a memory's
+   `applies_when` JSONB. Walk dependents, enqueue with
+   `edge_type='applies_when'`.
+
+**Use `INSERT … ON CONFLICT (memory_id, cascade_source_id, edge_type) WHERE attempt_count < 3 DO NOTHING`** to dedup against the partial unique index from migration 017. PG 15+ supports WHERE-clause conflict targets.
+
+**Implementation in `mcp-server/src/memory.ts`** (TypeScript). Pattern:
+
+```typescript
+// Inside the store handler, after the INSERT/UPDATE on devbrain.memory:
+async function enqueueCascades(
+  client: Pool,
+  cascadeSourceId: string,
+  edgeType: 'supersedes' | 'archived_at' | 'applies_when'
+): Promise<void> {
+  await client.query(
+    `INSERT INTO devbrain.curator_re_eval_queue
+       (memory_id, cascade_source_id, edge_type)
+     SELECT from_memory_id, $1, $2
+     FROM devbrain.memory_dependencies
+     WHERE to_memory_id = $1 AND edge_type = 'depends_on'
+     ON CONFLICT (memory_id, cascade_source_id, edge_type)
+       WHERE attempt_count < 3 DO NOTHING`,
+    [cascadeSourceId, edgeType]
+  );
+}
+
+// Trigger points in store handler:
+if (params.supersedes && params.supersedes.length > 0) {
+  for (const oldId of params.supersedes) {
+    await enqueueCascades(pool, oldId, 'supersedes');
+  }
+}
+if (params.archived_at && !previousArchivedAt) {
+  await enqueueCascades(pool, memoryId, 'archived_at');
+}
+if (params.applies_when && !deepEqual(params.applies_when, previousAppliesWhen)) {
+  await enqueueCascades(pool, memoryId, 'applies_when');
+}
+```
+
+**Test (`factory/tests/test_store_cascade_enqueue.py`)** — 3 integration
+tests, one per cascade trigger. Each writes a memory with the trigger,
+queries `curator_re_eval_queue`, asserts the expected dependent rows
+appear with the correct `(memory_id, cascade_source_id, edge_type)`.
+Use the `project_factory` + `memory_factory` fixtures from
+`factory/tests/conftest.py` (added in 5c). Setup: insert source, insert
+dependent, INSERT a `depends_on` edge, then exercise the store handler
+(may need to drive via the MCP server end-to-end OR call the
+TypeScript handler logic via a Python test wrapper — implementer's call).
+
+**Coverage gate:** the `enqueueCascades` function and its three call
+sites in the store handler must be exercised by these 3 tests.
+
+### Task 5e-NEW-2: `end_session()` drain trigger
+
+After `end_session_idempotent_handler` applies the structured judgment,
+call `drain_one_batch(conn, batch_size=200)`. Larger batch than the
+factory job startup default (50) because end_session is a natural
+"catch up" moment.
+
+**Add to `factory/curator/end_session.py`** at the end of
+`end_session_idempotent_handler`, after the `INSERT INTO end_session_log`:
+
+```python
+# Drain everything the session enqueued (during work) plus what step 1 just added.
+# Larger batch — end_session is a natural catch-up moment.
+from curator.worker import drain_one_batch
+try:
+    drained = drain_one_batch(conn, batch_size=200)
+    result["cascades_drained"] = drained
+except Exception as exc:  # noqa: BLE001
+    # Drain failure should NOT fail end_session — judgment already persisted.
+    # Log and continue.
+    import logging
+    logging.getLogger(__name__).exception("end_session drain failed: %s", exc)
+    result["cascades_drained"] = 0
+    result["drain_error"] = str(exc)[:500]
+```
+
+The drain failure is non-fatal — judgment is the user-facing primary
+work; drain is a "best-effort cleanup" that runs in the same call.
+Failed drain rows stay in queue for the next end_session OR factory job.
+
+**Test:** add to `factory/tests/test_curator_end_session.py`:
+`test_end_session_drains_queue_after_applying_judgment` — set up cascade
+queue rows pre-call, fire end_session, assert queue rows drained AND
+strength values updated AND `cascades_drained` count in result.
+
+
 
 ### Task 5e-1: Implement `factory/curator/end_session.py`
 

--- a/factory/curator/brief.py
+++ b/factory/curator/brief.py
@@ -1,0 +1,199 @@
+"""Curator brief generator.
+
+Synchronous; called from FactoryDB.transition() at the QUEUED -> PLANNING
+edge. Pure filtering + ranking — no LLM in v3.0. Could become LLM-driven
+later without breaking the CuratorBrief v1.0 contract.
+
+Profile filtering depends on the compliance_profiles columns shipped in
+Step 7. Until then, all tier='rule' rows are loaded (no profile filter)
+— the SELECT is wrapped in try/except + rollback so the same code keeps
+working before and after the column ships.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from curator.types import CascadeNote, CuratorBrief, MemoryRef
+
+logger = logging.getLogger(__name__)
+
+LESSON_TOP_N = 20
+DECISION_TOP_N = 30
+CASCADE_NOTE_LIMIT = 20
+CASCADE_SIGNAL_WINDOW = "24 hours"
+
+
+def generate_brief(
+    conn: Any, job_id: UUID, project_id: UUID, spec: str
+) -> CuratorBrief:
+    """Generate a CuratorBrief and persist to factory_jobs.curator_brief.
+
+    The conn must already be in a clean state (no aborted transaction).
+    On success the brief is committed via _persist_to_job. On any
+    SELECT-level failure caused by missing Step 7 columns, the function
+    rolls back the failed query and falls through to a no-filter SELECT
+    so the rest of the brief still builds.
+    """
+    profiles = _load_enabled_profiles(conn, project_id)
+    rules = _load_rules(conn, project_id, profiles)
+    lessons = _load_lessons(conn, project_id, top_n=LESSON_TOP_N)
+    decisions = _load_decisions_matching(conn, project_id, spec or "")
+    cascades = _load_recent_cascades(conn, project_id)
+
+    brief = CuratorBrief(
+        version="1.0",
+        job_id=job_id,
+        project_id=project_id,
+        rules=rules,
+        lessons=lessons,
+        relevant_decisions=decisions,
+        recent_cascade_signals=cascades,
+        generated_at=datetime.now(timezone.utc),
+    )
+
+    _persist_to_job(conn, job_id, brief)
+    return brief
+
+
+def _load_enabled_profiles(conn, project_id) -> list[str]:
+    """Step 7 column. Returns [] if column doesn't exist yet."""
+    with conn.cursor() as cur:
+        try:
+            cur.execute(
+                "SELECT compliance_profiles_enabled FROM devbrain.projects "
+                "WHERE id = %s",
+                (project_id,),
+            )
+            row = cur.fetchone()
+            return list(row[0] or []) if row and row[0] else []
+        except Exception:
+            conn.rollback()
+            return []
+
+
+def _load_rules(conn, project_id, profiles) -> list[MemoryRef]:
+    """Filter by profile intersection if Step 7 column exists; else all rules."""
+    base = (
+        "SELECT id, kind, title, content, tier, strength, last_cascade_at "
+        "FROM devbrain.memory "
+        "WHERE project_id = %s AND tier = 'rule' AND archived_at IS NULL"
+    )
+    with conn.cursor() as cur:
+        if profiles:
+            try:
+                cur.execute(
+                    base + " AND compliance_profiles && %s "
+                    "ORDER BY strength DESC",
+                    (project_id, profiles),
+                )
+                return [_to_ref(row) for row in cur.fetchall()]
+            except Exception:
+                conn.rollback()
+        cur.execute(base + " ORDER BY strength DESC", (project_id,))
+        return [_to_ref(row) for row in cur.fetchall()]
+
+
+def _load_lessons(conn, project_id, top_n) -> list[MemoryRef]:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, kind, title, content, tier, strength, last_cascade_at "
+            "FROM devbrain.memory "
+            "WHERE project_id = %s AND tier = 'lesson' AND archived_at IS NULL "
+            "ORDER BY strength DESC LIMIT %s",
+            (project_id, top_n),
+        )
+        return [_to_ref(row) for row in cur.fetchall()]
+
+
+def _load_decisions_matching(conn, project_id, spec) -> list[MemoryRef]:
+    """Naive matcher v0.1 — substring match against spec text.
+
+    TODO Phase 3.x: smarter matcher (semantic similarity, structured
+    applies_when match). Don't change the function signature.
+    """
+    keywords = [w for w in spec.split() if len(w) > 3][:10]
+    with conn.cursor() as cur:
+        if keywords:
+            patterns = [f"%{w}%" for w in keywords]
+            cur.execute(
+                "SELECT id, kind, title, content, tier, strength, "
+                "       last_cascade_at "
+                "FROM devbrain.memory "
+                "WHERE project_id = %s AND tier = 'memory' "
+                "  AND archived_at IS NULL "
+                "  AND content ILIKE ANY(%s) "
+                "ORDER BY strength DESC LIMIT %s",
+                (project_id, patterns, DECISION_TOP_N),
+            )
+        else:
+            cur.execute(
+                "SELECT id, kind, title, content, tier, strength, "
+                "       last_cascade_at "
+                "FROM devbrain.memory "
+                "WHERE project_id = %s AND tier = 'memory' "
+                "  AND archived_at IS NULL "
+                "ORDER BY strength DESC LIMIT %s",
+                (project_id, DECISION_TOP_N),
+            )
+        return [_to_ref(row) for row in cur.fetchall()]
+
+
+def _load_recent_cascades(conn, project_id) -> list[CascadeNote]:
+    """Surface memory rows whose last_cascade_at falls inside the recent
+    window. The cascade source / edge_type are placeholders — the queue
+    is drained synchronously so by the time the brief generates the
+    triplet is gone. Tracing the original source would require a ledger
+    join (TODO Phase 3.x — keeps the brief signature stable).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT id, last_cascade_at
+            FROM devbrain.memory
+            WHERE project_id = %s
+              AND last_cascade_at >= NOW() - INTERVAL '{CASCADE_SIGNAL_WINDOW}'
+              AND archived_at IS NULL
+            ORDER BY last_cascade_at DESC
+            LIMIT {CASCADE_NOTE_LIMIT}
+            """,
+            (project_id,),
+        )
+        notes: list[CascadeNote] = []
+        for memory_id, occurred_at in cur.fetchall():
+            notes.append(
+                CascadeNote(
+                    affected_memory_id=memory_id,
+                    cascade_source_id=memory_id,  # placeholder — see docstring
+                    edge_type="supersedes",       # placeholder — see docstring
+                    occurred_at=occurred_at,
+                    summary=f"Memory {memory_id} re-evaluated by cascade",
+                )
+            )
+        return notes
+
+
+def _to_ref(row) -> MemoryRef:
+    mid, kind, title, content, tier, strength, last_cascade_at = row
+    return MemoryRef(
+        id=mid,
+        kind=kind,
+        title=title,
+        content_excerpt=(content or "")[:500],
+        tier=tier,
+        strength=strength,
+        last_cascade_at=last_cascade_at,
+    )
+
+
+def _persist_to_job(conn, job_id, brief: CuratorBrief) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.factory_jobs "
+            "SET curator_brief = %s::jsonb "
+            "WHERE id = %s",
+            (brief.model_dump_json(), job_id),
+        )
+    conn.commit()

--- a/factory/state_machine.py
+++ b/factory/state_machine.py
@@ -271,7 +271,64 @@ class FactoryDB:
             conn.commit()
 
         logger.info("Job %s: %s → %s", job_id[:8], job.status.value, new_status.value)
+
+        # Curator brief generation hook. Runs at QUEUED -> PLANNING only.
+        # The brief is cached on factory_jobs.curator_brief so every
+        # downstream phase (planning, implementing, reviewing, qa) reads
+        # an identical snapshot. See
+        # docs/plans/2026-05-04-step-5-curator-design.md §3 for the
+        # design and §4 (Pathway 3) for the data flow.
+        if (
+            job.status == JobStatus.QUEUED
+            and new_status == JobStatus.PLANNING
+        ):
+            self._generate_brief_for_planning(job_id, job.project_id, job.spec)
+
         return self.get_job(job_id)
+
+    def _generate_brief_for_planning(
+        self, job_id: str, project_id: str, spec: str | None
+    ) -> None:
+        """Generate the curator brief at QUEUED -> PLANNING.
+
+        On failure: increment error_count, stash the error in metadata
+        (no last_error column exists on factory_jobs), and re-raise so
+        the caller (orchestrator._run_planning) sees the failure and can
+        decide whether to FAIL the job. After 3 brief-generation
+        failures the orchestrator's existing FAILED-after-max-retries
+        logic kicks in.
+        """
+        # Local import to avoid a circular import at module load —
+        # curator.brief lives under factory/curator/ and may itself
+        # import state_machine for the JobStatus enum at some point.
+        from curator.brief import generate_brief
+
+        try:
+            with self._conn() as conn:
+                generate_brief(conn, job_id, project_id, spec or "")
+        except Exception as exc:
+            logger.exception("Brief generation failed for job %s", job_id[:8])
+            self._record_brief_failure(job_id, str(exc))
+            raise
+
+    def _record_brief_failure(self, job_id: str, error: str) -> None:
+        """Increment error_count and stash the error in metadata.brief_error.
+
+        factory_jobs has error_count (migration 001) but no last_error
+        column — use the metadata JSONB instead. The orchestrator's
+        FIX_LOOP/max_retries branch already handles repeated failures
+        via error_count.
+        """
+        with self._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "UPDATE devbrain.factory_jobs "
+                "SET error_count = error_count + 1, "
+                "    metadata = metadata || %s::jsonb, "
+                "    updated_at = now() "
+                "WHERE id = %s",
+                (json.dumps({"brief_error": error[:1000]}), job_id),
+            )
+            conn.commit()
 
     def update_metadata(self, job_id: str, metadata: dict) -> None:
         """Merge the given dict into a job's metadata JSONB without

--- a/factory/tests/conftest.py
+++ b/factory/tests/conftest.py
@@ -64,8 +64,15 @@ def conn(database_url):
     """Per-test connection. Caller is responsible for cleanup of any rows
     they insert; schema-assertion tests that only read information_schema
     don't need teardown.
+
+    Registers psycopg2's UUID adapter on the module so id columns flow
+    in/out as `uuid.UUID` consistently — without this, the adapter is
+    only registered when state_machine.py happens to be imported, which
+    leaks load-order dependence into tests.
     """
     psycopg2 = pytest.importorskip("psycopg2")
+    import psycopg2.extras
+    psycopg2.extras.register_uuid()
     c = psycopg2.connect(database_url)
     try:
         with c.cursor() as cur:
@@ -147,7 +154,13 @@ def project_factory(conn):
 
 @pytest.fixture
 def memory_factory(conn):
-    """Insert a devbrain.memory row directly (bypassing the MCP server)."""
+    """Insert a devbrain.memory row directly (bypassing the MCP server).
+
+    Optional kwargs `tier` and `strength` set those columns at insert time
+    (both ship in migration 010). `compliance_profiles` is silently
+    ignored until that column ships in Step 7 — the kwarg is accepted so
+    forward-compat tests don't have to special-case the call site.
+    """
 
     def make(
         project_id: str,
@@ -156,18 +169,77 @@ def memory_factory(conn):
         title: str | None = None,
         content: str | None = None,
         provenance_id: str | None = None,
+        tier: str | None = None,
+        strength: float | None = None,
+        compliance_profiles: list[str] | None = None,  # noqa: ARG001 — Step 7
     ) -> dict:
         title = title or f"{TEST_TAG}title_{uuid.uuid4().hex[:6]}"
         content = content or f"{TEST_TAG}body_{uuid.uuid4().hex[:6]}"
+
+        cols = ["project_id", "kind", "title", "content", "provenance_id"]
+        vals: list = [project_id, kind, title, content, provenance_id]
+        if tier is not None:
+            cols.append("tier")
+            vals.append(tier)
+        if strength is not None:
+            cols.append("strength")
+            vals.append(strength)
+
+        placeholders = ", ".join(["%s"] * len(cols))
         with conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO devbrain.memory "
-                "(project_id, kind, title, content, provenance_id) "
-                "VALUES (%s, %s, %s, %s, %s) RETURNING id",
-                (project_id, kind, title, content, provenance_id),
+                f"INSERT INTO devbrain.memory ({', '.join(cols)}) "
+                f"VALUES ({placeholders}) RETURNING id",
+                vals,
             )
             row = cur.fetchone()
         conn.commit()
-        return {"id": row[0], "title": title, "content": content, "kind": kind}
+        # row[0] is a uuid.UUID — psycopg2.extras.register_uuid() is
+        # called from the conn fixture so all id flow is consistent.
+        return {
+            "id": row[0],
+            "title": title,
+            "content": content,
+            "kind": kind,
+            "tier": tier or "memory",
+        }
 
     return make
+
+
+@pytest.fixture
+def factory_job_factory(conn):
+    """Insert a devbrain.factory_jobs row.
+
+    Cleanup happens at fixture teardown — required because we commit the
+    INSERT (so the brief generator can see the row) and the conn fixture's
+    rollback won't undo committed work.
+    """
+    created: list[str] = []
+
+    def make(project_id, spec="test", status="queued", title=None) -> dict:
+        title = title or f"{TEST_TAG}job_{uuid.uuid4().hex[:6]}"
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.factory_jobs "
+                "(project_id, title, spec, status) "
+                "VALUES (%s, %s, %s, %s) "
+                "RETURNING id, project_id, title, spec, status",
+                (project_id, title, spec, status),
+            )
+            cols = [d[0] for d in cur.description]
+            row = dict(zip(cols, cur.fetchone()))
+        conn.commit()
+        created.append(row["id"])
+        return row
+
+    yield make
+
+    if created:
+        conn.rollback()
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)",
+                (created,),
+            )
+        conn.commit()

--- a/factory/tests/test_curator_brief.py
+++ b/factory/tests/test_curator_brief.py
@@ -1,0 +1,132 @@
+"""Integration tests for the curator brief generator.
+
+generate_brief() runs synchronously at the QUEUED -> PLANNING state
+transition. It assembles a CuratorBrief snapshot from the substrate
+(memory rows, last_cascade_at audit) and persists it to
+factory_jobs.curator_brief JSONB so every downstream phase reads an
+identical view.
+
+These tests use a real Postgres (devbrain-db). They commit mid-test
+because generate_brief opens its own cursors and SELECTs on committed
+state.
+"""
+from __future__ import annotations
+
+import pytest
+
+from curator.brief import generate_brief
+
+
+@pytest.mark.db
+@pytest.mark.skip(
+    reason="TODO Step 7: re-enable when compliance_profiles + "
+    "compliance_profiles_enabled columns ship. brief.py already handles "
+    "the missing-column case gracefully (try/except around the SELECT)."
+)
+def test_brief_filters_by_compliance_profiles(
+    conn, project_factory, memory_factory, factory_job_factory
+):
+    project = project_factory("bf", compliance_profiles_enabled=["hipaa"])
+    rule_hipaa = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        content="HIPAA rule", compliance_profiles=["hipaa"],
+    )
+    rule_soc2 = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        content="SOC2 rule", compliance_profiles=["soc2"],
+    )
+    job = factory_job_factory(project["id"], spec="touches phi_log.py")
+
+    brief = generate_brief(conn, job["id"], project["id"], job["spec"])
+
+    rule_ids = {r.id for r in brief.rules}
+    assert rule_hipaa["id"] in rule_ids
+    assert rule_soc2["id"] not in rule_ids
+
+
+@pytest.mark.db
+def test_brief_excludes_archived(
+    conn, project_factory, memory_factory, factory_job_factory
+):
+    project = project_factory("bea")
+    m = memory_factory(project["id"], tier="lesson", content="archived me")
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET archived_at = NOW() WHERE id = %s",
+            (m["id"],),
+        )
+    conn.commit()
+    job = factory_job_factory(project["id"], spec="anything")
+
+    brief = generate_brief(conn, job["id"], project["id"], job["spec"])
+    assert m["id"] not in {r.id for r in brief.lessons}
+
+
+@pytest.mark.db
+def test_brief_persisted_to_factory_job(
+    conn, project_factory, factory_job_factory
+):
+    project = project_factory("bp")
+    job = factory_job_factory(project["id"], spec="x")
+
+    brief = generate_brief(conn, job["id"], project["id"], job["spec"])
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT curator_brief FROM devbrain.factory_jobs WHERE id = %s",
+            (job["id"],),
+        )
+        stored = cur.fetchone()[0]
+    assert stored is not None
+    assert stored["version"] == "1.0"
+    assert stored["job_id"] == str(brief.job_id)
+
+
+@pytest.mark.db
+def test_brief_includes_recent_cascade_signals(
+    conn, project_factory, memory_factory, factory_job_factory
+):
+    project = project_factory("brc")
+    m_dep = memory_factory(project["id"], tier="lesson", content="recently cascaded")
+    memory_factory(project["id"], content="source")
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET last_cascade_at = NOW() WHERE id = %s",
+            (m_dep["id"],),
+        )
+    conn.commit()
+    job = factory_job_factory(project["id"], spec="x")
+
+    brief = generate_brief(conn, job["id"], project["id"], job["spec"])
+    affected = {n.affected_memory_id for n in brief.recent_cascade_signals}
+    assert m_dep["id"] in affected
+
+
+@pytest.mark.db
+def test_state_machine_transition_queued_to_planning_generates_brief(
+    conn, database_url, project_factory, factory_job_factory
+):
+    """End-to-end: FactoryDB.transition(QUEUED -> PLANNING) writes a
+    brief into factory_jobs.curator_brief. The brief generation hook in
+    state_machine fires only on this specific edge.
+    """
+    from state_machine import FactoryDB, JobStatus
+
+    project = project_factory("smb")
+    job = factory_job_factory(
+        project["id"], spec="implement greeting", status="queued"
+    )
+
+    db = FactoryDB(database_url)
+    transitioned = db.transition(str(job["id"]), JobStatus.PLANNING)
+    assert transitioned.status == JobStatus.PLANNING
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT curator_brief FROM devbrain.factory_jobs WHERE id = %s",
+            (job["id"],),
+        )
+        stored = cur.fetchone()[0]
+    assert stored is not None
+    assert stored["version"] == "1.0"
+    assert stored["job_id"] == str(job["id"])

--- a/tests/postulates/conftest.py
+++ b/tests/postulates/conftest.py
@@ -45,7 +45,14 @@ def database_url() -> str:
 
 @pytest.fixture
 def conn(database_url):
-    """Per-test connection with autocommit OFF so cleanup is total."""
+    """Per-test connection with autocommit OFF so cleanup is total.
+
+    Registers psycopg2's UUID adapter on the module so id columns flow
+    in/out as `uuid.UUID` consistently — without this, the adapter is
+    only registered when state_machine.py happens to be imported.
+    """
+    import psycopg2.extras
+    psycopg2.extras.register_uuid()
     c = psycopg2.connect(database_url)
     try:
         # Annotate this session as a postulate test so audit ledger rows

--- a/tests/postulates/test_p1_supersession_cascades.py
+++ b/tests/postulates/test_p1_supersession_cascades.py
@@ -8,17 +8,20 @@ within the same transaction.
 
 STATUS
 ------
-xfail(strict=True) until the curator agent (Atlas Step 5 in
-docs/plans/2026-04-29-phase-3-discipline-layer.md §7) lands. The
-substrate that the test stands on (memory_dependencies edges) is
-already shipped in migration 014 — what's missing is the curator's
-re-evaluation queue.
+xfail(strict=True) until **Phase 5e** ships the MCP `store()`
+cascade-detection-and-enqueue path. Atlas Step 5d ships the brief
+generator (P2 flips green) and the cascade worker drainer + queue
+substrate, but the enqueue side — converting a `supersedes` edge
+write into rows in `devbrain.curator_re_eval_queue` — is the
+explicit responsibility of the MCP server's `store()` tool per the
+locked design (docs/plans/2026-05-04-step-5-curator-design.md §3.1
+Pathway 1) and Phase 5e of the implementation plan
+(2026-05-04-step-5-curator-implementation.md §5e-NEW-1).
 
-Strict mode means: the day the curator queue does start surfacing
-dependents, this test FLIPS GREEN and CI fails (XPASS). That forces
-us back here to remove the xfail marker and own the postulate
-properly. Without strict=True the test would silently keep "passing
-by failing" forever.
+Strict mode means: when Phase 5e lands and supersession edges start
+populating the queue automatically, this test FLIPS GREEN and CI
+fails (XPASS). That forces us back here to remove the marker and
+own the postulate.
 """
 from __future__ import annotations
 
@@ -27,8 +30,12 @@ import pytest
 
 @pytest.mark.xfail(
     strict=True,
-    reason="Curator cascade re-eval queue lands in Atlas Step 5; "
-    "see docs/plans/2026-04-29-phase-3-discipline-layer.md §4.",
+    reason=(
+        "Cascade enqueue path lives in MCP store() — ships in Phase 5e "
+        "(see docs/plans/2026-05-04-step-5-curator-implementation.md §5e-NEW-1). "
+        "5d shipped the brief + worker drainer; the enqueue side is gated "
+        "behind 5e."
+    ),
 )
 def test_supersession_queues_dependent_for_reeval(
     conn, project_factory, memory_factory
@@ -68,13 +75,14 @@ def test_supersession_queues_dependent_for_reeval(
         )
     conn.commit()
 
-    # The curator re-eval queue does not exist yet. When Step 5 lands
-    # this query needs to be replaced with the real reader.
+    # The Phase 5e enqueue path should populate the queue here.
+    # Until 5e ships this query returns [] and the assertion fails
+    # (which is what the xfail marker captures).
     with conn.cursor() as cur:
         cur.execute(
-            "SELECT memory_id FROM devbrain.curator_reeval_queue "
-            "WHERE project_id = %s",
-            (project["id"],),
+            "SELECT memory_id FROM devbrain.curator_re_eval_queue "
+            "WHERE cascade_source_id = %s AND edge_type = 'supersedes'",
+            (m_old["id"],),
         )
         queued = [r[0] for r in cur.fetchall()]
 

--- a/tests/postulates/test_p2_archived_excluded.py
+++ b/tests/postulates/test_p2_archived_excluded.py
@@ -5,53 +5,124 @@ POSTULATE
 A memory with archived_at IS NOT NULL must never appear in the
 curator's project brief, regardless of its strength or recency.
 
-STATUS
-------
-xfail(strict=True) until the curator agent (Atlas Step 5 in
-docs/plans/2026-04-29-phase-3-discipline-layer.md §4) ships. The
-substrate (archived_at column on devbrain.memory) is already in
-place from migration 010, so the *data* the curator will need to
-read is fully testable today — only the curator function itself is
-missing.
-
-When Step 5 lands this xfail flips XPASS and CI forces us back here
-to remove the marker.
+Activated in Atlas Step 5d. Was xfail(strict=True) until the curator
+agent landed. See docs/plans/2026-05-04-step-5-curator-design.md §3.
+The substrate (archived_at column) ships in migration 010; the
+filter discipline lives in factory/curator/brief.py — every
+SELECT off devbrain.memory contains `archived_at IS NULL`.
 """
 from __future__ import annotations
 
-import pytest
+import sys
+import uuid
+from pathlib import Path
+
+# Make `from curator.brief import ...` resolve from tests/postulates/.
+_FACTORY = Path(__file__).resolve().parents[2] / "factory"
+if str(_FACTORY) not in sys.path:
+    sys.path.insert(0, str(_FACTORY))
+
+from curator.brief import generate_brief  # noqa: E402
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Curator agent + brief assembly lands in Atlas Step 5; "
-    "see docs/plans/2026-04-29-phase-3-discipline-layer.md §4.",
-)
 def test_archived_memory_not_in_curator_brief(
     conn, project_factory, memory_factory
 ):
     project = project_factory("p2")
-    live = memory_factory(
-        project["id"], kind="pattern", content="live pattern: prefer asyncpg"
+
+    # Live memory + lesson + rule — every section the brief surfaces.
+    live_decision = memory_factory(
+        project["id"], kind="pattern",
+        content="live pattern: prefer asyncpg",
     )
-    stale = memory_factory(
-        project["id"], kind="pattern", content="stale pattern: prefer aiopg"
+    stale_decision = memory_factory(
+        project["id"], kind="pattern",
+        content="stale pattern: prefer aiopg",
     )
     with conn.cursor() as cur:
         cur.execute(
             "UPDATE devbrain.memory SET archived_at = now() WHERE id = %s",
-            (stale["id"],),
+            (stale_decision["id"],),
         )
+
+        # Insert a lesson + rule with one archived sibling each so the
+        # postulate covers all three sections of the brief.
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, tier) "
+            "VALUES (%s, 'pattern', 'live-lesson', 'live lesson', 'lesson') "
+            "RETURNING id",
+            (project["id"],),
+        )
+        live_lesson_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, tier, archived_at) "
+            "VALUES (%s, 'pattern', 'stale-lesson', 'stale lesson', "
+            "        'lesson', now()) "
+            "RETURNING id",
+            (project["id"],),
+        )
+        stale_lesson_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, tier) "
+            "VALUES (%s, 'decision', 'live-rule', 'live rule', 'rule') "
+            "RETURNING id",
+            (project["id"],),
+        )
+        live_rule_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, tier, archived_at) "
+            "VALUES (%s, 'decision', 'stale-rule', 'stale rule', 'rule', "
+            "        now()) "
+            "RETURNING id",
+            (project["id"],),
+        )
+        stale_rule_id = cur.fetchone()[0]
+
+        # The brief lookup is keyed on factory_jobs.id (cascade target
+        # for the persist UPDATE). Use a real factory_jobs row so the
+        # UPDATE inside generate_brief succeeds — without a row the
+        # silent UPDATE 0-rows path would still let the test pass on
+        # the SELECT side, but a missing factory_jobs row also makes
+        # the contract clearer if generate_brief ever grows a returning-
+        # rowcount assertion.
+        cur.execute(
+            "INSERT INTO devbrain.factory_jobs "
+            "(project_id, title, spec, status) "
+            "VALUES (%s, 'p2-test', 'asyncpg pattern', 'queued') "
+            "RETURNING id",
+            (project["id"],),
+        )
+        job_id = cur.fetchone()[0]
     conn.commit()
 
-    # Curator entrypoint does not exist yet. Once Atlas Step 5 lands,
-    # replace this with the real `assemble_curator_brief(project_id)`
-    # call. Until then we import-fail and pytest treats the test as
-    # xfail.
-    from factory.curator import assemble_curator_brief  # type: ignore[import-not-found]
+    try:
+        brief = generate_brief(conn, job_id, project["id"], "asyncpg pattern")
 
-    brief = assemble_curator_brief(project["id"])
-    brief_ids = {entry.memory_id for entry in brief.entries}
+        decision_ids = {r.id for r in brief.relevant_decisions}
+        lesson_ids = {r.id for r in brief.lessons}
+        rule_ids = {r.id for r in brief.rules}
 
-    assert live["id"] in brief_ids
-    assert stale["id"] not in brief_ids
+        # Live entries surface in their respective sections.
+        assert live_decision["id"] in decision_ids
+        assert live_lesson_id in lesson_ids
+        assert live_rule_id in rule_ids
+
+        # Archived entries never surface, regardless of section.
+        assert stale_decision["id"] not in decision_ids
+        assert stale_lesson_id not in lesson_ids
+        assert stale_rule_id not in rule_ids
+    finally:
+        # The job_id was inserted directly (no factory_job_factory) so
+        # clean it up explicitly. The project_factory teardown won't
+        # touch factory_jobs because postulate-conftest doesn't track
+        # them.
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = %s",
+                (job_id,),
+            )
+        conn.commit()


### PR DESCRIPTION
## Summary

Atlas Step 5d ships the curator brief generator and wires it into the state machine. Phase 5d is one third of Atlas Step 5: 5a shipped the migration + Pydantic types, 5b the strength formula, 5c the cascade worker + drain hook in the orchestrator, and 5d closes the loop with the brief that downstream phases consume.

- **\`factory/curator/brief.py\`** (199 lines, **89% coverage**) — synchronous \`generate_brief(conn, job_id, project_id, spec)\`. Pure filtering + ranking, no LLM. Sections: \`rules\` (tier='rule', strength-ranked), \`lessons\` (tier='lesson', top-N strength), \`relevant_decisions\` (tier='memory', naive substring matcher against the spec — TODO Phase 3.x for semantic + structured \`applies_when\` matching), \`recent_cascade_signals\` (memory.last_cascade_at within 24h window). Persists to \`factory_jobs.curator_brief\` JSONB so every downstream phase reads an identical snapshot.
- **\`factory/state_machine.py\`** — \`FactoryDB.transition()\` calls \`generate_brief()\` on QUEUED → PLANNING. On failure: increment \`error_count\`, stash error in \`metadata.brief_error\`, re-raise so the orchestrator's existing FIX_LOOP / max_retries handling kicks in.
- **Compliance-profile filtering** (Step 7 territory) is gracefully degraded: the SELECT is wrapped in try/except + rollback so the same brief code keeps working before and after the \`compliance_profiles_enabled\` / \`compliance_profiles\` columns ship.

## Postulate flip

- **P2 — \`test_archived_memory_not_in_curator_brief\`** flips \`xfail(strict=True)\` → **passing**. Test was extended to cover all three brief sections (decisions, lessons, rules) — \`archived_at IS NULL\` is enforced on every SELECT in brief.py.
- **P1 — \`test_supersession_queues_dependent_for_reeval\`** stays xfailed. The xfail reason is tightened to point at Phase 5e: the enqueue side (turning a \`supersedes\` edge write into queue rows) is the explicit responsibility of the MCP server's \`store()\` tool per the locked design (§3.1 Pathway 1) and Phase 5e of the implementation plan (§5e-NEW-1). 5d ships the brief + worker drainer; 5e closes the loop. Strict mode means P1 will flip XPASS the day Phase 5e lands and force CI back here. **Flagging this as a deviation from the literal Step 5d scope** — see "Deviations" below.

## Other shipped pieces

- \`factory_job_factory\` fixture in \`factory/tests/conftest.py\` for tests that need a real \`factory_jobs\` row.
- \`memory_factory\` extended to take \`tier\` / \`strength\` / \`compliance_profiles\` kwargs (the last is silently accepted until Step 7 ships the column).
- \`psycopg2.extras.register_uuid()\` called from both factory and postulate conftests so id flow is consistent regardless of which other modules a given test imports.
- One state-machine integration test (\`test_state_machine_transition_queued_to_planning_generates_brief\`) verifying the wiring end-to-end.

## Test results

\`\`\`
tests/postulates/                    11 passed, 1 xfailed (P1)
tests/test_curator_brief.py           4 passed, 1 skipped (Step 7)
tests/test_curator_worker.py          4 passed
tests/test_curator_strength.py       10 passed
tests/test_curator_types.py           6 passed
tests/test_migration_017.py           5 passed
tests/test_state_machine_blocked.py  11 passed (no regressions from new hook)
tests/test_state_machine_cleanup.py   4 passed
tests/test_orchestrator_*             39 passed (no regressions)
\`\`\`

## Deviation: P1 left xfailed

The plan's Task 5d-4 calls for flipping both P1 and P2. Empirically only P2 can pass without modifying migrations or the MCP server (both forbidden by the 5d scope). The reason: the substrate that P1 stands on requires an enqueue path — a raw SQL \`INSERT INTO memory_dependencies (..., 'supersedes')\` does not currently populate \`devbrain.curator_re_eval_queue\` because no DB-level trigger exists and the MCP \`store()\` tool's cascade-detection ships in Phase 5e (5e-NEW-1).

The choice to leave P1 xfailed (with a tightened reason pointing at 5e) preserves the strict-xfail discipline: when 5e lands, P1 will XPASS and CI will fail loudly, forcing whoever ships 5e to come back here and remove the marker.

## Test plan

- [x] Brief tests pass (3 active + 1 state-machine integration; 1 skipped pending Step 7 columns)
- [x] P2 flips green
- [x] P1 stays xfailed with reason updated to point at Phase 5e
- [x] All other postulates (P3, P_cycle, P_archived_mid_cascade, P_stuck_surface_able) still pass
- [x] Existing curator + state machine tests pass — no regressions
- [x] Brief generation coverage at 89% (≥ 85% bar)
- [x] No migration changes, no MCP server changes, no end_session work

🤖 Generated with [Claude Code](https://claude.com/claude-code)