### PR TITLE
ci(tests): Atlas Step 5f — DB-available CI workflow + Step 5 done

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,13 +47,10 @@ jobs:
         # pure — those run locally fine but break CI without a service
         # container.
         #
-        # Adding a "DB-available" workflow with a pgvector service container
-        # for broader coverage is tracked as a follow-up — earlier attempts
-        # hit migrate-vs-schema-bootstrap ordering issues. The right next
-        # step there is `psql -f migrations/001_initial_schema.sql` first,
-        # then `python factory/cli.py migrate` for everything else (so the
-        # migrate command's schema_migrations writes have a target table
-        # to write to).
+        # The DB-available counterpart lives in the `pytest-db` job below,
+        # which spins up a pgvector service container, applies all
+        # migrations in order, and runs the postulates + curator
+        # integration tests (Atlas Step 5f).
         run: |
           cd factory
           python -m pytest \
@@ -72,3 +69,91 @@ jobs:
             tests/test_seed_ports.py \
             tests/test_compose_env.py \
             -p no:cacheprovider --tb=short -q
+
+  pytest-db:
+    name: pytest (DB-available — postulates + curator integration)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: devbrain
+          POSTGRES_PASSWORD: devbrain-ci
+          POSTGRES_DB: devbrain
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U devbrain"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Bootstrap schema (apply all migrations in order)
+        # Migration 001 creates the `vector` extension and the devbrain
+        # schema; subsequent migrations build on it. Apply every
+        # migrations/0NN_*.sql in numerical order.
+        env:
+          PGPASSWORD: devbrain-ci
+        run: |
+          for f in $(ls migrations/0*.sql | sort); do
+            echo "Applying $f..."
+            psql -h localhost -p 5432 -U devbrain -d devbrain -v ON_ERROR_STOP=1 -f "$f"
+          done
+
+      - name: Run postulates (rootdir = repo root)
+        # Conftest gates on DEVBRAIN_DB_PASSWORD and reads
+        # DEVBRAIN_DB_HOST_PORT (not DEVBRAIN_DB_PORT) — see
+        # tests/postulates/conftest.py.
+        env:
+          DEVBRAIN_DB_HOST: localhost
+          DEVBRAIN_DB_HOST_PORT: "5432"
+          DEVBRAIN_DB_USER: devbrain
+          DEVBRAIN_DB_PASSWORD: devbrain-ci
+          DEVBRAIN_DB_NAME: devbrain
+        run: |
+          python -m pytest tests/postulates/ -v --tb=short
+
+      - name: Run curator + migration + cascade integration tests (rootdir = factory/)
+        # factory/tests/conftest.py uses the same env-var contract; rootdir
+        # differs because pytest discovers factory/pytest.ini.
+        env:
+          DEVBRAIN_DB_HOST: localhost
+          DEVBRAIN_DB_HOST_PORT: "5432"
+          DEVBRAIN_DB_USER: devbrain
+          DEVBRAIN_DB_PASSWORD: devbrain-ci
+          DEVBRAIN_DB_NAME: devbrain
+        run: |
+          cd factory && python -m pytest \
+            tests/test_curator_brief.py \
+            tests/test_curator_end_session.py \
+            tests/test_curator_strength.py \
+            tests/test_curator_types.py \
+            tests/test_curator_worker.py \
+            tests/test_migration_017.py \
+            tests/test_migration_018.py \
+            tests/test_store_cascade_enqueue.py \
+            -v --tb=short


### PR DESCRIPTION
## Summary

Final sub-PR of **Atlas Step 5**. Adds a sibling `pytest-db` job to `.github/workflows/test.yml` that spins up a `pgvector/pgvector:pg16` service container, applies all 18 migrations in numerical order, and runs the postulates + curator integration tests on every push/PR.

The existing no-DB `pytest` job is unchanged (same allow-list, same Python 3.12 runner, same caching). Its comment block is updated to point at the new job rather than describing the DB workflow as a follow-up.

## What's new

- **Service container:** `pgvector/pgvector:pg16` with health-check loop on `pg_isready -U devbrain`
- **Schema bootstrap:** `for f in $(ls migrations/0*.sql | sort); do psql -v ON_ERROR_STOP=1 -f "$f"; done` — migration 001 already creates `CREATE EXTENSION IF NOT EXISTS vector` and the `devbrain` schema, so subsequent migrations build on it cleanly
- **Two pytest invocations** (because rootdirs differ):
  - `python -m pytest tests/postulates/ -v` — repo-root rootdir for the 8 postulate files
  - `cd factory && python -m pytest tests/test_curator_*.py tests/test_migration_*.py tests/test_store_cascade_enqueue.py -v` — `factory/` rootdir picks up `factory/pytest.ini` + `factory/tests/conftest.py`
- **Env-var contract** verified against both conftests: `DEVBRAIN_DB_HOST`, `DEVBRAIN_DB_HOST_PORT` (note: not `DEVBRAIN_DB_PORT`), `DEVBRAIN_DB_USER`, `DEVBRAIN_DB_PASSWORD`, `DEVBRAIN_DB_NAME`

## Postulates now running in CI on every push

All 8 postulates are GREEN as of Phase 5e (PR #76 merged at `aeea5aa`):

- P1 — supersession cascades
- P2 — archived excluded from curator brief
- P3 — HIPAA isolation
- P_cycle
- P_archived_mid_cascade
- P_stuck_surface_able
- P_end_session_isolation
- P_end_session_idempotent

Plus the curator integration test files: `test_curator_brief`, `test_curator_end_session`, `test_curator_strength`, `test_curator_types`, `test_curator_worker`, `test_migration_017`, `test_migration_018`, `test_store_cascade_enqueue`.

## Step 5 verification matrix (closed out)

This PR completes the verification matrix from §6 of the design doc. The discipline layer's enforcement (cascade re-eval, archived-exclusion, HIPAA isolation, end_session enrichment) is now exercised on every PR — adding regressions to any of these surfaces will fail CI loudly rather than only when a developer remembers to run `pytest tests/postulates/` locally.

## Refs

- `docs/plans/2026-05-04-step-5-curator-implementation.md` (Phase 5f, Tasks 5f-1/2/3)
- `docs/plans/2026-05-04-step-5-curator-design.md` §6 Testing
- DevBrain decision `2ee7aff0`

## Test plan

- [ ] Both jobs pass on this PR: existing `pytest` (no-DB subset) + new `pytest-db` (DB-available)
- [ ] All 8 postulates execute and pass in `pytest-db`
- [ ] All 8 curator integration test files execute and pass in `pytest-db`
- [ ] No regressions in the existing pytest job (same allow-list, same runner, same Python version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)