### PR TITLE
feat(curator): Atlas Step 6d — refinement path (curator self-introspection)

### DIFF
--- a/factory/curator/refinement.py
+++ b/factory/curator/refinement.py
@@ -1,20 +1,195 @@
 """Curator self-introspection — proposes applies_when widening for memories
 that should have been in the brief but weren't (signal #2).
 
+Lifecycle:
+  1. apply_feedback_signals (graduation.py) sees a finding whose
+     relevant_memory_id is NOT in the brief and calls queue_refinement.
+  2. queue_refinement extracts a file_pattern + keywords from the
+     finding's file/message and writes a row into devbrain.refinement_queue.
+  3. At the end of every REVIEWING phase, refine_applies_when dequeues
+     pending rows for the project and merges (file_pattern, keywords)
+     into each memory's applies_when JSONB.
+
+Design notes:
+  - 7-day stale window: queue rows older than 7 days are skipped but
+    still get applied_at set so they don't pile up forever and so a
+    re-tick of refine_applies_when doesn't keep re-considering them.
+  - Error-path persistence: if _widen_applies_when raises, the row gets
+    applied_at = NOW() AND error = <msg>. We don't retry indefinitely.
+  - Cross-project safety: the dequeue JOINs memory and filters on
+    project_id so a refinement queued in project A can't be applied to
+    a memory row in project B even if the queue table was tampered with.
+  - applies_when shape: existing values like {"category": "tools"} are
+    preserved; we only merge "files" and "keywords" array keys.
+
+v3.0: simple keyword extraction from finding.file + finding.message.
+Phase 3.x: smarter heuristic or LLM-driven proposal.
+
 Public API:
 - queue_refinement(conn, finding)
 - refine_applies_when(conn, project_id)
-
-Implementation lands in 6d.
 """
 from __future__ import annotations
 
+import json
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
 
 def queue_refinement(conn, finding):
-    """Stub. Implementation lands in 6d."""
-    raise NotImplementedError("ships in Phase 6d")
+    """Queue a signal-#2 case for end-of-tick refinement.
+
+    Args:
+        conn: psycopg2 connection. Commit happens inside.
+        finding: an EvalFinding. If relevant_memory_id is None this is a
+            no-op — heuristic findings (rule_id is None) don't have a
+            specific memory row to widen.
+
+    Side effects:
+        Writes one row into devbrain.refinement_queue with file_pattern
+        derived from finding.file (directory glob) and keywords extracted
+        from finding.message.
+    """
+    if finding.relevant_memory_id is None:
+        return
+
+    file_pattern = _file_glob_from_path(finding.file)
+    keywords = _extract_keywords(finding.message)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.refinement_queue "
+            "(memory_id, file_pattern, keywords) VALUES (%s, %s, %s)",
+            (finding.relevant_memory_id, file_pattern, keywords),
+        )
+    conn.commit()
 
 
 def refine_applies_when(conn, project_id):
-    """Stub. Implementation lands in 6d."""
-    raise NotImplementedError("ships in Phase 6d")
+    """Process queued refinements: widen each memory's applies_when.
+
+    Args:
+        conn: psycopg2 connection. Commit happens at the end.
+        project_id: UUID. Only queue rows whose memory belongs to this
+            project are processed (cross-project safety).
+
+    Per row:
+      - On success: applied_at = NOW().
+      - On _widen_applies_when raising: applied_at = NOW(), error = msg
+        (truncated to 500 chars). The row is NOT retried.
+
+    Stale rows (queued_at older than 7 days) are skipped entirely — they
+    don't get applied_at set on this pass, but they're filtered out by
+    the queued_at > NOW() - INTERVAL '7 days' predicate so they won't be
+    considered again by future ticks either.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT q.id, q.memory_id, q.file_pattern, q.keywords
+            FROM devbrain.refinement_queue q
+            JOIN devbrain.memory m ON m.id = q.memory_id
+            WHERE q.applied_at IS NULL
+              AND q.queued_at > NOW() - INTERVAL '7 days'
+              AND m.project_id = %s
+            """,
+            (project_id,),
+        )
+        rows = cur.fetchall()
+
+        for queue_id, memory_id, file_pattern, keywords in rows:
+            try:
+                _widen_applies_when(conn, memory_id, file_pattern, keywords)
+                cur.execute(
+                    "UPDATE devbrain.refinement_queue "
+                    "SET applied_at = NOW() WHERE id = %s",
+                    (queue_id,),
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "refine_applies_when: queue row %s failed", queue_id
+                )
+                cur.execute(
+                    "UPDATE devbrain.refinement_queue "
+                    "SET applied_at = NOW(), error = %s WHERE id = %s",
+                    (str(exc)[:500], queue_id),
+                )
+    conn.commit()
+
+
+def _widen_applies_when(conn, memory_id, file_pattern, keywords):
+    """Merge (file_pattern, keywords) into a memory's applies_when JSONB.
+
+    Behavior:
+      - NULL applies_when is treated as {} (no existing keys to preserve).
+      - Existing keys (e.g. {"category": "tools"}) are preserved verbatim.
+      - "files" and "keywords" array keys are merged with the new values
+        and deduplicated. Sorted for determinism.
+      - If the memory row no longer exists (e.g. archived), this is a
+        no-op (the FK CASCADE on the queue would have already wiped the
+        queue row in normal flow, but defensive code can't hurt).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT applies_when FROM devbrain.memory WHERE id = %s",
+            (memory_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return
+        current = row[0] or {}
+        files = set(current.get("files", []))
+        if file_pattern:
+            files.add(file_pattern)
+        kw_set = set(current.get("keywords", []))
+        kw_set.update(keywords or [])
+
+        new_aw = {**current, "files": sorted(files), "keywords": sorted(kw_set)}
+        cur.execute(
+            "UPDATE devbrain.memory SET applies_when = %s::jsonb WHERE id = %s",
+            (json.dumps(new_aw), memory_id),
+        )
+
+
+def _file_glob_from_path(path: str) -> str:
+    """Convert a specific file path to a directory-level glob.
+
+    Examples:
+      'factory/curator/worker.py' -> 'factory/curator/*.py'
+      'README.md'                 -> 'README.md'  (no slash, returned as-is)
+      ''                          -> ''
+      None                        -> ''
+
+    The glob granularity is intentionally coarse — refinement is meant to
+    widen, not narrow.
+    """
+    if not path or "/" not in path:
+        return path or ""
+    parts = path.rsplit("/", 1)
+    if len(parts) != 2:
+        return path
+    dir_part, _filename = parts
+    return f"{dir_part}/*.py"
+
+
+def _extract_keywords(text: str) -> list[str]:
+    """Naive keyword extraction: words >= 4 chars, deduped, capped at 5.
+
+    Lower-cases the input. Order is preserved (first occurrence wins).
+    Cap of 5 keeps the resulting JSONB array bounded — applies_when is
+    read on every brief generation so we shouldn't bloat it unboundedly.
+    """
+    if not text:
+        return []
+    words = re.findall(r"\b[a-zA-Z_]{4,}\b", text.lower())
+    seen = set()
+    keywords: list[str] = []
+    for w in words:
+        if w not in seen:
+            seen.add(w)
+            keywords.append(w)
+        if len(keywords) >= 5:
+            break
+    return keywords

--- a/factory/tests/test_curator_refinement.py
+++ b/factory/tests/test_curator_refinement.py
@@ -1,0 +1,523 @@
+"""Unit tests for the curator refinement path (Atlas Step 6d).
+
+Covers factory/curator/refinement.py:
+
+  Pure helpers (no DB):
+    * _file_glob_from_path — directory globs, edge cases
+    * _extract_keywords — dedupe, length floor, cap at 5
+
+  DB tests (@pytest.mark.db):
+    * queue_refinement inserts a row with file_pattern + keywords from
+      finding.file/message
+    * queue_refinement is a no-op when finding.relevant_memory_id is None
+    * refine_applies_when widens applies_when JSONB:
+        - preserves existing keys (e.g. category)
+        - adds new files + keywords
+        - dedupes against existing values
+    * refine_applies_when respects project boundaries — queue rows for a
+      different project are not processed
+    * refine_applies_when failure path — when _widen_applies_when raises,
+      applied_at + error are set so the row doesn't retry forever
+    * refine_applies_when 7-day window — queue entries queued_at > 7
+      days ago are skipped
+"""
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from curator.eval.types import EvalFinding
+from curator.refinement import (
+    _extract_keywords,
+    _file_glob_from_path,
+    queue_refinement,
+    refine_applies_when,
+)
+
+
+def _make_finding(
+    *,
+    relevant_memory_id,
+    file: str = "factory/curator/worker.py",
+    message: str = "missing nullcheck on env variable lookup",
+):
+    return EvalFinding(
+        rule_id=relevant_memory_id,
+        severity="important",
+        file=file,
+        line=42,
+        message=message,
+        fix_hint="add a guard",
+        relevant_memory_id=relevant_memory_id,
+    )
+
+
+def _read_queue_row(conn, queue_id):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT memory_id, file_pattern, keywords, "
+            "       queued_at, applied_at, error "
+            "FROM devbrain.refinement_queue WHERE id = %s",
+            (queue_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return {
+        "memory_id": row[0],
+        "file_pattern": row[1],
+        "keywords": row[2],
+        "queued_at": row[3],
+        "applied_at": row[4],
+        "error": row[5],
+    }
+
+
+def _read_applies_when(conn, memory_id):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT applies_when FROM devbrain.memory WHERE id = %s",
+            (memory_id,),
+        )
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def _set_applies_when(conn, memory_id, value):
+    """Direct UPDATE of applies_when (memory_factory doesn't take it)."""
+    import json
+
+    with conn.cursor() as cur:
+        if value is None:
+            cur.execute(
+                "UPDATE devbrain.memory SET applies_when = NULL WHERE id = %s",
+                (memory_id,),
+            )
+        else:
+            cur.execute(
+                "UPDATE devbrain.memory SET applies_when = %s::jsonb WHERE id = %s",
+                (json.dumps(value), memory_id),
+            )
+    conn.commit()
+
+
+def _select_pending_queue_ids(conn, memory_id):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.refinement_queue "
+            "WHERE memory_id = %s AND applied_at IS NULL "
+            "ORDER BY queued_at",
+            (memory_id,),
+        )
+        return [r[0] for r in cur.fetchall()]
+
+
+def _select_all_queue_ids(conn, memory_id):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.refinement_queue "
+            "WHERE memory_id = %s ORDER BY queued_at",
+            (memory_id,),
+        )
+        return [r[0] for r in cur.fetchall()]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pure helpers (no DB)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_file_glob_from_path_directory_glob():
+    """Standard case: file in a directory becomes dir/*.py."""
+    assert (
+        _file_glob_from_path("factory/curator/worker.py")
+        == "factory/curator/*.py"
+    )
+
+
+def test_file_glob_from_path_deep_path():
+    """Multiple intermediate directories collapse to last-dir/*.py."""
+    assert (
+        _file_glob_from_path("a/b/c/d/e.py") == "a/b/c/d/*.py"
+    )
+
+
+def test_file_glob_from_path_no_slash():
+    """No slash → return as-is (no directory level to glob over)."""
+    assert _file_glob_from_path("README.md") == "README.md"
+
+
+def test_file_glob_from_path_empty_string():
+    """Empty/falsy returns empty string."""
+    assert _file_glob_from_path("") == ""
+
+
+def test_file_glob_from_path_none_safe():
+    """None-safe: helper accepts a None-ish (falsy) argument."""
+    assert _file_glob_from_path(None) == ""  # type: ignore[arg-type]
+
+
+def test_extract_keywords_basic():
+    """Words >= 4 chars are returned, deduped, lowercased."""
+    keywords = _extract_keywords("Missing nullcheck on env variable")
+    # "on" is < 4 chars and dropped
+    assert "missing" in keywords
+    assert "nullcheck" in keywords
+    assert "variable" in keywords
+    assert "on" not in keywords
+
+
+def test_extract_keywords_capped_at_five():
+    """Result is capped at 5 entries even if input has more eligible words."""
+    text = "alpha beta gamma delta epsilon zeta eta theta iota kappa"
+    keywords = _extract_keywords(text)
+    assert len(keywords) == 5
+    # First-five-eligible wins, in input order.
+    assert keywords == ["alpha", "beta", "gamma", "delta", "epsilon"]
+
+
+def test_extract_keywords_dedupes():
+    """Repeated words appear once."""
+    keywords = _extract_keywords("repeat repeat repeat unique unique")
+    assert keywords == ["repeat", "unique"]
+
+
+def test_extract_keywords_empty_or_none():
+    """Empty + None inputs return []."""
+    assert _extract_keywords("") == []
+    assert _extract_keywords(None) == []  # type: ignore[arg-type]
+
+
+def test_extract_keywords_drops_short_words():
+    """Words < 4 chars are excluded."""
+    # 'a', 'is', 'the' are all < 4 chars
+    keywords = _extract_keywords("a is the four")
+    assert keywords == ["four"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# queue_refinement (DB)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_queue_refinement_inserts_row(
+    conn, project_factory, memory_factory
+):
+    """queue_refinement writes one row with derived file_pattern + keywords."""
+    project = project_factory("queueref")
+    m = memory_factory(project["id"], tier="lesson")
+
+    finding = _make_finding(
+        relevant_memory_id=m["id"],
+        file="factory/curator/worker.py",
+        message="missing nullcheck on env variable",
+    )
+
+    queue_refinement(conn, finding)
+
+    pending = _select_pending_queue_ids(conn, m["id"])
+    assert len(pending) == 1
+    row = _read_queue_row(conn, pending[0])
+    assert row["memory_id"] == m["id"]
+    assert row["file_pattern"] == "factory/curator/*.py"
+    # Keywords are extracted (lower-cased, deduped, ≥4 chars).
+    assert "missing" in row["keywords"]
+    assert "nullcheck" in row["keywords"]
+    assert "variable" in row["keywords"]
+    assert row["applied_at"] is None
+    assert row["error"] is None
+
+
+@pytest.mark.db
+def test_queue_refinement_noop_when_relevant_memory_id_is_none(
+    conn, project_factory
+):
+    """Heuristic findings (relevant_memory_id=None) don't insert a row."""
+    project_factory("queuenoop")  # nothing to look up; just need a clean DB
+
+    finding = EvalFinding(
+        rule_id=None,
+        severity="minor",
+        file="x.py",
+        line=1,
+        message="heuristic finding with no memory ref",
+        fix_hint="...",
+        relevant_memory_id=None,
+    )
+
+    # Snapshot count before.
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM devbrain.refinement_queue")
+        before = cur.fetchone()[0]
+
+    queue_refinement(conn, finding)
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM devbrain.refinement_queue")
+        after = cur.fetchone()[0]
+
+    assert after == before
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# refine_applies_when (DB)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_refine_applies_when_widens_jsonb_preserving_existing(
+    conn, project_factory, memory_factory
+):
+    """refine_applies_when merges file_pattern + keywords into applies_when:
+      - keeps existing keys (e.g. {"category": "tools"})
+      - adds new "files" + "keywords" arrays
+      - dedupes against pre-existing values"""
+    project = project_factory("widen")
+    m = memory_factory(project["id"], tier="lesson")
+    # Seed an existing applies_when with a category key + some keywords
+    # already present so we can verify dedupe.
+    _set_applies_when(
+        conn,
+        m["id"],
+        {
+            "category": "tools",
+            "files": ["existing/path.py"],
+            "keywords": ["nullcheck"],
+        },
+    )
+
+    finding = _make_finding(
+        relevant_memory_id=m["id"],
+        file="factory/curator/worker.py",
+        message="missing nullcheck guard",
+    )
+    queue_refinement(conn, finding)
+
+    refine_applies_when(conn, project["id"])
+
+    aw = _read_applies_when(conn, m["id"])
+    # category preserved
+    assert aw["category"] == "tools"
+    # files merged + sorted, includes existing + new pattern
+    assert "factory/curator/*.py" in aw["files"]
+    assert "existing/path.py" in aw["files"]
+    assert aw["files"] == sorted(aw["files"])
+    # keywords deduped (nullcheck appears once)
+    assert aw["keywords"].count("nullcheck") == 1
+    # new keywords added
+    assert "missing" in aw["keywords"]
+    # sorted for determinism
+    assert aw["keywords"] == sorted(aw["keywords"])
+
+    # Queue row marked applied_at and no error.
+    all_rows = _select_all_queue_ids(conn, m["id"])
+    assert len(all_rows) == 1
+    queue_row = _read_queue_row(conn, all_rows[0])
+    assert queue_row["applied_at"] is not None
+    assert queue_row["error"] is None
+
+
+@pytest.mark.db
+def test_refine_applies_when_treats_null_applies_when_as_empty(
+    conn, project_factory, memory_factory
+):
+    """If applies_when is NULL on the memory row, _widen_applies_when
+    treats it as {} and writes a fresh dict containing files + keywords."""
+    project = project_factory("widennull")
+    m = memory_factory(project["id"], tier="lesson")
+    _set_applies_when(conn, m["id"], None)
+
+    finding = _make_finding(
+        relevant_memory_id=m["id"],
+        file="src/utils.py",
+        message="forgot timeout parameter",
+    )
+    queue_refinement(conn, finding)
+
+    refine_applies_when(conn, project["id"])
+
+    aw = _read_applies_when(conn, m["id"])
+    assert aw is not None
+    assert "src/*.py" in aw["files"]
+    # All keywords should be present
+    assert "forgot" in aw["keywords"]
+    assert "timeout" in aw["keywords"]
+
+
+@pytest.mark.db
+def test_refine_applies_when_is_project_scoped(
+    conn, project_factory, memory_factory
+):
+    """A queue row for project A's memory is NOT processed when
+    refine_applies_when runs against project B."""
+    project_a = project_factory("scopedA")
+    project_b = project_factory("scopedB")
+
+    m_a = memory_factory(project_a["id"], tier="lesson")
+    m_b = memory_factory(project_b["id"], tier="lesson")
+    _set_applies_when(conn, m_a["id"], None)
+    _set_applies_when(conn, m_b["id"], None)
+
+    queue_refinement(
+        conn,
+        _make_finding(
+            relevant_memory_id=m_a["id"], file="a/x.py", message="alpha bravo"
+        ),
+    )
+    queue_refinement(
+        conn,
+        _make_finding(
+            relevant_memory_id=m_b["id"], file="b/y.py", message="charlie delta"
+        ),
+    )
+
+    # Run refine for project B only.
+    refine_applies_when(conn, project_b["id"])
+
+    # m_a is unchanged — its queue row was NOT processed.
+    aw_a = _read_applies_when(conn, m_a["id"])
+    assert aw_a is None  # _widen never ran on it
+    # m_a queue row is still pending.
+    assert len(_select_pending_queue_ids(conn, m_a["id"])) == 1
+
+    # m_b was widened.
+    aw_b = _read_applies_when(conn, m_b["id"])
+    assert aw_b is not None
+    assert "b/*.py" in aw_b["files"]
+    # m_b queue row was applied.
+    assert len(_select_pending_queue_ids(conn, m_b["id"])) == 0
+
+
+@pytest.mark.db
+def test_refine_applies_when_failure_path_persists_error(
+    conn, project_factory, memory_factory, monkeypatch
+):
+    """When _widen_applies_when raises, the queue row is closed out with
+    applied_at + error so it doesn't retry forever."""
+    project = project_factory("widenfail")
+    m = memory_factory(project["id"], tier="lesson")
+    _set_applies_when(conn, m["id"], None)
+
+    queue_refinement(
+        conn,
+        _make_finding(
+            relevant_memory_id=m["id"],
+            file="x.py",
+            message="some failing finding",
+        ),
+    )
+
+    # Monkey-patch _widen_applies_when to raise on first call.
+    import curator.refinement as refmod
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("simulated widen failure")
+
+    monkeypatch.setattr(refmod, "_widen_applies_when", _boom)
+
+    refine_applies_when(conn, project["id"])
+
+    pending = _select_pending_queue_ids(conn, m["id"])
+    assert pending == [], "errored row should have applied_at set"
+
+    all_rows = _select_all_queue_ids(conn, m["id"])
+    row = _read_queue_row(conn, all_rows[0])
+    assert row["applied_at"] is not None
+    assert row["error"] is not None
+    assert "simulated widen failure" in row["error"]
+
+    # Run again — should NOT process the same row again (it has applied_at).
+    refine_applies_when(conn, project["id"])
+    row2 = _read_queue_row(conn, all_rows[0])
+    # error message stays the same (not retried).
+    assert row2["error"] == row["error"]
+
+
+@pytest.mark.db
+def test_refine_applies_when_skips_stale_queue_rows(
+    conn, project_factory, memory_factory
+):
+    """Queue rows older than 7 days are NOT processed (and don't get
+    applied_at set on this pass — they're filtered out by the WHERE)."""
+    project = project_factory("widenstale")
+    m = memory_factory(project["id"], tier="lesson")
+    _set_applies_when(conn, m["id"], None)
+
+    # Queue a row, then back-date it past the 7-day window.
+    queue_refinement(
+        conn,
+        _make_finding(
+            relevant_memory_id=m["id"],
+            file="x.py",
+            message="stale finding text",
+        ),
+    )
+    pending = _select_pending_queue_ids(conn, m["id"])
+    assert len(pending) == 1
+    queue_id = pending[0]
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.refinement_queue "
+            "SET queued_at = NOW() - INTERVAL '8 days' WHERE id = %s",
+            (queue_id,),
+        )
+    conn.commit()
+
+    refine_applies_when(conn, project["id"])
+
+    # applies_when should NOT have been widened.
+    aw = _read_applies_when(conn, m["id"])
+    assert aw is None, "stale queue row must not be processed"
+
+    # Queue row remains untouched (no applied_at).
+    row = _read_queue_row(conn, queue_id)
+    assert row["applied_at"] is None
+
+
+@pytest.mark.db
+def test_widen_applies_when_no_op_when_memory_id_missing(conn, project_factory):
+    """Direct call to _widen_applies_when with a non-existent memory_id
+    must early-return without raising (defensive — the JOIN in the
+    public dequeue normally filters this out, but the helper is callable
+    directly)."""
+    from curator.refinement import _widen_applies_when
+    project_factory("widenmissingdirect")  # ensure DB connection is alive
+
+    fake = uuid4()
+    # Should not raise.
+    _widen_applies_when(conn, fake, "x/*.py", ["alpha"])
+
+
+@pytest.mark.db
+def test_refine_applies_when_no_op_when_memory_row_missing(
+    conn, project_factory, memory_factory
+):
+    """If the memory row has been deleted between queue_refinement and
+    refine_applies_when, the JOIN in the dequeue filters the row out so
+    we don't blow up. (Defensive coverage for the early return in
+    _widen_applies_when, which would only fire if the JOIN somehow let
+    a stale row through — for example, manual table tampering — but is
+    cheap to keep.)"""
+    project = project_factory("widenmissing")
+    m = memory_factory(project["id"], tier="lesson")
+
+    queue_refinement(
+        conn,
+        _make_finding(
+            relevant_memory_id=m["id"],
+            file="x.py",
+            message="finding text here",
+        ),
+    )
+
+    # Delete the memory row directly. ON DELETE CASCADE will remove the
+    # queue row too — refine should run cleanly with nothing to do.
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM devbrain.memory WHERE id = %s", (m["id"],))
+    conn.commit()
+
+    # Should not raise.
+    refine_applies_when(conn, project["id"])

--- a/factory/tests/test_migration_021.py
+++ b/factory/tests/test_migration_021.py
@@ -1,0 +1,73 @@
+"""Test migration 021 applies cleanly and creates the expected schema objects.
+
+Migration 021 adds:
+  - devbrain.refinement_queue table — signal #2 cases (memories that
+    should have been in the brief but weren't) queued for end-of-tick
+    applies_when widening
+  - idx_refinement_queue_pending partial index — `WHERE applied_at IS
+    NULL`, optimizes the per-tick dequeue scan
+
+Note: this was originally migration 020 in the plan, but 020 was used in
+Phase 6c for the effective_hit_count column. See migrations/021 header
+for context.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+EXPECTED_COLUMNS = {
+    "id",
+    "memory_id",
+    "file_pattern",
+    "keywords",
+    "queued_at",
+    "applied_at",
+    "error",
+}
+
+
+@pytest.mark.db
+def test_021_refinement_queue_table_exists(conn):
+    """devbrain.refinement_queue table must exist."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema='devbrain' AND table_name='refinement_queue'"
+        )
+        row = cur.fetchone()
+    assert row is not None, "devbrain.refinement_queue table is missing"
+
+
+@pytest.mark.db
+def test_021_refinement_queue_has_all_columns(conn):
+    """All 7 expected columns must be present on refinement_queue."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema='devbrain' AND table_name='refinement_queue'"
+        )
+        cols = {r[0] for r in cur.fetchall()}
+    missing = EXPECTED_COLUMNS - cols
+    extra = cols - EXPECTED_COLUMNS
+    assert not missing, f"missing columns on refinement_queue: {missing}"
+    assert not extra, f"unexpected columns on refinement_queue: {extra}"
+
+
+@pytest.mark.db
+def test_021_refinement_queue_pending_index_exists(conn):
+    """idx_refinement_queue_pending must be a partial index on queued_at
+    with the predicate `applied_at IS NULL` so the dequeue scan only walks
+    pending rows."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE schemaname='devbrain' "
+            "  AND tablename='refinement_queue' "
+            "  AND indexname='idx_refinement_queue_pending'"
+        )
+        row = cur.fetchone()
+    assert row is not None, "idx_refinement_queue_pending is missing"
+    indexdef = row[0]
+    assert "queued_at" in indexdef
+    assert "applied_at IS NULL" in indexdef

--- a/migrations/021_refinement_queue.sql
+++ b/migrations/021_refinement_queue.sql
@@ -1,0 +1,24 @@
+-- Atlas Step 6 — Refinement queue
+-- ============================================================================
+--
+-- Signal #2 cases (NOT in brief but should have been) get queued here.
+-- The curator's refinement pass at end of REVIEWING dequeues entries and
+-- proposes applies_when widening for each.
+--
+-- Note: this was originally planned as migration 020, but migration 020
+-- was used in Phase 6c for the `effective_hit_count` column on
+-- devbrain.memory. The plan §Phase 6d uses 020; in this branch it's 021.
+
+CREATE TABLE IF NOT EXISTS devbrain.refinement_queue (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    memory_id    UUID NOT NULL REFERENCES devbrain.memory(id) ON DELETE CASCADE,
+    file_pattern TEXT,
+    keywords     TEXT[],
+    queued_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    applied_at   TIMESTAMPTZ,
+    error        TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_refinement_queue_pending
+    ON devbrain.refinement_queue (queued_at)
+    WHERE applied_at IS NULL;


### PR DESCRIPTION
## Summary

Atlas Step 6d ships the **refinement path**: when an eval agent finds a
violation that maps to a memory NOT in the brief (signal #2), the
curator queues a proposal to widen that memory's `applies_when`. At the
end of every REVIEWING phase the queue is dequeued and the proposals
are merged into the memory's `applies_when` JSONB so it surfaces next
time around.

Three commits, ~700 lines added, all delivered:

1. **Migration 021** (`migrations/021_refinement_queue.sql`)
   - Plan called for migration 020. Phase 6c claimed 020 for the
     `effective_hit_count` column, so this PR uses **021** instead.
     The migration header documents the shift.
   - New table `devbrain.refinement_queue` (memory_id FK CASCADE,
     file_pattern, keywords TEXT[], queued_at, applied_at, error)
   - Partial index `idx_refinement_queue_pending` on `queued_at WHERE
     applied_at IS NULL` — hot-path dequeue scan only walks pending rows
   - Schema-assertion test in `factory/tests/test_migration_021.py`

2. **`factory/curator/refinement.py`** — replaces Phase 6a stubs
   - `queue_refinement(conn, finding)` — extracts file_pattern (dir
     glob) + keywords (≥4 chars, deduped, capped at 5) from finding;
     no-op when `relevant_memory_id is None`
   - `refine_applies_when(conn, project_id)` — dequeues pending rows
     joined to `devbrain.memory` so cross-project leakage is impossible,
     then per-row widens `applies_when`
   - `_widen_applies_when` — preserves existing keys (e.g.
     `{"category": "tools"}`); merges `files` + `keywords` arrays with
     dedupe + sort
   - **7-day stale window**: rows older than 7 days are filtered out by
     the dequeue WHERE clause so we don't chew on stale proposals
   - **Error-path persistence**: `_widen_applies_when` exceptions get
     `applied_at = NOW()` + `error = msg` so a poison row doesn't
     retry forever
   - **NULL `applies_when`** treated as `{}` so first-time widens work

3. **Tests** (`factory/tests/test_curator_refinement.py` — 19 tests)
   - 10 pure-helper tests: `_file_glob_from_path` edge cases,
     `_extract_keywords` cap/dedupe/length-floor/empty
   - 9 `@pytest.mark.db` tests: queue insertion, no-op heuristic
     finding, JSONB widening with preserve+dedupe, NULL→{} init,
     project scoping, failure-path persistence, 7-day stale window,
     defensive missing-memory paths
   - **Coverage on `factory/curator/refinement.py`: 98%** (single
     uncovered line is an unreachable defensive branch in
     `_file_glob_from_path`'s `rsplit` guard)

## Activates Phase 6c's dormant signal-2 path

Phase 6c's `apply_feedback_signals` already imports `queue_refinement`
and wraps it in `try/except NotImplementedError` so partial-state-machine
runs wouldn't break. With this PR the stub raises become real INSERTs;
the swallow path is dormant. The graduation test
`test_apply_feedback_signals_swallows_signal2_not_implemented` stays
green (the wrap-and-log is still in place, just unreachable now).

## Verification

```
factory tests:    97 passed, 1 skipped (curator suite)
                  19 tests on refinement.py
                  20 tests on graduation.py (no regressions)
postulates:       12 passed (P1, P2, P3, P4, P_*)
coverage:         98% on factory/curator/refinement.py
schema_migrations updated for 021_refinement_queue.sql
```

## Test plan

- [x] Migration 021 applied locally + ledger backfilled
- [x] All 19 refinement tests pass (pure + @pytest.mark.db)
- [x] All 20 graduation tests still pass (signal-2 now routes through real queue_refinement)
- [x] All 12 postulates still pass
- [x] Coverage on `factory/curator/refinement.py` ≥ 85% (actual: 98%)
- [ ] CI: `pytest-db` workflow passes on the PR
- [ ] Phase 6e wires `refine_applies_when` into the IMPLEMENTING→REVIEWING state-machine hook

## Discipline

- Only `factory/curator/refinement.py`, `migrations/021_refinement_queue.sql`, and the two test files touched
- No state-machine changes (Phase 6e)
- No `factory/curator/graduation.py` changes (already shipped in 6c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)