### PR TITLE
feat(memory): Atlas Step 6a — migration 019 + eval types + graduation skeleton

### DIFF
--- a/factory/curator/eval/types.py
+++ b/factory/curator/eval/types.py
@@ -1,0 +1,40 @@
+"""Versioned Pydantic models for eval findings.
+
+Stable contract consumed by the fix-loop implementer + graduation pipeline.
+Bumping a model goes via Pydantic discriminated union on `version`.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class EvalFinding(BaseModel):
+    """A single finding from an eval agent."""
+
+    model_config = ConfigDict(frozen=True)
+
+    rule_id: UUID | None  # NULL if finding is from a heuristic, not a memory row
+    severity: Literal["critical", "important", "minor"]
+    file: str
+    line: int | None
+    message: str
+    fix_hint: str
+    relevant_memory_id: UUID | None  # which memory in brief surfaced this; NULL if missed
+
+
+class EvalResult(BaseModel):
+    """Full result of one eval agent run."""
+
+    model_config = ConfigDict(frozen=True)
+
+    version: Literal["1.0"]
+    job_id: UUID
+    agent_name: Literal["eval_security", "eval_test"]
+    findings: list[EvalFinding]
+    elapsed_ms: int
+    started_at: datetime
+    error: str | None = None  # set if agent failed; findings will be []

--- a/factory/curator/graduation.py
+++ b/factory/curator/graduation.py
@@ -1,0 +1,23 @@
+"""Three-signal feedback loop for lesson graduation + rule demotion.
+
+Public API:
+- apply_feedback_signals(conn, job_id, brief, eval_results)
+- demote_low_precision_rules(conn, project_id)
+"""
+from __future__ import annotations
+
+# Tunable constants — change here if real-world data shows them wrong.
+GRADUATION_STREAK_THRESHOLD = 3
+GRADUATION_FRESHNESS_WINDOW = "90 days"
+DEMOTION_PRECISION_THRESHOLD = 0.50
+DEMOTION_WINDOW = "30 days"
+
+
+def apply_feedback_signals(conn, job_id, brief, eval_results):
+    """Stub. Implementation lands in 6c."""
+    raise NotImplementedError("ships in Phase 6c")
+
+
+def demote_low_precision_rules(conn, project_id):
+    """Stub. Implementation lands in 6c."""
+    raise NotImplementedError("ships in Phase 6c")

--- a/factory/curator/refinement.py
+++ b/factory/curator/refinement.py
@@ -1,0 +1,20 @@
+"""Curator self-introspection — proposes applies_when widening for memories
+that should have been in the brief but weren't (signal #2).
+
+Public API:
+- queue_refinement(conn, finding)
+- refine_applies_when(conn, project_id)
+
+Implementation lands in 6d.
+"""
+from __future__ import annotations
+
+
+def queue_refinement(conn, finding):
+    """Stub. Implementation lands in 6d."""
+    raise NotImplementedError("ships in Phase 6d")
+
+
+def refine_applies_when(conn, project_id):
+    """Stub. Implementation lands in 6d."""
+    raise NotImplementedError("ships in Phase 6d")

--- a/factory/tests/test_curator_eval_types.py
+++ b/factory/tests/test_curator_eval_types.py
@@ -1,0 +1,88 @@
+"""Tests for the eval finding/result Pydantic models.
+
+Covers JSON round-trip + validation rules. The contract is stable as soon
+as Phase 6b (eval runner) starts producing these — bumping requires a new
+version literal.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from curator.eval.types import EvalFinding, EvalResult
+
+
+def _finding(**overrides) -> EvalFinding:
+    """Build a valid finding with sensible defaults; overrides win."""
+    payload = {
+        "rule_id": uuid4(),
+        "severity": "critical",
+        "file": "src/auth.py",
+        "line": 42,
+        "message": "SQL string interpolation",
+        "fix_hint": "Use parameterized query",
+        "relevant_memory_id": uuid4(),
+    }
+    payload.update(overrides)
+    return EvalFinding(**payload)
+
+
+def _result(**overrides) -> EvalResult:
+    payload = {
+        "version": "1.0",
+        "job_id": uuid4(),
+        "agent_name": "eval_security",
+        "findings": [_finding()],
+        "elapsed_ms": 1234,
+        "started_at": datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc),
+        "error": None,
+    }
+    payload.update(overrides)
+    return EvalResult(**payload)
+
+
+def test_eval_finding_roundtrip():
+    """A finding should survive a full JSON round-trip with no data loss."""
+    original = _finding()
+    rehydrated = EvalFinding.model_validate_json(original.model_dump_json())
+    assert rehydrated == original
+
+
+def test_eval_result_roundtrip():
+    """An EvalResult — including its findings list — should round-trip clean."""
+    original = _result()
+    rehydrated = EvalResult.model_validate_json(original.model_dump_json())
+    assert rehydrated == original
+
+
+def test_eval_finding_rejects_invalid_severity():
+    """severity must be one of critical|important|minor."""
+    with pytest.raises(ValidationError):
+        _finding(severity="catastrophic")
+
+
+def test_eval_result_rejects_invalid_agent_name():
+    """agent_name is locked to the two known eval agents."""
+    with pytest.raises(ValidationError):
+        _result(agent_name="eval_performance")
+
+
+def test_eval_result_rejects_unknown_version():
+    """Forward-incompat versions must not silently parse — bumping the
+    contract requires a new Literal value."""
+    with pytest.raises(ValidationError):
+        _result(version="2.0")
+
+
+def test_eval_finding_allows_null_rule_id():
+    """Heuristic findings (no backing memory row) carry rule_id=None;
+    relevant_memory_id can also be None for findings the brief missed."""
+    finding = _finding(rule_id=None, relevant_memory_id=None)
+    assert finding.rule_id is None
+    assert finding.relevant_memory_id is None
+    # Round-trip preserves the nulls.
+    rehydrated = EvalFinding.model_validate_json(finding.model_dump_json())
+    assert rehydrated == finding

--- a/factory/tests/test_migration_019.py
+++ b/factory/tests/test_migration_019.py
@@ -1,0 +1,92 @@
+"""Test migration 019 applies cleanly and creates the expected schema objects.
+
+Migration 019 adds:
+  - devbrain.memory.current_streak (INTEGER NOT NULL DEFAULT 0) — consecutive
+    successful preventions; signal #3 increments, signal #1 resets
+  - devbrain.memory.graduated_at (TIMESTAMPTZ) — set on tier transition
+    'lesson' -> 'rule'
+  - devbrain.memory.demoted_at (TIMESTAMPTZ) — set on tier transition
+    'rule' -> 'lesson'
+  - idx_memory_graduation_candidates partial index — optimizes the
+    graduation candidate query at end of every REVIEWING phase
+
+These tests assert the schema is in place; behavioral correctness of the
+graduation pipeline is covered by the graduation-module tests in Task 6c.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.db
+def test_019_memory_has_current_streak(conn):
+    """current_streak must exist as INTEGER NOT NULL DEFAULT 0."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT data_type, is_nullable, column_default "
+            "FROM information_schema.columns "
+            "WHERE table_schema='devbrain' AND table_name='memory' "
+            "AND column_name='current_streak'"
+        )
+        row = cur.fetchone()
+    assert row is not None, "current_streak column is missing"
+    data_type, is_nullable, column_default = row
+    assert data_type == "integer"
+    assert is_nullable == "NO"
+    assert column_default == "0"
+
+
+@pytest.mark.db
+def test_019_memory_has_graduated_at(conn):
+    """graduated_at must exist as TIMESTAMPTZ, nullable."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT data_type, is_nullable "
+            "FROM information_schema.columns "
+            "WHERE table_schema='devbrain' AND table_name='memory' "
+            "AND column_name='graduated_at'"
+        )
+        row = cur.fetchone()
+    assert row is not None, "graduated_at column is missing"
+    data_type, is_nullable = row
+    assert data_type == "timestamp with time zone"
+    assert is_nullable == "YES"
+
+
+@pytest.mark.db
+def test_019_memory_has_demoted_at(conn):
+    """demoted_at must exist as TIMESTAMPTZ, nullable."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT data_type, is_nullable "
+            "FROM information_schema.columns "
+            "WHERE table_schema='devbrain' AND table_name='memory' "
+            "AND column_name='demoted_at'"
+        )
+        row = cur.fetchone()
+    assert row is not None, "demoted_at column is missing"
+    data_type, is_nullable = row
+    assert data_type == "timestamp with time zone"
+    assert is_nullable == "YES"
+
+
+@pytest.mark.db
+def test_019_graduation_candidates_index(conn):
+    """idx_memory_graduation_candidates must be a partial index on
+    last_hit DESC with the predicate filtering to lesson tier, streak >= 3,
+    not archived. This is the hot-path query at end of every REVIEWING phase.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE schemaname='devbrain' "
+            "  AND tablename='memory' "
+            "  AND indexname='idx_memory_graduation_candidates'"
+        )
+        row = cur.fetchone()
+    assert row is not None, "idx_memory_graduation_candidates is missing"
+    indexdef = row[0]
+    assert "last_hit DESC" in indexdef
+    assert "tier = 'lesson'" in indexdef
+    assert "current_streak >= 3" in indexdef
+    assert "archived_at IS NULL" in indexdef

--- a/migrations/019_lesson_graduation.sql
+++ b/migrations/019_lesson_graduation.sql
@@ -1,0 +1,20 @@
+-- Atlas Step 6 — Lesson graduation tracking
+-- ============================================================================
+--
+-- Three columns + one index for the graduation pipeline:
+--   1. current_streak — consecutive successful preventions (signal #3
+--      increments, signal #1 resets)
+--   2. graduated_at — timestamp when tier transitioned 'lesson' -> 'rule'
+--   3. demoted_at — timestamp when tier transitioned 'rule' -> 'lesson'
+--
+-- Index optimizes the graduation candidate query at end of every
+-- REVIEWING phase.
+
+ALTER TABLE devbrain.memory
+    ADD COLUMN IF NOT EXISTS current_streak INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS graduated_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS demoted_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_memory_graduation_candidates
+    ON devbrain.memory (last_hit DESC)
+    WHERE tier = 'lesson' AND current_streak >= 3 AND archived_at IS NULL;


### PR DESCRIPTION
## Summary

Phase 6a of Atlas Step 6 — scaffolding only. Lands the schema + types + module skeletons that 6b/6c/6d will fill in.

- **Migration 019** — adds `current_streak`, `graduated_at`, `demoted_at` to `devbrain.memory`, plus partial index `idx_memory_graduation_candidates` on `(last_hit DESC) WHERE tier='lesson' AND current_streak >= 3 AND archived_at IS NULL` for the end-of-REVIEWING graduation query
- **Pydantic types** — `factory/curator/eval/types.py` exports `EvalFinding` + `EvalResult` (frozen, version-locked at `"1.0"`); the stable contract eval agents (6b) emit and the graduation pipeline (6c) consumes
- **Module skeletons** — `factory/curator/graduation.py` + `factory/curator/refinement.py` with `NotImplementedError` stubs and tunable constants pre-declared so 6c/6d only edit one place

Reference: `docs/plans/2026-05-04-step-6-eval-graduation-design.md` (locked design) and `docs/plans/2026-05-04-step-6-eval-graduation-implementation.md` (Phase 6a tasks 6a-1 through 6a-5).

## Tests added (10 new)

Schema assertions on `devbrain.memory` (4):
- `test_019_memory_has_current_streak` — INTEGER NOT NULL DEFAULT 0
- `test_019_memory_has_graduated_at` — TIMESTAMPTZ, nullable
- `test_019_memory_has_demoted_at` — TIMESTAMPTZ, nullable
- `test_019_graduation_candidates_index` — partial index predicate is exact

Pydantic round-trip + validation (6):
- `test_eval_finding_roundtrip`
- `test_eval_result_roundtrip`
- `test_eval_finding_rejects_invalid_severity`
- `test_eval_result_rejects_invalid_agent_name`
- `test_eval_result_rejects_unknown_version`
- `test_eval_finding_allows_null_rule_id`

Coverage: **100% on `curator/eval/types.py`** (23/23 stmts).

## Out of scope (explicitly deferred)

- Eval runner — Phase 6b
- Graduation logic in `apply_feedback_signals` / `demote_low_precision_rules` — Phase 6c
- Refinement logic in `queue_refinement` / `refine_applies_when` — Phase 6d

The skeleton modules raise `NotImplementedError` with phase pointers so accidental imports surface immediately.

## Test plan

- [x] Migration 019 applied locally; `\d devbrain.memory` shows the 3 new columns + new partial index
- [x] `schema_migrations` ledger row inserted for `019_lesson_graduation.sql`
- [x] All 4 schema-assertion tests pass against the live DB
- [x] All 6 Pydantic type tests pass
- [x] 100% coverage on `curator/eval/types.py`
- [ ] CI db-tests workflow goes green on the PR