### PR TITLE
feat(curator): Atlas Step 6c — graduation pipeline + P4 postulate

### DIFF
--- a/factory/curator/graduation.py
+++ b/factory/curator/graduation.py
@@ -1,10 +1,39 @@
 """Three-signal feedback loop for lesson graduation + rule demotion.
 
+Three signals fire after every REVIEWING phase, derived from comparing the
+curator brief (which memories were surfaced) against the eval results
+(which violations the eval agents found):
+
+  Signal #1 — in-brief AND eval found a violation:
+              hit_count++, current_streak = 0
+              The memory was surfaced but the planner/implementer ignored
+              it, so streak resets.
+
+  Signal #2 — NOT in-brief but eval found a relevant violation:
+              queue refinement (widen applies_when so the memory surfaces
+              next time). Implementation lands in Phase 6d.
+
+  Signal #3 — in-brief AND no violation (clean run):
+              effective_hit_count++, current_streak++, last_hit = NOW()
+              If tier='lesson' AND streak >= GRADUATION_STREAK_THRESHOLD,
+              promote tier='lesson' -> tier='rule' (graduation).
+
+A separate sweep (`demote_low_precision_rules`) runs periodically and
+demotes any tier='rule' whose precision dropped below 0.50 over the last
+30 days back to tier='lesson'.
+
+All tier transitions are recorded in devbrain.memory_ledger automatically
+via the AFTER UPDATE trigger from migration 015.
+
 Public API:
 - apply_feedback_signals(conn, job_id, brief, eval_results)
 - demote_low_precision_rules(conn, project_id)
 """
 from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 # Tunable constants — change here if real-world data shows them wrong.
 GRADUATION_STREAK_THRESHOLD = 3
@@ -14,10 +43,179 @@ DEMOTION_WINDOW = "30 days"
 
 
 def apply_feedback_signals(conn, job_id, brief, eval_results):
-    """Stub. Implementation lands in 6c."""
-    raise NotImplementedError("ships in Phase 6c")
+    """Apply the three feedback signals based on a brief + eval results.
+
+    For each memory in the brief:
+      - if any finding's relevant_memory_id matches it -> signal #1 (failure)
+      - else -> signal #3 (success), may trigger graduation
+
+    For each finding whose relevant_memory_id is NOT in the brief:
+      -> signal #2 (refinement) — queue for applies_when widening
+
+    Args:
+        conn: psycopg2 connection (transaction managed inside helpers).
+        job_id: factory_jobs.id (currently unused but reserved for future
+            audit logging that wants to correlate signals to a specific job).
+        brief: CuratorBrief Pydantic model OR a dict (loaded from JSONB).
+            Walked for memory IDs across rules + lessons + relevant_decisions.
+        eval_results: list[EvalResult] — output of curator.eval.runner.run_evals.
+    """
+    in_brief_ids = _collect_brief_memory_ids(brief)
+    findings_by_memory = _index_findings_by_memory(eval_results)
+
+    # Signals #1 and #3: walk in-brief memory IDs, classify by whether
+    # any finding's relevant_memory_id points at them.
+    for mid in in_brief_ids:
+        if mid in findings_by_memory:
+            _signal_failure(conn, mid)
+        else:
+            _signal_success(conn, mid)
+
+    # Signal #2: findings with relevant_memory_id NOT in the brief —
+    # queue for applies_when refinement so they surface next time.
+    # The refinement helper raises NotImplementedError until Phase 6d
+    # ships; swallow that here so the failure/success signals still
+    # apply when the runner is invoked from a partially-implemented
+    # state machine (Phase 6c).
+    from curator.refinement import queue_refinement
+    for result in eval_results:
+        for finding in result.findings:
+            mid = finding.relevant_memory_id
+            if mid is not None and mid not in in_brief_ids:
+                try:
+                    queue_refinement(conn, finding)
+                except NotImplementedError:
+                    logger.debug(
+                        "queue_refinement not implemented yet; deferring "
+                        "signal #2 for finding %s -> memory %s",
+                        finding.message,
+                        mid,
+                    )
+
+
+def _signal_failure(conn, memory_id):
+    """In-brief AND failure — reset streak, increment hit_count.
+
+    The memory was surfaced in the brief but the eval agent still found a
+    violation that maps back to it. The streak resets so a future
+    graduation attempt has to re-prove three consecutive clean runs.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory "
+            "SET hit_count = hit_count + 1, current_streak = 0 "
+            "WHERE id = %s",
+            (memory_id,),
+        )
+    conn.commit()
+
+
+def _signal_success(conn, memory_id):
+    """In-brief AND clean — streak++, effective_hit_count++, check graduation.
+
+    A returning RETURNING clause gives us the post-update tier + streak in
+    one round-trip so the graduation check doesn't need a second SELECT.
+    If the row is missing (e.g. archived between brief generation and the
+    feedback pass), fail closed and skip.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory "
+            "SET effective_hit_count = effective_hit_count + 1, "
+            "    current_streak = current_streak + 1, "
+            "    last_hit = NOW() "
+            "WHERE id = %s "
+            "RETURNING tier, current_streak",
+            (memory_id,),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    if row is None:
+        return
+    tier, streak = row
+    if tier == "lesson" and streak >= GRADUATION_STREAK_THRESHOLD:
+        _graduate(conn, memory_id)
+
+
+def _graduate(conn, memory_id):
+    """Promote tier='lesson' to tier='rule'.
+
+    The WHERE filter on tier='lesson' makes this idempotent — running it
+    on an already-graduated row is a no-op. The AFTER UPDATE trigger
+    (migration 015) writes the audit row to devbrain.memory_ledger.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory "
+            "SET tier = 'rule', graduated_at = NOW() "
+            "WHERE id = %s AND tier = 'lesson'",
+            (memory_id,),
+        )
+    conn.commit()
 
 
 def demote_low_precision_rules(conn, project_id):
-    """Stub. Implementation lands in 6c."""
-    raise NotImplementedError("ships in Phase 6c")
+    """Sweep rules with precision < 50% over a 30-day window. Demote to lesson.
+
+    Precision = effective_hit_count / (hit_count + effective_hit_count).
+    Stale rules (last_hit older than the demotion window or NULL) are
+    untouched — we only demote rules that have been recently active and
+    misfiring.
+
+    The demotion sets tier back to 'lesson', stamps demoted_at, and resets
+    current_streak so the row has to re-earn graduation. Project scope is
+    enforced by project_id so the sweep can't accidentally demote rules
+    from other projects.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            UPDATE devbrain.memory
+            SET tier = 'lesson', demoted_at = NOW(), current_streak = 0
+            WHERE tier = 'rule'
+              AND project_id = %s
+              AND last_hit > NOW() - INTERVAL '{DEMOTION_WINDOW}'
+              AND CAST(effective_hit_count AS FLOAT)
+                  / NULLIF(hit_count + effective_hit_count, 0)
+                  < %s
+            """,
+            (project_id, DEMOTION_PRECISION_THRESHOLD),
+        )
+    conn.commit()
+
+
+def _collect_brief_memory_ids(brief):
+    """Extract every memory ID referenced in a curator brief.
+
+    `brief` may be either a CuratorBrief Pydantic model (returned by
+    generate_brief) or a plain dict (loaded from
+    factory_jobs.curator_brief JSONB). Walk rules + lessons +
+    relevant_decisions and return a set of UUIDs.
+    """
+    if hasattr(brief, "model_dump"):
+        brief = brief.model_dump()
+    ids: set = set()
+    for section in ("rules", "lessons", "relevant_decisions"):
+        for ref in brief.get(section, []) or []:
+            if isinstance(ref, dict):
+                ids.add(ref["id"])
+            else:
+                # MemoryRef-like object (e.g. partially-decoded test input)
+                ids.add(ref.id)
+    return ids
+
+
+def _index_findings_by_memory(eval_results):
+    """Return {memory_id: [finding, ...]} for findings with a relevant_memory_id.
+
+    Used to test "is this brief memory pointed at by any finding?" in O(1).
+    Findings without a relevant_memory_id (rule_id is None heuristic
+    findings) don't need to be indexed because they can't fire signal #1.
+    """
+    index: dict = {}
+    for result in eval_results:
+        for finding in result.findings:
+            mid = finding.relevant_memory_id
+            if mid is not None:
+                index.setdefault(mid, []).append(finding)
+    return index

--- a/factory/tests/test_curator_graduation.py
+++ b/factory/tests/test_curator_graduation.py
@@ -1,0 +1,596 @@
+"""Unit tests for the three-signal graduation pipeline + demote sweep.
+
+Covers factory/curator/graduation.py:
+  * _signal_failure resets streak, increments hit_count
+  * _signal_success increments streak + effective_hit_count + last_hit
+  * _signal_success triggers graduation at streak == 3 for lessons
+  * _signal_success does NOT graduate at streak < 3 or for non-lesson tiers
+  * _graduate is idempotent on already-graduated rows
+  * apply_feedback_signals classifies in-brief findings into signals 1 vs 3
+  * demote_low_precision_rules respects precision threshold + freshness window
+  * demote_low_precision_rules is project-scoped
+
+These tests exercise the real DB substrate (current_streak from migration
+019, effective_hit_count from migration 020, AFTER trigger from migration
+015 writing memory_ledger rows on tier transitions).
+
+Signal #2 (refinement) is NOT exercised here — that ships in Phase 6d
+when curator.refinement.queue_refinement is implemented. The graduation
+module already swallows the NotImplementedError so apply_feedback_signals
+exercises signals #1 and #3 cleanly even with refinement stubbed out.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from curator.eval.types import EvalFinding, EvalResult
+from curator.graduation import (
+    DEMOTION_PRECISION_THRESHOLD,
+    GRADUATION_STREAK_THRESHOLD,
+    _collect_brief_memory_ids,
+    _graduate,
+    _index_findings_by_memory,
+    _signal_failure,
+    _signal_success,
+    apply_feedback_signals,
+    demote_low_precision_rules,
+)
+
+
+def _seed_counters(
+    conn,
+    memory_id,
+    *,
+    current_streak: int = 0,
+    hit_count: int = 0,
+    effective_hit_count: int = 0,
+    last_hit_offset_days: float | None = None,
+):
+    """Set graduation-related counters directly via UPDATE.
+
+    The memory_factory doesn't take these kwargs (Phase 6a only added the
+    schema columns); tests need to seed them after insert.
+    """
+    if last_hit_offset_days is None:
+        last_hit_sql = "last_hit = NULL"
+        params = (current_streak, hit_count, effective_hit_count, memory_id)
+    else:
+        last_hit_sql = (
+            f"last_hit = NOW() - INTERVAL '{last_hit_offset_days} days'"
+        )
+        params = (current_streak, hit_count, effective_hit_count, memory_id)
+    with conn.cursor() as cur:
+        cur.execute(
+            f"UPDATE devbrain.memory SET "
+            f"current_streak = %s, hit_count = %s, "
+            f"effective_hit_count = %s, {last_hit_sql} "
+            f"WHERE id = %s",
+            params,
+        )
+    conn.commit()
+
+
+def _read_counters(conn, memory_id):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT tier, current_streak, hit_count, effective_hit_count, "
+            "last_hit, graduated_at, demoted_at "
+            "FROM devbrain.memory WHERE id = %s",
+            (memory_id,),
+        )
+        row = cur.fetchone()
+    return {
+        "tier": row[0],
+        "current_streak": row[1],
+        "hit_count": row[2],
+        "effective_hit_count": row[3],
+        "last_hit": row[4],
+        "graduated_at": row[5],
+        "demoted_at": row[6],
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pure helpers (no DB)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_collect_brief_memory_ids_handles_dict_brief():
+    """Plain dict (the JSONB shape) walks all three sections."""
+    a, b, c = uuid4(), uuid4(), uuid4()
+    brief = {
+        "rules": [{"id": a}],
+        "lessons": [{"id": b}],
+        "relevant_decisions": [{"id": c}],
+    }
+    assert _collect_brief_memory_ids(brief) == {a, b, c}
+
+
+def test_collect_brief_memory_ids_handles_pydantic_brief():
+    """CuratorBrief Pydantic model is converted via model_dump."""
+    from decimal import Decimal
+
+    from curator.types import CuratorBrief, MemoryRef
+
+    a = uuid4()
+    ref = MemoryRef(
+        id=a,
+        kind="decision",
+        title="t",
+        content_excerpt="x",
+        tier="rule",
+        strength=Decimal("1.0"),
+        last_cascade_at=None,
+    )
+    brief = CuratorBrief(
+        version="1.0",
+        job_id=uuid4(),
+        project_id=uuid4(),
+        rules=[ref],
+        lessons=[],
+        relevant_decisions=[],
+        recent_cascade_signals=[],
+        generated_at=datetime.now(timezone.utc),
+    )
+    assert _collect_brief_memory_ids(brief) == {a}
+
+
+def test_collect_brief_memory_ids_handles_empty_sections():
+    """Missing or None sections don't blow up."""
+    assert _collect_brief_memory_ids({}) == set()
+    assert _collect_brief_memory_ids(
+        {"rules": None, "lessons": [], "relevant_decisions": []}
+    ) == set()
+
+
+def test_collect_brief_memory_ids_handles_object_refs_in_dict_brief():
+    """Mixed-shape brief: a dict whose section contains object-style refs
+    (e.g. from a partially-decoded test or a future serializer that
+    preserves Pydantic objects). Falls through to the .id attribute path.
+    """
+    class _Ref:
+        def __init__(self, mid):
+            self.id = mid
+
+    a = uuid4()
+    brief = {"rules": [_Ref(a)], "lessons": [], "relevant_decisions": []}
+    assert _collect_brief_memory_ids(brief) == {a}
+
+
+def test_index_findings_by_memory_skips_findings_with_null_memory_id():
+    finding_with = EvalFinding(
+        rule_id=uuid4(),
+        severity="critical",
+        file="x.py",
+        line=1,
+        message="m",
+        fix_hint="h",
+        relevant_memory_id=uuid4(),
+    )
+    finding_without = EvalFinding(
+        rule_id=None,
+        severity="minor",
+        file="y.py",
+        line=2,
+        message="m2",
+        fix_hint="h2",
+        relevant_memory_id=None,
+    )
+    result = EvalResult(
+        version="1.0",
+        job_id=uuid4(),
+        agent_name="eval_security",
+        findings=[finding_with, finding_without],
+        elapsed_ms=1,
+        started_at=datetime.now(timezone.utc),
+    )
+    index = _index_findings_by_memory([result])
+    assert finding_with.relevant_memory_id in index
+    assert len(index) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Signal handlers (DB)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_signal_failure_resets_streak_and_increments_hit_count(
+    conn, project_factory, memory_factory
+):
+    project = project_factory("sigfail")
+    m = memory_factory(project["id"], tier="lesson")
+    _seed_counters(
+        conn, m["id"], current_streak=2, hit_count=4, effective_hit_count=7
+    )
+
+    _signal_failure(conn, m["id"])
+
+    after = _read_counters(conn, m["id"])
+    assert after["current_streak"] == 0
+    assert after["hit_count"] == 5
+    # effective_hit_count + last_hit untouched by failure signal
+    assert after["effective_hit_count"] == 7
+    assert after["last_hit"] is None
+    # tier didn't change
+    assert after["tier"] == "lesson"
+
+
+@pytest.mark.db
+def test_signal_success_increments_streak_and_effective_hit_count(
+    conn, project_factory, memory_factory
+):
+    project = project_factory("sigsucc")
+    m = memory_factory(project["id"], tier="lesson")
+    _seed_counters(
+        conn, m["id"], current_streak=0, hit_count=3, effective_hit_count=5
+    )
+
+    _signal_success(conn, m["id"])
+
+    after = _read_counters(conn, m["id"])
+    assert after["current_streak"] == 1
+    assert after["effective_hit_count"] == 6
+    assert after["last_hit"] is not None
+    # hit_count untouched by success signal
+    assert after["hit_count"] == 3
+    # streak hasn't hit threshold yet
+    assert after["tier"] == "lesson"
+    assert after["graduated_at"] is None
+
+
+@pytest.mark.db
+def test_signal_success_graduates_lesson_at_threshold(
+    conn, project_factory, memory_factory
+):
+    project = project_factory("siggrad")
+    m = memory_factory(project["id"], tier="lesson")
+    # Pre-seed streak = THRESHOLD - 1; one more success triggers graduation.
+    _seed_counters(
+        conn, m["id"], current_streak=GRADUATION_STREAK_THRESHOLD - 1
+    )
+
+    _signal_success(conn, m["id"])
+
+    after = _read_counters(conn, m["id"])
+    assert after["tier"] == "rule"
+    assert after["current_streak"] == GRADUATION_STREAK_THRESHOLD
+    assert after["graduated_at"] is not None
+
+
+@pytest.mark.db
+def test_signal_success_does_not_graduate_below_threshold(
+    conn, project_factory, memory_factory
+):
+    """At streak = THRESHOLD - 2, one success leaves us at THRESHOLD - 1
+    which is below the gate, so no graduation should fire."""
+    project = project_factory("signograd")
+    m = memory_factory(project["id"], tier="lesson")
+    _seed_counters(
+        conn, m["id"], current_streak=GRADUATION_STREAK_THRESHOLD - 2
+    )
+
+    _signal_success(conn, m["id"])
+
+    after = _read_counters(conn, m["id"])
+    assert after["tier"] == "lesson"
+    assert after["graduated_at"] is None
+    assert after["current_streak"] == GRADUATION_STREAK_THRESHOLD - 1
+
+
+@pytest.mark.db
+def test_signal_success_does_not_graduate_non_lesson_tiers(
+    conn, project_factory, memory_factory
+):
+    """tier='rule' and tier='memory' are NOT eligible for graduation even
+    at streak >= threshold."""
+    project = project_factory("signonlesson")
+    rule = memory_factory(project["id"], tier="rule")
+    mem = memory_factory(project["id"], tier="memory")
+    _seed_counters(
+        conn, rule["id"], current_streak=GRADUATION_STREAK_THRESHOLD - 1
+    )
+    _seed_counters(
+        conn, mem["id"], current_streak=GRADUATION_STREAK_THRESHOLD - 1
+    )
+
+    _signal_success(conn, rule["id"])
+    _signal_success(conn, mem["id"])
+
+    rule_after = _read_counters(conn, rule["id"])
+    mem_after = _read_counters(conn, mem["id"])
+    assert rule_after["tier"] == "rule"
+    assert rule_after["graduated_at"] is None
+    assert mem_after["tier"] == "memory"
+    assert mem_after["graduated_at"] is None
+
+
+@pytest.mark.db
+def test_signal_success_no_op_on_missing_row(
+    conn, project_factory, memory_factory
+):
+    """If the memory was archived between brief generation and feedback,
+    the UPDATE...RETURNING returns no rows; no-op (don't crash)."""
+    fake_id = uuid4()
+    # Should not raise even though no row matches.
+    _signal_success(conn, fake_id)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _graduate
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_graduate_sets_tier_and_graduated_at(
+    conn, project_factory, memory_factory
+):
+    project = project_factory("grad")
+    m = memory_factory(project["id"], tier="lesson")
+
+    _graduate(conn, m["id"])
+
+    after = _read_counters(conn, m["id"])
+    assert after["tier"] == "rule"
+    assert after["graduated_at"] is not None
+
+
+@pytest.mark.db
+def test_graduate_is_idempotent_on_already_graduated_row(
+    conn, project_factory, memory_factory
+):
+    """Running _graduate twice is a no-op — the WHERE clause filters on
+    tier='lesson' so the second call updates nothing."""
+    project = project_factory("gradidem")
+    m = memory_factory(project["id"], tier="lesson")
+
+    _graduate(conn, m["id"])
+    after_first = _read_counters(conn, m["id"])
+    first_grad_at = after_first["graduated_at"]
+
+    # Second call must not change graduated_at (no UPDATE fires).
+    _graduate(conn, m["id"])
+    after_second = _read_counters(conn, m["id"])
+    assert after_second["tier"] == "rule"
+    assert after_second["graduated_at"] == first_grad_at
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# apply_feedback_signals
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_apply_feedback_signals_classifies_in_brief_findings(
+    conn, project_factory, memory_factory
+):
+    """Walks brief, fires signal #1 for in-brief memories with findings,
+    signal #3 for in-brief memories without findings."""
+    project = project_factory("apply")
+    fired = memory_factory(project["id"], tier="lesson", content="failed")
+    clean = memory_factory(project["id"], tier="lesson", content="clean")
+    _seed_counters(conn, fired["id"], current_streak=2, hit_count=0)
+    _seed_counters(conn, clean["id"], current_streak=0, hit_count=0)
+
+    brief = {
+        "rules": [],
+        "lessons": [
+            {"id": fired["id"]},
+            {"id": clean["id"]},
+        ],
+        "relevant_decisions": [],
+    }
+
+    finding_for_fired = EvalFinding(
+        rule_id=fired["id"],
+        severity="important",
+        file="x.py",
+        line=10,
+        message="violation",
+        fix_hint="...",
+        relevant_memory_id=fired["id"],
+    )
+    eval_result = EvalResult(
+        version="1.0",
+        job_id=uuid4(),
+        agent_name="eval_security",
+        findings=[finding_for_fired],
+        elapsed_ms=10,
+        started_at=datetime.now(timezone.utc),
+    )
+
+    apply_feedback_signals(conn, uuid4(), brief, [eval_result])
+
+    fired_after = _read_counters(conn, fired["id"])
+    clean_after = _read_counters(conn, clean["id"])
+
+    # fired memory: signal #1 (failure)
+    assert fired_after["current_streak"] == 0
+    assert fired_after["hit_count"] == 1
+
+    # clean memory: signal #3 (success)
+    assert clean_after["current_streak"] == 1
+    assert clean_after["effective_hit_count"] == 1
+    assert clean_after["last_hit"] is not None
+
+
+@pytest.mark.db
+def test_apply_feedback_signals_swallows_signal2_not_implemented(
+    conn, project_factory, memory_factory
+):
+    """A finding pointing at a memory NOT in the brief tries to call
+    queue_refinement, which raises NotImplementedError until Phase 6d.
+    The swallow-and-log path lets signals #1 and #3 still fire."""
+    project = project_factory("sig2swallow")
+    in_brief = memory_factory(project["id"], tier="lesson", content="in brief")
+    not_in_brief = memory_factory(
+        project["id"], tier="lesson", content="missing from brief"
+    )
+    _seed_counters(conn, in_brief["id"], current_streak=0)
+
+    brief = {
+        "rules": [],
+        "lessons": [{"id": in_brief["id"]}],
+        "relevant_decisions": [],
+    }
+
+    # Finding points at a memory that's NOT in the brief — signal #2 path.
+    finding = EvalFinding(
+        rule_id=not_in_brief["id"],
+        severity="minor",
+        file="x.py",
+        line=1,
+        message="missed",
+        fix_hint="...",
+        relevant_memory_id=not_in_brief["id"],
+    )
+    eval_result = EvalResult(
+        version="1.0",
+        job_id=uuid4(),
+        agent_name="eval_test",
+        findings=[finding],
+        elapsed_ms=5,
+        started_at=datetime.now(timezone.utc),
+    )
+
+    # Should NOT raise — refinement stub's NotImplementedError is swallowed.
+    apply_feedback_signals(conn, uuid4(), brief, [eval_result])
+
+    # Signal #3 still fired for the in-brief memory.
+    after = _read_counters(conn, in_brief["id"])
+    assert after["current_streak"] == 1
+    assert after["effective_hit_count"] == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# demote_low_precision_rules
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_demote_demotes_rules_below_precision_threshold(
+    conn, project_factory, memory_factory
+):
+    """A rule with hit_count=5, effective_hit_count=3 (precision = 0.375 <
+    0.5) and a recent last_hit gets demoted to lesson."""
+    project = project_factory("demote")
+    rule = memory_factory(project["id"], tier="rule")
+    _seed_counters(
+        conn,
+        rule["id"],
+        current_streak=4,
+        hit_count=5,
+        effective_hit_count=3,
+        last_hit_offset_days=1,
+    )
+
+    demote_low_precision_rules(conn, project["id"])
+
+    after = _read_counters(conn, rule["id"])
+    assert after["tier"] == "lesson"
+    assert after["demoted_at"] is not None
+    assert after["current_streak"] == 0
+
+
+@pytest.mark.db
+def test_demote_ignores_rules_above_precision_threshold(
+    conn, project_factory, memory_factory
+):
+    """A rule with hit_count=2, effective_hit_count=8 (precision = 0.8 >=
+    0.5) is left alone."""
+    project = project_factory("nodemote")
+    rule = memory_factory(project["id"], tier="rule")
+    _seed_counters(
+        conn,
+        rule["id"],
+        hit_count=2,
+        effective_hit_count=8,
+        last_hit_offset_days=1,
+    )
+
+    demote_low_precision_rules(conn, project["id"])
+
+    after = _read_counters(conn, rule["id"])
+    assert after["tier"] == "rule"
+    assert after["demoted_at"] is None
+
+
+@pytest.mark.db
+def test_demote_ignores_stale_rules(
+    conn, project_factory, memory_factory
+):
+    """A rule with low precision but last_hit older than the demotion
+    window is NOT demoted — we only demote recently-active misfiring rules.
+    """
+    project = project_factory("stale")
+    rule = memory_factory(project["id"], tier="rule")
+    _seed_counters(
+        conn,
+        rule["id"],
+        hit_count=10,
+        effective_hit_count=1,
+        last_hit_offset_days=60,  # well past the 30-day window
+    )
+
+    demote_low_precision_rules(conn, project["id"])
+
+    after = _read_counters(conn, rule["id"])
+    assert after["tier"] == "rule"
+    assert after["demoted_at"] is None
+
+
+@pytest.mark.db
+def test_demote_resets_current_streak(
+    conn, project_factory, memory_factory
+):
+    """Demotion zeros current_streak so the lesson has to re-earn graduation."""
+    project = project_factory("demoteresets")
+    rule = memory_factory(project["id"], tier="rule")
+    _seed_counters(
+        conn,
+        rule["id"],
+        current_streak=10,
+        hit_count=5,
+        effective_hit_count=1,
+        last_hit_offset_days=1,
+    )
+
+    # Sanity: precision = 1/6 ≈ 0.167 < 0.5
+    assert 1 / (5 + 1) < DEMOTION_PRECISION_THRESHOLD
+
+    demote_low_precision_rules(conn, project["id"])
+
+    after = _read_counters(conn, rule["id"])
+    assert after["tier"] == "lesson"
+    assert after["current_streak"] == 0
+
+
+@pytest.mark.db
+def test_demote_is_project_scoped(
+    conn, project_factory, memory_factory
+):
+    """A demotion sweep on project A must NOT touch low-precision rules
+    in project B."""
+    project_a = project_factory("scopea")
+    project_b = project_factory("scopeb")
+    rule_a = memory_factory(project_a["id"], tier="rule")
+    rule_b = memory_factory(project_b["id"], tier="rule")
+    for r in (rule_a, rule_b):
+        _seed_counters(
+            conn,
+            r["id"],
+            hit_count=5,
+            effective_hit_count=1,
+            last_hit_offset_days=1,
+        )
+
+    demote_low_precision_rules(conn, project_a["id"])
+
+    after_a = _read_counters(conn, rule_a["id"])
+    after_b = _read_counters(conn, rule_b["id"])
+    assert after_a["tier"] == "lesson"
+    assert after_b["tier"] == "rule"
+    assert after_b["demoted_at"] is None

--- a/factory/tests/test_migration_020.py
+++ b/factory/tests/test_migration_020.py
@@ -1,0 +1,32 @@
+"""Test migration 020 applies cleanly and creates the expected schema objects.
+
+Migration 020 adds:
+  - devbrain.memory.effective_hit_count (INTEGER NOT NULL DEFAULT 0) —
+    counts in-brief, no-violation events (signal #3). Used together with
+    hit_count to compute precision = effective_hit_count /
+    (hit_count + effective_hit_count) for the demote sweep.
+
+This column was missed by migration 019 but is required by the graduation
+pipeline shipped in Step 6c (factory/curator/graduation.py).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.db
+def test_020_memory_has_effective_hit_count(conn):
+    """effective_hit_count must exist as INTEGER NOT NULL DEFAULT 0."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT data_type, is_nullable, column_default "
+            "FROM information_schema.columns "
+            "WHERE table_schema='devbrain' AND table_name='memory' "
+            "AND column_name='effective_hit_count'"
+        )
+        row = cur.fetchone()
+    assert row is not None, "effective_hit_count column is missing"
+    data_type, is_nullable, column_default = row
+    assert data_type == "integer"
+    assert is_nullable == "NO"
+    assert column_default == "0"

--- a/migrations/020_effective_hit_count.sql
+++ b/migrations/020_effective_hit_count.sql
@@ -1,0 +1,22 @@
+-- Atlas Step 6c — effective_hit_count column for graduation precision
+-- ============================================================================
+--
+-- Adds devbrain.memory.effective_hit_count INTEGER NOT NULL DEFAULT 0.
+--
+-- This column was missed by migration 019 (Step 6a) but is required by the
+-- three-signal feedback loop shipped in Step 6c (factory/curator/graduation.py):
+--
+--   * Signal #1 (in-brief AND failure): hit_count++, current_streak = 0
+--   * Signal #3 (in-brief AND clean):   effective_hit_count++, current_streak++
+--
+-- Demotion precision = effective_hit_count / (hit_count + effective_hit_count).
+-- A rule whose precision drops below 0.50 over a 30-day window gets demoted
+-- back to tier='lesson'.
+
+ALTER TABLE devbrain.memory
+    ADD COLUMN IF NOT EXISTS effective_hit_count INTEGER NOT NULL DEFAULT 0;
+
+-- Track this migration in schema_migrations (009 introduced the tracker).
+INSERT INTO devbrain.schema_migrations (filename, applied_at)
+VALUES ('020_effective_hit_count.sql', now())
+ON CONFLICT (filename) DO NOTHING;

--- a/tests/postulates/test_p4_lesson_graduation.py
+++ b/tests/postulates/test_p4_lesson_graduation.py
@@ -1,0 +1,91 @@
+"""P4 — Lesson graduation.
+
+POSTULATE
+---------
+A tier='lesson' row that:
+  1. Receives 3 successful preventions (signal #3) consecutively
+  2. Has last_hit within the 90-day freshness window
+
+...transitions to tier='rule', graduated_at is set, and a memory_ledger
+row records the transition (via the AFTER trigger from Step 2 substrate).
+
+This is the verification gate for Phase 6c. It's the end-to-end contract
+that the three-signal feedback loop must honor: signal #3 fires, the
+streak counter advances, and at the threshold the tier flips with a
+ledger audit row written by the migration-015 trigger.
+
+STATUS
+------
+Activated in Atlas Step 6c — the graduation pipeline lands here. Phase
+6a shipped the schema (current_streak + graduated_at columns + the
+graduation-candidates index). Phase 6b shipped the eval substrate.
+Phase 6c wires it together: the three signal handlers in
+factory/curator/graduation.py walk the brief + eval results and call
+_signal_success which advances the streak and graduates at threshold.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# The postulate suite runs from repo root; the curator module lives under
+# factory/. Add factory/ to sys.path so the import resolves regardless of
+# where pytest is invoked from.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "factory"))
+
+from curator.graduation import _signal_success  # noqa: E402
+
+
+def test_lesson_graduates_after_3_consecutive_successes(
+    conn, project_factory, memory_factory
+):
+    project = project_factory("p4_grad")
+    lesson = memory_factory(
+        project["id"], kind="pattern", content="will graduate"
+    )
+    # The factory inserts at tier='memory' by default; bump to 'lesson'
+    # so the graduation gate applies. Pre-seed current_streak = 2 — one
+    # more success crosses the threshold.
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory "
+            "SET tier = 'lesson', current_streak = 2 "
+            "WHERE id = %s",
+            (lesson["id"],),
+        )
+    conn.commit()
+
+    # Capture the ledger seq before the signal fires so we can assert
+    # the graduation transition produced a NEW ledger row.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.memory_ledger WHERE memory_id = %s",
+            (lesson["id"],),
+        )
+        ledger_count_before = cur.fetchone()[0]
+
+    _signal_success(conn, lesson["id"])
+
+    # Verify tier flipped, graduated_at set, streak landed at threshold.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT tier, graduated_at, current_streak FROM devbrain.memory "
+            "WHERE id = %s",
+            (lesson["id"],),
+        )
+        tier, graduated_at, streak = cur.fetchone()
+    assert tier == "rule"
+    assert graduated_at is not None
+    assert streak == 3
+
+    # The AFTER UPDATE trigger from migration 015 writes a ledger row on
+    # every UPDATE. The signal-success UPDATE writes one, the graduation
+    # UPDATE writes a second — the postulate just asserts the ledger
+    # advanced (>= 1 new row), not the exact count.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.memory_ledger WHERE memory_id = %s",
+            (lesson["id"],),
+        )
+        ledger_count_after = cur.fetchone()[0]
+    assert ledger_count_after > ledger_count_before


### PR DESCRIPTION
## Summary

Phase 6c — wires together the three-signal feedback loop and demote sweep on top of the schema (Phase 6a) and eval substrate (Phase 6b). After every REVIEWING phase, the curator brief is compared against the eval results to fire one of three signals per memory:

- **Signal #1 (in-brief AND violation):** `hit_count++`, `current_streak = 0` — the memory was surfaced but ignored, streak resets.
- **Signal #2 (NOT in-brief, finding):** queue refinement so applies_when widens. The Phase 6d stub raises NotImplementedError; graduation.py swallows it with a debug log so signals 1/3 still fire cleanly.
- **Signal #3 (in-brief AND clean):** `effective_hit_count++`, `current_streak++`, `last_hit = NOW`. If tier=`lesson` and streak hits the threshold (N=3), promote to tier=`rule` (graduation).

`demote_low_precision_rules` runs as a sweep: any tier=`rule` whose precision (`effective_hit_count / (hit_count + effective_hit_count)`) drops below 0.50 over the last 30 days is demoted back to tier=`lesson` with `current_streak = 0`. Project-scoped to prevent cross-project bleeds.

## Changes

- **Migration 020 (`migrations/020_effective_hit_count.sql`)** — adds `devbrain.memory.effective_hit_count INTEGER NOT NULL DEFAULT 0`. This column was missed by migration 019 but is required by the success-signal counter and the demote-sweep precision calculation. Schema-assertion test in `factory/tests/test_migration_020.py`.
- **`factory/curator/graduation.py`** — replaces the Phase 6a stubs with the full implementation. Public API: `apply_feedback_signals(conn, job_id, brief, eval_results)` and `demote_low_precision_rules(conn, project_id)`. The brief argument accepts both the `CuratorBrief` Pydantic model and a plain dict (the JSONB shape on `factory_jobs.curator_brief`).
- **`factory/tests/test_curator_graduation.py`** — 20 unit tests covering the three signal handlers, graduation idempotency, the demote sweep precision/freshness/scoping, and pure-helper edge cases (mixed dict/Pydantic brief shapes, findings without a `relevant_memory_id`).
- **`tests/postulates/test_p4_lesson_graduation.py`** — P4 postulate: a tier=`lesson` row with `current_streak = 2` plus one signal #3 transitions to tier=`rule` with `graduated_at` set and a memory_ledger row written by the migration-015 AFTER trigger. Activated alongside P1/P2/P3.

## Coverage + tests

- `curator/graduation.py`: **100%** (20 tests, 0 misses)
- All 12 postulates pass (P1, P2, P3, **P4 new**, plus 8 helper postulates)
- Phase 6a + 6b regression: **133 passing** across the curator/migration/eval-runner suite, no regressions
- `test_attribute_orphans.py` and `test_memory_table.py` failures observed locally are pre-existing on main (unrelated config.DATABASE_URL discrepancy, not introduced by this PR)

## Note on scope

The plan's 3-commit shape became 4 because migration 020 had to land separately from the implementation — the success-signal SQL needs the `effective_hit_count` column to exist before it can run. Migration 019 (Step 6a) didn't add this column, so adding it here was the smallest-scope way to honor the plan's SQL verbatim. Surfaced as a deviation in the agent report.

Signal #2 (refinement) is intentionally NOT exercised end-to-end — `curator.refinement.queue_refinement` is still a Phase 6d stub. `apply_feedback_signals` already handles the `NotImplementedError`, and one unit test covers that swallow path.

## Test plan
- [x] Unit tests pass with 100% coverage on graduation.py
- [x] P4 postulate runs as PASSED (not xfail/skip)
- [x] All Step 5 postulates still pass (P1/P2/P3, plus 8 helpers)
- [x] No regressions in Phase 6a (4 tests) or Phase 6b (39 tests)
- [ ] Orchestrator merges; Phase 6d (refinement) picks up next

🤖 Generated with [Claude Code](https://claude.com/claude-code)