### PR TITLE
docs: clear post-Step-5 backlog (#2 migrations workflow + #3 Tahoe TCC)

### DIFF
--- a/docs/plans/onboarding-webhook-deploy.md
+++ b/docs/plans/onboarding-webhook-deploy.md
@@ -32,39 +32,37 @@ hostile to SSH-only operation, and bought us nothing in return.
 Running under launchd directly with the existing devbrain venv is
 simpler, faster to iterate, and easier to debug.
 
-## ⚠️ Known issue on this Mac Studio (2026-05-01)
+## Tahoe TCC platform issue — resolved (2026-05-04)
 
-Empirically: Python 3.14.4 + macOS arm64 + launchd is dropping
-`http.server`'s listening socket into CLOSED state immediately after
-bind. The bind succeeds, the log line prints, but the server never
-serves connections. Reproduces with:
-- ThreadingHTTPServer in main thread
-- ThreadingHTTPServer in worker thread
-- Plain HTTPServer
-- Bare `python3.14 -m http.server` invocation under launchd
-- Same `python -m http.server` backgrounded with `&`
-- Same in tmux detached session
-- nohup, setsid, script, launchctl asuser variants
+**Original symptom (2026-05-01):** Python 3.14 + macOS Tahoe + launchd
+dropped `http.server`'s listening socket into CLOSED state immediately
+after bind. Diagnosed as macOS 26 (Tahoe) silently denying the new
+"Local Network" TCC permission to faceless launchd processes (no UI to
+display the consent prompt). Reproduced with every `http.server`
+variant we tried (ThreadingHTTPServer, plain HTTPServer, bare
+`python -m http.server`, nohup/setsid/launchctl-asuser) — all bound
+and immediately closed. **Worked only when run interactively in an
+attached TTY** because TTY-attached processes inherit the GUI user's
+TCC grants.
 
-The same code works correctly when run **interactively in an attached
-TTY** (`./bin/devbrain-onboard` in a foreground Terminal session).
-This points at TTY/process-group/signal handling in the macOS arm64
-build of Python 3.14.
+**Resolution:** `launchd/com.devbrain.onboard.plist` was updated to
+tunnel the program through `/usr/bin/login -fpq` and set
+`SessionCreate=true`, both of which place the spawned process inside
+the GUI user's Aqua session context. The session inherits the user's
+existing Local Network TCC grant, so http.server's bind survives and
+the socket actually listens.
 
-**Workaround for now:** run the webhook in an attached tmux session
-on the Mac Studio's GUI shell (Patrick's Terminal.app while RDP'd in,
-or an SSH session with `-t` from a real terminal). The session must
-have a controlling TTY. Document a follow-up to investigate further:
-- Try Python 3.13 (we installed it; same issue reproduces)
-- Try Python 3.12 (not yet installed; potentially affected)
-- Replace stdlib http.server with `aiohttp` or `flask + waitress`
-- File against Python upstream / Apple if the simple repro is real
+**Verified working** on 2026-05-04 with Mac Studio Tahoe + Python 3.14
++ devbrain venv:
+- `launchctl load -w` succeeds
+- Python process binds 127.0.0.1:8000 in LISTEN state
+- `curl http://127.0.0.1:8000/healthz` returns `{"status":"ok"}`
+- Survives launchd respawn after kill -9
 
-If you can spin a Terminal.app on the Mac Studio's GUI session and
-run `./bin/devbrain-onboard` there, the rest of this doc applies as
-written. Skip Step 2 (launchd plist) until the platform issue is
-resolved — `bin/devbrain-onboard` running under tmux-attach is
-sufficient for the alpha onboarding workflow.
+**No follow-up investigation needed.** The original "try Python 3.13 /
+3.12, file against Python upstream" leads were chasing the wrong
+problem — it wasn't a Python http.server bug, it was a macOS TCC
+deny. The plist workaround is sufficient and stable.
 
 ## Step 1 — Smoke-test the webhook on the Mac Studio
 
@@ -82,7 +80,7 @@ curl -s http://127.0.0.1:8000/healthz
 # {"status":"ok"}
 ```
 
-## Step 2 — Install the launchd plist (gated on platform-issue resolution)
+## Step 2 — Install the launchd plist
 
 Copy `com.devbrain.onboard.plist` to
 `~/Library/LaunchAgents/com.devbrain.onboard.plist`, then load it:

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,98 @@
+# DevBrain Migrations
+
+Sequential SQL migrations applied to `devbrain` schema in `devbrain.devbrain`
+Postgres. Source of truth: `devbrain.schema_migrations` ledger table (added
+in 009).
+
+## File naming
+
+```
+0NN_<short-slug>.sql
+```
+
+- Numeric prefix is the sequence; never reuse a number.
+- Always idempotent — every `CREATE TABLE`, `CREATE INDEX`, `ALTER TABLE
+  ADD COLUMN` uses `IF NOT EXISTS`. This lets the runner re-apply safely
+  if the ledger drifts from reality.
+- One concern per file. Don't bundle "add a column + seed five rows" in
+  the same file unless the seeding is logically part of the schema.
+
+## How migrations are applied
+
+**Two paths, depending on lifecycle stage:**
+
+### First install (fresh DB)
+
+`docker compose up -d devbrain-db` triggers the `pgvector/pgvector:pg17`
+entrypoint, which auto-runs every `migrations/*.sql` in lexical order
+against the empty DB. No manual step needed. See `INSTALL.md` Step 3.
+
+### After install — applying new migrations
+
+Use the `devbrain migrate` CLI (calls `factory/cli.py migrate` under the
+hood). Don't apply via direct `psql`.
+
+```bash
+# See what's pending without applying
+devbrain migrate --dry-run
+
+# Apply pending migrations
+devbrain migrate
+```
+
+The runner:
+1. Reads `migrations/*.sql` from disk
+2. Looks each filename up in `devbrain.schema_migrations`
+3. Executes any not-yet-recorded migrations in their own transactions
+4. Records each successful apply in the ledger
+
+A Postgres advisory lock prevents two concurrent invocations from
+colliding.
+
+## What if I applied directly via `psql` by accident?
+
+`devbrain migrate` self-heals. The schema is already in place (your direct
+apply did that). The ledger is the only thing missing. Running `devbrain
+migrate` will:
+
+1. Detect the migration as "pending" (not in ledger)
+2. Re-run the SQL — idempotent, so it's a no-op
+3. INSERT into `schema_migrations` with `ON CONFLICT DO NOTHING`
+
+After that, the ledger matches reality.
+
+If you want to verify ledger health periodically:
+
+```bash
+# Lists migrations on disk that aren't yet recorded as applied.
+# If empty, the ledger is in sync with disk.
+devbrain migrate --dry-run
+```
+
+## Cross-instance application
+
+When propagating a migration across instances (laptop → Mac Studio,
+laptop → BrightBrain instance, etc.) — pull the new code first
+(`git pull`), THEN run `devbrain migrate`. The new SQL file lands on
+disk first; the ledger gets updated when the runner sees it pending.
+
+## When to bump the migration number
+
+- Adding a column / index / table → new migration
+- Renaming a column → new migration with `ALTER TABLE ... RENAME COLUMN`
+- Dropping a deprecated table → new migration with `DROP TABLE IF EXISTS`
+- Editing an existing migration file in place: **never**, even pre-merge.
+  Once a migration has been applied anywhere (including your local DB
+  during dev), edit-in-place desyncs the ledger from reality. If you
+  need to fix a mistake, write a new migration that corrects the prior.
+
+## Schema_migrations table itself
+
+Created in `009_schema_migrations.sql`. That migration:
+- Creates the `devbrain.schema_migrations` table
+- Backfills rows for 001-008 via a trailing `ON CONFLICT INSERT` (so the
+  runner doesn't re-execute those files on existing DBs that pre-date
+  the ledger)
+
+Do not delete rows from `schema_migrations` manually unless you also
+intend to re-apply the corresponding migration file.


### PR DESCRIPTION
## Summary

Two doc-only commits clearing two backlog items raised after Atlas Step 5 shipped.

### #3 — Tahoe TCC fix marked resolved

`docs/plans/onboarding-webhook-deploy.md` — replaces the "⚠️ Known issue" section with a "Resolved" writeup. The launchd plist (`launchd/com.devbrain.onboard.plist`) was already in tree with the fix (\`login -fpq\` + \`SessionCreate=true\` to inherit the GUI user's TCC grant); we just hadn't verified it on Tahoe.

**Verified 2026-05-04 on LHT Mac Studio:**
- \`launchctl load -w\` succeeds
- Python binds 127.0.0.1:8000 in LISTEN state
- \`/healthz\` returns \`{"status":"ok"}\`
- Survives respawn after kill -9

The "Skip Step 2 until platform-issue resolved" caveat is removed.

### #2 — schema_migrations workflow documented

New `migrations/README.md` capturing conventions that were implicit until now:
- File naming + idempotency requirement
- Apply via \`devbrain migrate\` (not direct psql)
- \`devbrain migrate --dry-run\` as a ledger-health check
- Self-healing path when ledger drifts (just run migrate again — idempotent SQL + ON CONFLICT DO NOTHING)
- Cross-instance propagation order (git pull then migrate)
- Never edit migration files in-place after they've been applied

## Out of scope (separate fix paths)

- **#4 — CLAUDE.md sweep:** edits applied directly in \`~/.claude/CLAUDE.md\` (lives outside this repo, no commit needed)
- **#1 — pre-existing factory test failures:** investigation in flight, separate PR when complete

## Test plan
- [x] No code changed — pure docs PR, no test impact
- [x] Existing 180 no-DB tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)