### PR TITLE
feat(curator): Atlas Step 6b — eval runner + eval_security + eval_test

### DIFF
--- a/factory/curator/eval/eval_security.py
+++ b/factory/curator/eval/eval_security.py
@@ -1,0 +1,59 @@
+"""eval_security finding parser.
+
+eval_security checks: auth, injection, secret leakage, dependency CVE.
+The prompt instructs claude to emit a JSON list of findings; this parser
+maps that to EvalFinding objects.
+
+Schema kept identical to eval_test.parse — both modules consume the
+same response shape, only the underlying prompt differs. Bumping the
+shape is a coordinated change across both parsers.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from curator.eval.types import EvalFinding
+
+
+def parse(response: dict) -> list[EvalFinding]:
+    """Map claude's JSON response to an EvalFinding list.
+
+    Expected response shape from the prompt:
+
+    {
+      "findings": [
+        {
+          "rule_id": "uuid-or-null",
+          "severity": "critical|important|minor",
+          "file": "path/to/file.py",
+          "line": 42,
+          "message": "...",
+          "fix_hint": "...",
+          "relevant_memory_id": "uuid-or-null"
+        }
+      ]
+    }
+
+    Missing optional fields fall back to defaults:
+    - line: None (finding doesn't pin a line)
+    - fix_hint: empty string (parser is permissive — prompts target this
+      field but don't always fill it)
+    - rule_id, relevant_memory_id: None (heuristic finding / brief miss)
+    """
+    raw = response.get("findings", [])
+    return [_parse_one(item) for item in raw]
+
+
+def _parse_one(item: dict) -> EvalFinding:
+    return EvalFinding(
+        rule_id=UUID(item["rule_id"]) if item.get("rule_id") else None,
+        severity=item["severity"],
+        file=item["file"],
+        line=item.get("line"),
+        message=item["message"],
+        fix_hint=item.get("fix_hint", ""),
+        relevant_memory_id=(
+            UUID(item["relevant_memory_id"])
+            if item.get("relevant_memory_id") else None
+        ),
+    )

--- a/factory/curator/eval/eval_test.py
+++ b/factory/curator/eval/eval_test.py
@@ -1,0 +1,58 @@
+"""eval_test finding parser.
+
+eval_test checks: coverage of the diff, test quality, brittleness,
+missing edge cases. The prompt emits the same JSON schema as
+eval_security; this parser is structurally identical to it.
+
+Kept as its own module so Phase 6c+ can specialize parsing without
+touching the security parser. v3.0 keeps them on the same shape.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from curator.eval.types import EvalFinding
+
+
+def parse(response: dict) -> list[EvalFinding]:
+    """Map claude's JSON response to an EvalFinding list.
+
+    Expected response shape (same as eval_security):
+
+    {
+      "findings": [
+        {
+          "rule_id": "uuid-or-null",
+          "severity": "critical|important|minor",
+          "file": "path/to/file.py",
+          "line": 42,
+          "message": "...",
+          "fix_hint": "...",
+          "relevant_memory_id": "uuid-or-null"
+        }
+      ]
+    }
+
+    Missing optional fields fall back to defaults:
+    - line: None (finding doesn't pin a line)
+    - fix_hint: empty string (parser is permissive — prompts target this
+      field but don't always fill it)
+    - rule_id, relevant_memory_id: None (heuristic finding / brief miss)
+    """
+    raw = response.get("findings", [])
+    return [_parse_one(item) for item in raw]
+
+
+def _parse_one(item: dict) -> EvalFinding:
+    return EvalFinding(
+        rule_id=UUID(item["rule_id"]) if item.get("rule_id") else None,
+        severity=item["severity"],
+        file=item["file"],
+        line=item.get("line"),
+        message=item["message"],
+        fix_hint=item.get("fix_hint", ""),
+        relevant_memory_id=(
+            UUID(item["relevant_memory_id"])
+            if item.get("relevant_memory_id") else None
+        ),
+    )

--- a/factory/curator/eval/prompts/eval_security.md
+++ b/factory/curator/eval/prompts/eval_security.md
@@ -1,0 +1,63 @@
+You are eval_security, a domain-specialized eval agent for the DevBrain
+factory. You inspect a code diff for security violations.
+
+## Your task
+
+Read the brief, plan, and diff (provided in the user message). Identify:
+
+- Authentication / authorization gaps
+- Injection vulnerabilities (SQL, command, prompt)
+- Secret leakage (logs, error messages, fixture data)
+- Dependency CVE references (only if the diff touches dependencies)
+
+For each finding, surface which memory in the brief covers it (if any) by
+setting `relevant_memory_id` to that memory's id from the brief's
+`rules`, `lessons`, or `relevant_decisions` sections. If no in-brief
+memory covers the finding, set `relevant_memory_id: null`.
+
+If the finding maps to a specific tier='rule' memory in the brief, set
+`rule_id` to that memory's id. If the finding is a heuristic catch (you
+spotted it but it's not anchored to a rule row), set `rule_id: null`.
+
+## Output format
+
+Strict JSON. **NO PROSE OUTSIDE THE JSON.** Output only the JSON object
+described below — no markdown fences, no leading/trailing commentary.
+
+```
+{
+  "findings": [
+    {
+      "rule_id": "uuid-or-null",
+      "severity": "critical|important|minor",
+      "file": "factory/whatever.py",
+      "line": 42,
+      "message": "Brief finding description.",
+      "fix_hint": "How to address.",
+      "relevant_memory_id": "uuid-or-null"
+    }
+  ]
+}
+```
+
+If you find no violations, return: `{"findings": []}`
+
+## Severity guidance
+
+- **critical**: exploitable now in this diff (e.g., SQL injection vector,
+  unauthenticated admin endpoint, hardcoded secret committed to source).
+- **important**: would become exploitable in production (e.g., logged
+  secret, missing CSRF token on state-changing route, weak hash on
+  credentials).
+- **minor**: defense-in-depth gap (e.g., missing rate limit on a public
+  endpoint, missing input length cap, error message leaks stack trace).
+
+## What NOT to flag
+
+- Style/lint issues (eval_test handles brittleness).
+- Pure refactoring with no behavior change.
+- Missing tests (eval_test handles coverage).
+- Performance concerns absent a security angle.
+
+If the diff is clean, return an empty findings list. Do not invent
+findings to look thorough.

--- a/factory/curator/eval/prompts/eval_test.md
+++ b/factory/curator/eval/prompts/eval_test.md
@@ -1,0 +1,72 @@
+You are eval_test, a domain-specialized eval agent for the DevBrain
+factory. You inspect a code diff for test quality issues.
+
+## Your task
+
+Read the brief, plan, and diff (provided in the user message). Identify:
+
+- **Coverage gaps**: new code in the diff (production module changes)
+  that ships without a corresponding test. Flag the specific function /
+  branch / file that's untested.
+- **Assertion quality**: tests that assert against mocks instead of
+  observable behavior (e.g., `mock.called_once_with(...)` as the only
+  assertion when a return value or DB row is what actually matters).
+- **Brittleness**: snapshot tests / golden-file tests that lock
+  irrelevant detail (e.g., timestamps, IDs, formatting) and will break
+  on every refactor without catching real regressions.
+- **Missing edge cases relative to the spec**: the brief or plan calls
+  out a behavior (e.g., "rejects unknown severity", "skips stale rows",
+  "demotes only within 30-day window") that has no corresponding test.
+
+For each finding, surface which memory in the brief covers it (if any)
+by setting `relevant_memory_id` to that memory's id from the brief's
+`rules`, `lessons`, or `relevant_decisions` sections. If no in-brief
+memory covers the finding, set `relevant_memory_id: null`.
+
+If the finding maps to a specific tier='rule' memory in the brief, set
+`rule_id` to that memory's id. If the finding is a heuristic catch (you
+spotted it but it's not anchored to a rule row), set `rule_id: null`.
+
+## Output format
+
+Strict JSON. **NO PROSE OUTSIDE THE JSON.** Output only the JSON object
+described below — no markdown fences, no leading/trailing commentary.
+
+```
+{
+  "findings": [
+    {
+      "rule_id": "uuid-or-null",
+      "severity": "critical|important|minor",
+      "file": "factory/whatever.py",
+      "line": 42,
+      "message": "Brief finding description.",
+      "fix_hint": "How to address.",
+      "relevant_memory_id": "uuid-or-null"
+    }
+  ]
+}
+```
+
+If you find no test issues, return: `{"findings": []}`
+
+## Severity guidance
+
+- **critical**: a coverage gap or brittle test that masks a regression
+  the diff is likely to introduce (e.g., new public API with no test;
+  test asserts mock was called but never that the side effect happened).
+- **important**: missing edge case the spec explicitly calls out (e.g.,
+  brief says "must reject empty input" and no test covers that path).
+- **minor**: stylistic test smell that won't mask regressions but is
+  worth refactoring (e.g., duplicated setup, overly specific snapshot).
+
+## What NOT to flag
+
+- Security issues (eval_security handles those).
+- Production code style/lint.
+- Tests that already exist and pass — only flag what's missing or
+  structurally wrong.
+- Coverage of code that wasn't touched in the diff.
+
+If the diff has adequate tests, return an empty findings list. Do not
+invent findings to look thorough.

--- a/factory/curator/eval/runner.py
+++ b/factory/curator/eval/runner.py
@@ -1,0 +1,222 @@
+"""Sequential eval invocation with warm prompt cache.
+
+run_evals() spawns one claude subprocess per agent. eval_security runs
+first and instantiates the cache (project + spec + brief + plan + diff).
+eval_test runs second against the same cache, hitting cached input at
+~10% cost. The two agents share an identical user-message body
+(`_build_cached_context`) — only the system prompt differs — so claude's
+prompt cache (5-min TTL) is reused on the second call.
+
+Findings are persisted to `devbrain.factory_artifacts` (one row per
+finding). The schema reuses the existing artifact columns:
+- phase = 'reviewing'
+- artifact_type = agent_name (e.g. 'eval_security' or 'eval_test')
+- content = finding.model_dump_json()
+- findings_count = 1
+- metadata = {agent_name, version, elapsed_ms, started_at, error}
+
+If an agent fails (subprocess exit non-zero, JSON parse error, timeout),
+the EvalResult carries an empty findings list + the error string. The
+OTHER agent still runs — failure isolation is per-agent, not per-batch.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from curator.eval.types import EvalFinding, EvalResult
+
+logger = logging.getLogger(__name__)
+
+# Path to prompts dir — resolved relative to this module.
+_PROMPTS_DIR = Path(__file__).parent / "prompts"
+
+# Sequential ordering matters: eval_security primes the cache, eval_test
+# hits it. Reversing this order doubles the cost of the second call.
+_AGENT_ORDER: list[tuple[str, str]] = [
+    ("eval_security", "eval_security.md"),
+    ("eval_test", "eval_test.md"),
+]
+
+
+def run_evals(
+    conn: Any,
+    job_id: UUID,
+    brief: dict,
+    plan: str,
+    diff: str,
+) -> list[EvalResult]:
+    """Run eval_security then eval_test, sharing a warm prompt cache.
+
+    Persists findings to factory_artifacts. Returns the EvalResult list
+    in invocation order (security first, test second).
+
+    Failure isolation: if one agent raises, its EvalResult carries
+    findings=[] + error=<exc>; the other agent still runs.
+    """
+    cached_context = _build_cached_context(brief, plan, diff)
+    results: list[EvalResult] = []
+
+    for agent_name, prompt_file in _AGENT_ORDER:
+        try:
+            result = _invoke_agent(
+                job_id=job_id,
+                agent_name=agent_name,
+                prompt_path=_PROMPTS_DIR / prompt_file,
+                cached_context=cached_context,
+            )
+        except Exception as exc:  # noqa: BLE001 — agent failures must not abort the batch
+            logger.exception("run_evals: %s failed", agent_name)
+            result = EvalResult(
+                version="1.0",
+                job_id=job_id,
+                agent_name=agent_name,
+                findings=[],
+                elapsed_ms=0,
+                started_at=datetime.now(timezone.utc),
+                error=str(exc)[:500],
+            )
+        results.append(result)
+
+    _persist_findings(conn, job_id, results)
+    return results
+
+
+def _build_cached_context(brief: dict, plan: str, diff: str) -> str:
+    """Format the shared eval context for prompt caching.
+
+    Both eval agents (current and future) read the same context, so this
+    is the cache-hit hot path. The exact byte-level shape of this string
+    matters — any whitespace drift between the security and test calls
+    breaks the cache. Don't reformat without intent.
+    """
+    return (
+        f"## Brief\n\n{json.dumps(brief, indent=2)}\n\n"
+        f"## Plan\n\n{plan}\n\n"
+        f"## Diff\n\n```diff\n{diff}\n```\n"
+    )
+
+
+def _invoke_agent(
+    job_id: UUID,
+    agent_name: str,
+    prompt_path: Path,
+    cached_context: str,
+) -> EvalResult:
+    """Invoke claude with the eval prompt + cached context.
+
+    First call instantiates cache; second call reuses it (claude's prompt
+    cache TTL is 5 min, well within typical job phase duration).
+    """
+    started_at = datetime.now(timezone.utc)
+    start = time.perf_counter()
+
+    system_prompt = prompt_path.read_text()
+    user_prompt = cached_context
+
+    # Spawn claude — stdin payload, JSON output expected. The system
+    # prompt differs per agent (eval_security.md vs eval_test.md); the
+    # user message is identical so the cache is shared.
+    proc = subprocess.run(
+        [
+            "claude",
+            "-p",
+            "--output-format", "json",
+            "--system-prompt", system_prompt,
+        ],
+        input=user_prompt,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"claude exit {proc.returncode}: {proc.stderr[:500]}")
+
+    response = json.loads(proc.stdout)
+    findings = _parse_findings(agent_name, response)
+
+    elapsed_ms = int((time.perf_counter() - start) * 1000)
+    return EvalResult(
+        version="1.0",
+        job_id=job_id,
+        agent_name=agent_name,
+        findings=findings,
+        elapsed_ms=elapsed_ms,
+        started_at=started_at,
+    )
+
+
+def _parse_findings(agent_name: str, response: dict) -> list[EvalFinding]:
+    """Delegate finding parsing to the per-agent module."""
+    if agent_name == "eval_security":
+        from curator.eval.eval_security import parse
+    elif agent_name == "eval_test":
+        from curator.eval.eval_test import parse
+    else:
+        raise ValueError(f"unknown agent_name: {agent_name}")
+    return parse(response)
+
+
+def _persist_findings(conn: Any, job_id: UUID, results: list[EvalResult]) -> None:
+    """Write findings to factory_artifacts (one row per finding).
+
+    Maps onto the existing artifact schema:
+    - phase = 'reviewing'
+    - artifact_type = agent_name
+    - content = finding.model_dump_json()
+    - findings_count = 1
+    - metadata = {version, agent_name, elapsed_ms, started_at, error}
+
+    Each result also writes one summary row when findings is empty so
+    the run is observable even on a clean diff (artifact_type =
+    '<agent>_summary'). Errors are surfaced via metadata.error so the
+    dashboard can render them.
+    """
+    with conn.cursor() as cur:
+        for result in results:
+            base_metadata = {
+                "version": result.version,
+                "agent_name": result.agent_name,
+                "elapsed_ms": result.elapsed_ms,
+                "started_at": result.started_at.isoformat(),
+                "error": result.error,
+            }
+            if not result.findings:
+                # Always write at least a summary row so run is observable.
+                cur.execute(
+                    "INSERT INTO devbrain.factory_artifacts "
+                    "(job_id, phase, artifact_type, content, "
+                    " findings_count, metadata) "
+                    "VALUES (%s, %s, %s, %s, %s, %s::jsonb)",
+                    (
+                        str(job_id),
+                        "reviewing",
+                        f"{result.agent_name}_summary",
+                        "",
+                        0,
+                        json.dumps(base_metadata),
+                    ),
+                )
+                continue
+            for finding in result.findings:
+                cur.execute(
+                    "INSERT INTO devbrain.factory_artifacts "
+                    "(job_id, phase, artifact_type, content, "
+                    " findings_count, metadata) "
+                    "VALUES (%s, %s, %s, %s, %s, %s::jsonb)",
+                    (
+                        str(job_id),
+                        "reviewing",
+                        result.agent_name,
+                        finding.model_dump_json(),
+                        1,
+                        json.dumps(base_metadata),
+                    ),
+                )
+    conn.commit()

--- a/factory/tests/test_curator_eval_runner.py
+++ b/factory/tests/test_curator_eval_runner.py
@@ -1,0 +1,459 @@
+"""Tests for the eval runner.
+
+The runner orchestrates two sequential claude-CLI invocations sharing a
+warm prompt cache. Tests mock subprocess.run so no real claude is
+invoked, and use a fake DB connection so coverage on the persistence
+path is observable without a Postgres dependency.
+
+Coverage gate: factory/curator/eval/runner.py >= 85%.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from curator.eval.runner import (
+    _build_cached_context,
+    _persist_findings,
+    run_evals,
+)
+from curator.eval.types import EvalFinding, EvalResult
+
+
+# ---------------------------------------------------------------- helpers
+
+
+class _FakeCursor:
+    """Minimal cursor that records executed SQL + params for assertions."""
+
+    def __init__(self):
+        self.executed: list[tuple[str, tuple]] = []
+
+    def execute(self, sql, params=()):
+        self.executed.append((sql, params))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    """Minimal psycopg2-style connection that captures cursor activity."""
+
+    def __init__(self):
+        self.cursor_obj = _FakeCursor()
+        self.commits = 0
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.commits += 1
+
+
+def _proc_result(stdout: str = '{"findings": []}', returncode: int = 0,
+                  stderr: str = "") -> MagicMock:
+    """Build a CompletedProcess-like MagicMock matching subprocess.run."""
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _security_finding_response() -> dict:
+    return {
+        "findings": [
+            {
+                "rule_id": str(uuid4()),
+                "severity": "critical",
+                "file": "factory/auth.py",
+                "line": 42,
+                "message": "SQL string interpolation",
+                "fix_hint": "Use parameterized query",
+                "relevant_memory_id": str(uuid4()),
+            }
+        ]
+    }
+
+
+def _test_finding_response() -> dict:
+    return {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "important",
+                "file": "factory/widget.py",
+                "line": 11,
+                "message": "no test for widget.bake()",
+                "fix_hint": "Add a unit test that covers widget.bake() success path.",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+
+
+# ----------------------------------------------------- _build_cached_context
+
+
+def test_build_cached_context_shape_is_stable():
+    """Cached context byte-shape is the cache-hit hot path. Any drift
+    between security and test invocations breaks the warm cache, so the
+    builder must be deterministic across calls with identical inputs."""
+    brief = {"version": "1.0", "rules": []}
+    plan = "Step 1: do the thing"
+    diff = "+ added line\n- removed line"
+
+    a = _build_cached_context(brief, plan, diff)
+    b = _build_cached_context(brief, plan, diff)
+    assert a == b
+
+    # Sanity: each section is present and labeled.
+    assert "## Brief" in a
+    assert "## Plan" in a
+    assert "## Diff" in a
+    # Brief is rendered as indented JSON.
+    assert json.dumps(brief, indent=2) in a
+    # Plan is verbatim.
+    assert plan in a
+    # Diff is wrapped in a fenced ```diff block.
+    assert "```diff" in a
+    assert diff in a
+
+
+def test_build_cached_context_preserves_brief_structure():
+    """The brief json must round-trip — the eval prompts read this back
+    out to find `relevant_memory_id` candidates."""
+    rule_id = str(uuid4())
+    brief = {
+        "version": "1.0",
+        "rules": [{"id": rule_id, "title": "no_secrets_in_logs"}],
+        "lessons": [],
+        "relevant_decisions": [],
+    }
+    ctx = _build_cached_context(brief, "plan", "diff")
+    # The id must survive intact for the eval agent to surface it.
+    assert rule_id in ctx
+
+
+# ------------------------------------------------------------- run_evals
+
+
+def test_run_evals_invokes_both_agents_in_order():
+    """eval_security MUST run before eval_test — reversing the order
+    means the second call doesn't hit the prompt cache."""
+    job_id = uuid4()
+    conn = _FakeConn()
+    captured_args: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured_args.append(list(cmd))
+        return _proc_result(stdout=json.dumps({"findings": []}))
+
+    with patch("curator.eval.runner.subprocess.run", side_effect=fake_run):
+        results = run_evals(conn, job_id, brief={}, plan="", diff="")
+
+    assert len(results) == 2
+    assert results[0].agent_name == "eval_security"
+    assert results[1].agent_name == "eval_test"
+    # Both invocations went through the claude CLI.
+    assert all(args[0] == "claude" for args in captured_args)
+    assert len(captured_args) == 2
+
+
+def test_run_evals_passes_same_user_payload_to_both_agents():
+    """Cache hit depends on identical user message across calls. The
+    runner sends the same `cached_context` as stdin to both subprocess
+    calls; only the system-prompt differs."""
+    job_id = uuid4()
+    conn = _FakeConn()
+    captured_inputs: list[str] = []
+
+    def fake_run(cmd, **kwargs):
+        captured_inputs.append(kwargs["input"])
+        return _proc_result()
+
+    with patch("curator.eval.runner.subprocess.run", side_effect=fake_run):
+        run_evals(conn, job_id, brief={"k": "v"}, plan="P", diff="D")
+
+    assert len(captured_inputs) == 2
+    assert captured_inputs[0] == captured_inputs[1]
+
+
+def test_run_evals_persists_findings_to_factory_artifacts():
+    """Each finding from each agent gets its own factory_artifacts row.
+    Empty-result agents emit a single summary row instead."""
+    job_id = uuid4()
+    conn = _FakeConn()
+
+    responses = [_security_finding_response(), _test_finding_response()]
+    response_iter = iter(responses)
+
+    def fake_run(cmd, **kwargs):
+        return _proc_result(stdout=json.dumps(next(response_iter)))
+
+    with patch("curator.eval.runner.subprocess.run", side_effect=fake_run):
+        results = run_evals(conn, job_id, brief={}, plan="", diff="")
+
+    # Two findings -> two INSERT rows; one commit at end.
+    inserts = [r for r in conn.cursor_obj.executed if r[0].startswith("INSERT")]
+    assert len(inserts) == 2
+    assert conn.commits == 1
+    # Each result has 1 finding.
+    assert len(results[0].findings) == 1
+    assert len(results[1].findings) == 1
+
+
+def test_run_evals_persists_summary_row_when_no_findings():
+    """A clean-diff result still writes one row so the run is observable
+    in the dashboard. The artifact_type carries an `_summary` suffix."""
+    job_id = uuid4()
+    conn = _FakeConn()
+
+    def fake_run(cmd, **kwargs):
+        return _proc_result(stdout=json.dumps({"findings": []}))
+
+    with patch("curator.eval.runner.subprocess.run", side_effect=fake_run):
+        run_evals(conn, job_id, brief={}, plan="", diff="")
+
+    inserts = [r for r in conn.cursor_obj.executed if r[0].startswith("INSERT")]
+    assert len(inserts) == 2  # one summary per agent
+    # Each insert has artifact_type ending in _summary.
+    artifact_types = [params[2] for _, params in inserts]
+    assert artifact_types == ["eval_security_summary", "eval_test_summary"]
+
+
+def test_run_evals_isolates_agent_failure():
+    """When eval_security raises, eval_test still runs. The failed
+    agent's EvalResult carries findings=[] and a non-null `error`."""
+    job_id = uuid4()
+    conn = _FakeConn()
+
+    call_idx = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        call_idx["n"] += 1
+        if call_idx["n"] == 1:
+            # First (eval_security) call fails.
+            return _proc_result(stdout="", returncode=2, stderr="boom")
+        return _proc_result(stdout=json.dumps({"findings": []}))
+
+    with patch("curator.eval.runner.subprocess.run", side_effect=fake_run):
+        results = run_evals(conn, job_id, brief={}, plan="", diff="")
+
+    assert len(results) == 2
+    # eval_security failed.
+    assert results[0].agent_name == "eval_security"
+    assert results[0].findings == []
+    assert results[0].error is not None
+    assert "claude exit 2" in results[0].error
+    # eval_test still ran cleanly.
+    assert results[1].agent_name == "eval_test"
+    assert results[1].error is None
+
+
+def test_run_evals_handles_json_decode_error():
+    """If claude returns malformed JSON, the agent's EvalResult carries
+    the exception in `error`; the other agent is unaffected."""
+    job_id = uuid4()
+    conn = _FakeConn()
+    call_idx = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        call_idx["n"] += 1
+        if call_idx["n"] == 1:
+            return _proc_result(stdout="<not json>")
+        return _proc_result(stdout=json.dumps({"findings": []}))
+
+    with patch("curator.eval.runner.subprocess.run", side_effect=fake_run):
+        results = run_evals(conn, job_id, brief={}, plan="", diff="")
+
+    assert results[0].error is not None
+    # The error message length is bounded so we don't blow up the
+    # factory_artifacts row.
+    assert len(results[0].error) <= 500
+    assert results[1].error is None
+
+
+def test_run_evals_handles_subprocess_timeout():
+    """Subprocess timeouts are caught by the agent isolation block."""
+    import subprocess as _sp
+    job_id = uuid4()
+    conn = _FakeConn()
+    call_idx = {"n": 0}
+
+    def fake_run(cmd, **kwargs):
+        call_idx["n"] += 1
+        if call_idx["n"] == 1:
+            raise _sp.TimeoutExpired(cmd=cmd, timeout=120)
+        return _proc_result(stdout=json.dumps({"findings": []}))
+
+    with patch("curator.eval.runner.subprocess.run", side_effect=fake_run):
+        results = run_evals(conn, job_id, brief={}, plan="", diff="")
+
+    assert results[0].error is not None
+    assert results[1].error is None
+
+
+def test_run_evals_passes_system_prompts_per_agent():
+    """eval_security and eval_test must use different --system-prompt
+    bodies — that's the only thing that varies between the two cached
+    calls."""
+    job_id = uuid4()
+    conn = _FakeConn()
+    captured_cmds: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmds.append(list(cmd))
+        return _proc_result()
+
+    with patch("curator.eval.runner.subprocess.run", side_effect=fake_run):
+        run_evals(conn, job_id, brief={}, plan="", diff="")
+
+    # Each cmd has --system-prompt followed by the prompt text.
+    def _system_prompt(cmd):
+        idx = cmd.index("--system-prompt")
+        return cmd[idx + 1]
+
+    sp_security = _system_prompt(captured_cmds[0])
+    sp_test = _system_prompt(captured_cmds[1])
+    assert sp_security != sp_test
+    # Sanity: the prompt files we shipped land in the right slot.
+    assert "eval_security" in sp_security
+    assert "eval_test" in sp_test
+
+
+# ----------------------------------------------------- _persist_findings
+
+
+def test_persist_findings_writes_one_row_per_finding():
+    """Each finding becomes one factory_artifacts INSERT."""
+    job_id = uuid4()
+    conn = _FakeConn()
+    findings = [
+        EvalFinding(
+            rule_id=uuid4(),
+            severity="critical",
+            file="a.py",
+            line=1,
+            message="m1",
+            fix_hint="f1",
+            relevant_memory_id=uuid4(),
+        ),
+        EvalFinding(
+            rule_id=None,
+            severity="minor",
+            file="b.py",
+            line=None,
+            message="m2",
+            fix_hint="",
+            relevant_memory_id=None,
+        ),
+    ]
+    result = EvalResult(
+        version="1.0",
+        job_id=job_id,
+        agent_name="eval_security",
+        findings=findings,
+        elapsed_ms=42,
+        started_at=datetime.now(timezone.utc),
+    )
+    _persist_findings(conn, job_id, [result])
+
+    inserts = [r for r in conn.cursor_obj.executed if r[0].startswith("INSERT")]
+    assert len(inserts) == 2
+    # Each row carries phase='reviewing' and artifact_type=agent_name.
+    for _, params in inserts:
+        assert params[1] == "reviewing"
+        assert params[2] == "eval_security"
+
+
+def test_persist_findings_metadata_includes_error():
+    """A failed agent's metadata.error is preserved for the dashboard."""
+    job_id = uuid4()
+    conn = _FakeConn()
+    result = EvalResult(
+        version="1.0",
+        job_id=job_id,
+        agent_name="eval_test",
+        findings=[],
+        elapsed_ms=0,
+        started_at=datetime.now(timezone.utc),
+        error="claude exit 2: boom",
+    )
+    _persist_findings(conn, job_id, [result])
+
+    inserts = [r for r in conn.cursor_obj.executed if r[0].startswith("INSERT")]
+    assert len(inserts) == 1
+    metadata_json = inserts[0][1][5]
+    metadata = json.loads(metadata_json)
+    assert metadata["error"] == "claude exit 2: boom"
+    assert metadata["agent_name"] == "eval_test"
+
+
+# ------------------------------------------------------- EvalResult IO
+
+
+def test_eval_result_round_trips_through_serialization():
+    """Sanity check the contract eval_runner produces — downstream
+    Phase 6c graduation reads these values back out."""
+    job_id = uuid4()
+    finding = EvalFinding(
+        rule_id=uuid4(),
+        severity="important",
+        file="x.py",
+        line=10,
+        message="m",
+        fix_hint="f",
+        relevant_memory_id=uuid4(),
+    )
+    original = EvalResult(
+        version="1.0",
+        job_id=job_id,
+        agent_name="eval_security",
+        findings=[finding],
+        elapsed_ms=42,
+        started_at=datetime.now(timezone.utc),
+    )
+    rehydrated = EvalResult.model_validate_json(original.model_dump_json())
+    assert rehydrated == original
+    assert rehydrated.findings[0].rule_id == finding.rule_id
+
+
+# ----------------------------------------------------- _parse_findings
+
+
+def test_parse_findings_unknown_agent_raises():
+    """The internal dispatcher rejects unknown agent names — only the
+    two registered eval agents are valid."""
+    from curator.eval.runner import _parse_findings
+    with pytest.raises(ValueError):
+        _parse_findings("eval_performance", {"findings": []})
+
+
+def test_parse_findings_routes_to_correct_module():
+    """eval_security delegates to curator.eval.eval_security.parse;
+    eval_test delegates to curator.eval.eval_test.parse."""
+    from curator.eval.runner import _parse_findings
+
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "minor",
+                "file": "x.py",
+                "line": None,
+                "message": "m",
+                "fix_hint": "",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    sec = _parse_findings("eval_security", response)
+    tst = _parse_findings("eval_test", response)
+    assert len(sec) == 1
+    assert len(tst) == 1
+    assert sec[0].file == "x.py"
+    assert tst[0].file == "x.py"

--- a/factory/tests/test_eval_security.py
+++ b/factory/tests/test_eval_security.py
@@ -1,0 +1,238 @@
+"""Tests for the eval_security finding parser.
+
+Coverage gate: factory/curator/eval/eval_security.py >= 85%.
+"""
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from curator.eval.eval_security import parse
+
+
+def test_parse_empty_findings_list():
+    """Clean response yields an empty list — common steady-state path."""
+    assert parse({"findings": []}) == []
+
+
+def test_parse_missing_findings_key():
+    """If claude omits the key entirely, treat as empty rather than KeyError.
+    Robust because the prompt instructs it but real LLM output drifts."""
+    assert parse({}) == []
+
+
+def test_parse_single_finding_all_fields_populated():
+    """Happy path — every optional field present, every UUID parses."""
+    rule_id = uuid4()
+    memory_id = uuid4()
+    response = {
+        "findings": [
+            {
+                "rule_id": str(rule_id),
+                "severity": "critical",
+                "file": "factory/auth.py",
+                "line": 42,
+                "message": "SQL string interpolation in build_query()",
+                "fix_hint": "Use parameterized query",
+                "relevant_memory_id": str(memory_id),
+            }
+        ]
+    }
+    findings = parse(response)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.rule_id == rule_id
+    assert f.severity == "critical"
+    assert f.file == "factory/auth.py"
+    assert f.line == 42
+    assert f.message == "SQL string interpolation in build_query()"
+    assert f.fix_hint == "Use parameterized query"
+    assert f.relevant_memory_id == memory_id
+
+
+def test_parse_finding_with_null_rule_id_is_heuristic():
+    """rule_id=None marks a finding the agent caught heuristically (not
+    anchored to a memory row)."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "important",
+                "file": "factory/x.py",
+                "line": 1,
+                "message": "Heuristic catch — no backing rule.",
+                "fix_hint": "Promote to a tracked rule once stable.",
+                "relevant_memory_id": str(uuid4()),
+            }
+        ]
+    }
+    findings = parse(response)
+    assert findings[0].rule_id is None
+    assert findings[0].relevant_memory_id is not None
+
+
+def test_parse_finding_with_null_relevant_memory_id_is_brief_miss():
+    """relevant_memory_id=None means the finding wasn't surfaced by the
+    curator's brief — that's the signal that drives Phase 6d refinement."""
+    response = {
+        "findings": [
+            {
+                "rule_id": str(uuid4()),
+                "severity": "critical",
+                "file": "factory/y.py",
+                "line": 10,
+                "message": "Logged secret detected.",
+                "fix_hint": "Redact before logging.",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    findings = parse(response)
+    assert findings[0].rule_id is not None
+    assert findings[0].relevant_memory_id is None
+
+
+def test_parse_finding_with_both_uuids_null():
+    """Heuristic catch + brief miss — the most common shape for early
+    Phase 6 runs before the curator is well-trained."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "minor",
+                "file": "factory/z.py",
+                "line": 5,
+                "message": "Defense-in-depth gap.",
+                "fix_hint": "Add input length cap.",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    findings = parse(response)
+    assert findings[0].rule_id is None
+    assert findings[0].relevant_memory_id is None
+
+
+def test_parse_multiple_findings_of_different_severities():
+    """Each finding carries its own severity — order is preserved."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None, "severity": "critical",
+                "file": "a.py", "line": 1, "message": "m1",
+                "fix_hint": "f1", "relevant_memory_id": None,
+            },
+            {
+                "rule_id": None, "severity": "important",
+                "file": "b.py", "line": 2, "message": "m2",
+                "fix_hint": "f2", "relevant_memory_id": None,
+            },
+            {
+                "rule_id": None, "severity": "minor",
+                "file": "c.py", "line": 3, "message": "m3",
+                "fix_hint": "f3", "relevant_memory_id": None,
+            },
+        ]
+    }
+    findings = parse(response)
+    assert [f.severity for f in findings] == ["critical", "important", "minor"]
+    assert [f.file for f in findings] == ["a.py", "b.py", "c.py"]
+
+
+def test_parse_missing_optional_line_defaults_to_none():
+    """Findings that don't pin a line still parse — `line` is optional."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "minor",
+                "file": "factory/dep.py",
+                "message": "Dependency CVE notice without a specific line.",
+                "fix_hint": "Bump to a patched version.",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    findings = parse(response)
+    assert findings[0].line is None
+    assert findings[0].file == "factory/dep.py"
+
+
+def test_parse_missing_optional_fix_hint_defaults_to_empty():
+    """fix_hint is optional in real responses (prompts request it but
+    LLMs occasionally omit it)."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "minor",
+                "file": "factory/z.py",
+                "line": 1,
+                "message": "Missing rate limit on public endpoint.",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    findings = parse(response)
+    assert findings[0].fix_hint == ""
+
+
+def test_parse_invalid_severity_raises():
+    """Unknown severity must fail loudly — that's a prompt regression
+    we want surfaced, not silently dropped."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "catastrophic",  # not in the Literal
+                "file": "x.py",
+                "line": 1,
+                "message": "m",
+                "fix_hint": "f",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    with pytest.raises(Exception):  # Pydantic ValidationError
+        parse(response)
+
+
+def test_parse_invalid_uuid_raises():
+    """A malformed rule_id is a prompt regression — fail loudly."""
+    response = {
+        "findings": [
+            {
+                "rule_id": "not-a-uuid",
+                "severity": "minor",
+                "file": "x.py",
+                "line": 1,
+                "message": "m",
+                "fix_hint": "f",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    with pytest.raises(ValueError):
+        parse(response)
+
+
+def test_parse_uuid_strings_become_uuid_objects():
+    """Sanity check: rule_id and relevant_memory_id are UUID instances
+    on the parsed model, not strings."""
+    response = {
+        "findings": [
+            {
+                "rule_id": str(uuid4()),
+                "severity": "critical",
+                "file": "x.py",
+                "line": 1,
+                "message": "m",
+                "fix_hint": "f",
+                "relevant_memory_id": str(uuid4()),
+            }
+        ]
+    }
+    f = parse(response)[0]
+    assert isinstance(f.rule_id, UUID)
+    assert isinstance(f.relevant_memory_id, UUID)

--- a/factory/tests/test_eval_test.py
+++ b/factory/tests/test_eval_test.py
@@ -1,0 +1,234 @@
+"""Tests for the eval_test finding parser.
+
+Schema is identical to eval_security in v3.0 — these tests mirror
+test_eval_security with eval_test-flavored fixtures so a future
+divergence (if eval_test gets a richer shape) is easy to spot in diffs.
+
+Coverage gate: factory/curator/eval/eval_test.py >= 85%.
+"""
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from curator.eval.eval_test import parse
+
+
+def test_parse_empty_findings_list():
+    """Clean diff with adequate tests yields an empty list."""
+    assert parse({"findings": []}) == []
+
+
+def test_parse_missing_findings_key():
+    """Defensive: missing key is treated as empty rather than KeyError."""
+    assert parse({}) == []
+
+
+def test_parse_single_finding_all_fields_populated():
+    """Happy path — coverage gap finding with all metadata."""
+    rule_id = uuid4()
+    memory_id = uuid4()
+    response = {
+        "findings": [
+            {
+                "rule_id": str(rule_id),
+                "severity": "critical",
+                "file": "factory/widget.py",
+                "line": 17,
+                "message": "widget.bake() has no test coverage.",
+                "fix_hint": "Add a unit test that exercises bake() success and failure paths.",
+                "relevant_memory_id": str(memory_id),
+            }
+        ]
+    }
+    findings = parse(response)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.rule_id == rule_id
+    assert f.severity == "critical"
+    assert f.file == "factory/widget.py"
+    assert f.line == 17
+    assert "no test coverage" in f.message
+    assert f.relevant_memory_id == memory_id
+
+
+def test_parse_finding_with_null_rule_id_is_heuristic():
+    """A test-quality issue spotted by heuristic (not anchored to a rule)."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "minor",
+                "file": "factory/tests/test_x.py",
+                "line": 22,
+                "message": "Snapshot test asserts on a timestamp — brittle.",
+                "fix_hint": "Strip volatile fields before comparing.",
+                "relevant_memory_id": str(uuid4()),
+            }
+        ]
+    }
+    findings = parse(response)
+    assert findings[0].rule_id is None
+    assert findings[0].relevant_memory_id is not None
+
+
+def test_parse_finding_with_null_relevant_memory_id_is_brief_miss():
+    """Coverage gap that wasn't surfaced by the curator brief — drives
+    Phase 6d refinement."""
+    response = {
+        "findings": [
+            {
+                "rule_id": str(uuid4()),
+                "severity": "important",
+                "file": "factory/y.py",
+                "line": 5,
+                "message": "Edge case from spec is untested.",
+                "fix_hint": "Add a parametrize case for the empty-input branch.",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    findings = parse(response)
+    assert findings[0].rule_id is not None
+    assert findings[0].relevant_memory_id is None
+
+
+def test_parse_finding_with_both_uuids_null():
+    """Heuristic test-quality catch + brief miss."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "minor",
+                "file": "factory/tests/test_z.py",
+                "line": 1,
+                "message": "Asserts on mock.called_once_with instead of return value.",
+                "fix_hint": "Assert on the function's observable output.",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    findings = parse(response)
+    assert findings[0].rule_id is None
+    assert findings[0].relevant_memory_id is None
+
+
+def test_parse_multiple_findings_of_different_severities():
+    """Order preserved across severities — coverage > brittleness > smell."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None, "severity": "critical",
+                "file": "a.py", "line": 1, "message": "no test",
+                "fix_hint": "f1", "relevant_memory_id": None,
+            },
+            {
+                "rule_id": None, "severity": "important",
+                "file": "b.py", "line": 2, "message": "missing edge case",
+                "fix_hint": "f2", "relevant_memory_id": None,
+            },
+            {
+                "rule_id": None, "severity": "minor",
+                "file": "c.py", "line": 3, "message": "test smell",
+                "fix_hint": "f3", "relevant_memory_id": None,
+            },
+        ]
+    }
+    findings = parse(response)
+    assert [f.severity for f in findings] == ["critical", "important", "minor"]
+
+
+def test_parse_missing_optional_line_defaults_to_none():
+    """Missing-test findings often have no line to pin to (the gap IS
+    the absence of a line)."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "important",
+                "file": "factory/feature.py",
+                "message": "New feature has no test file.",
+                "fix_hint": "Add factory/tests/test_feature.py.",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    findings = parse(response)
+    assert findings[0].line is None
+
+
+def test_parse_missing_optional_fix_hint_defaults_to_empty():
+    """fix_hint is optional even though prompts request it."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "minor",
+                "file": "factory/z.py",
+                "line": 1,
+                "message": "Test asserts on internal log output.",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    findings = parse(response)
+    assert findings[0].fix_hint == ""
+
+
+def test_parse_invalid_severity_raises():
+    """Unknown severity must fail loudly."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "wow_super_bad",
+                "file": "x.py",
+                "line": 1,
+                "message": "m",
+                "fix_hint": "f",
+                "relevant_memory_id": None,
+            }
+        ]
+    }
+    with pytest.raises(Exception):  # Pydantic ValidationError
+        parse(response)
+
+
+def test_parse_invalid_uuid_raises():
+    """Malformed UUID is a prompt regression."""
+    response = {
+        "findings": [
+            {
+                "rule_id": None,
+                "severity": "minor",
+                "file": "x.py",
+                "line": 1,
+                "message": "m",
+                "fix_hint": "f",
+                "relevant_memory_id": "obviously-not-a-uuid",
+            }
+        ]
+    }
+    with pytest.raises(ValueError):
+        parse(response)
+
+
+def test_parse_uuid_strings_become_uuid_objects():
+    """Sanity: parsed UUIDs are UUID instances, not strings."""
+    response = {
+        "findings": [
+            {
+                "rule_id": str(uuid4()),
+                "severity": "important",
+                "file": "x.py",
+                "line": 1,
+                "message": "m",
+                "fix_hint": "f",
+                "relevant_memory_id": str(uuid4()),
+            }
+        ]
+    }
+    f = parse(response)[0]
+    assert isinstance(f.rule_id, UUID)
+    assert isinstance(f.relevant_memory_id, UUID)


### PR DESCRIPTION
## Summary

Phase 6b of [Atlas Step 6 — Eval Agents + Lesson Graduation](../blob/main/docs/plans/2026-05-04-step-6-eval-graduation-implementation.md). Adds the eval runner and the two domain-specialized eval agents that drive the three feedback signals shipping in Phase 6c.

- **Warm-cache pattern**: `run_evals` invokes `eval_security` first (primes the cache), then `eval_test` against the same cached user payload — only the system prompt differs. Sequential ordering is the cost optimization (~10x reduction on the second call vs. cold-cache parallel).
- **factory_artifacts integration**: one row per finding with `phase='reviewing'`, `artifact_type=<agent_name>`, `content=finding.model_dump_json()`. Empty-result agents emit a single `<agent>_summary` row so the run is observable on a clean diff.
- **Per-agent failure isolation**: subprocess timeout / non-zero exit / malformed JSON all funnel into `EvalResult(findings=[], error=<exc>)`; the OTHER agent still runs.
- **Parsers**: `eval_security` and `eval_test` share the same response schema in v3.0 — kept as separate modules so Phase 6c+ can specialize without touching the security path.
- **Prompts**: both emit strict JSON (no prose). `relevant_memory_id` linkage to brief memories is the signal Phase 6c reads to drive graduation streak increments and Phase 6d reads to drive `applies_when` widening.

## Files

| Path | Lines |
|---|---|
| `factory/curator/eval/runner.py` | 222 |
| `factory/curator/eval/eval_security.py` | 59 |
| `factory/curator/eval/eval_test.py` | 58 |
| `factory/curator/eval/prompts/eval_security.md` | 63 |
| `factory/curator/eval/prompts/eval_test.md` | 72 |
| `factory/tests/test_curator_eval_runner.py` | 459 |
| `factory/tests/test_eval_security.py` | 238 |
| `factory/tests/test_eval_test.py` | 234 |

## Test plan

- [x] `pytest tests/test_curator_eval_runner.py tests/test_eval_security.py tests/test_eval_test.py` — 39 passed
- [x] Coverage: `runner.py` 100% / `eval_security.py` 100% / `eval_test.py` 100% (gates: 85%)
- [x] Phase 6a regression: `tests/test_curator_eval_types.py` — 6 passed
- [x] No-DB CI subset still green (97 tests)
- [x] No real claude invoked — `subprocess.run` mocked via `unittest.mock.patch`

## Deviation from plan

The plan's `_persist_findings` SQL targeted columns `agent_name` and `finding` that do not exist on `devbrain.factory_artifacts` (the schema uses `phase`, `artifact_type`, `content`, `metadata`, `findings_count`). The implementation maps cleanly onto the existing columns: `phase='reviewing'`, `artifact_type=<agent_name>`, `content=finding.model_dump_json()`, `metadata={version, agent_name, elapsed_ms, started_at, error}`. No migration needed.

## Out of scope

Graduation logic (Phase 6c), refinement logic (Phase 6d), and the IMPLEMENTING→REVIEWING state-machine hook (Phase 6e) are explicitly NOT touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)