### PR TITLE
feat(curator): Atlas Step 6e — state machine integration + P5 postulate (Step 6 done)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,10 +150,20 @@ jobs:
           cd factory && python -m pytest \
             tests/test_curator_brief.py \
             tests/test_curator_end_session.py \
+            tests/test_curator_eval_runner.py \
+            tests/test_curator_eval_types.py \
+            tests/test_curator_graduation.py \
+            tests/test_curator_refinement.py \
             tests/test_curator_strength.py \
             tests/test_curator_types.py \
             tests/test_curator_worker.py \
+            tests/test_eval_security.py \
+            tests/test_eval_test.py \
             tests/test_migration_017.py \
             tests/test_migration_018.py \
+            tests/test_migration_019.py \
+            tests/test_migration_020.py \
+            tests/test_migration_021.py \
+            tests/test_step6_e2e.py \
             tests/test_store_cascade_enqueue.py \
             -v --tb=short

--- a/factory/state_machine.py
+++ b/factory/state_machine.py
@@ -284,6 +284,18 @@ class FactoryDB:
         ):
             self._generate_brief_for_planning(job_id, job.project_id, job.spec)
 
+        # Curator eval phase hook. Runs at IMPLEMENTING -> REVIEWING only.
+        # Invokes the two eval agents (security + test) over the brief +
+        # plan + diff, applies the three-signal feedback loop to the
+        # surfaced memories, processes the refinement queue, and runs the
+        # rule-demotion sweep. See docs/plans/2026-05-04-step-6-eval-
+        # graduation-design.md §3 + Phase 6e Task 6e-1.
+        if (
+            job.status == JobStatus.IMPLEMENTING
+            and new_status == JobStatus.REVIEWING
+        ):
+            self._run_eval_phase(job)
+
         return self.get_job(job_id)
 
     def _generate_brief_for_planning(
@@ -329,6 +341,107 @@ class FactoryDB:
                 (json.dumps({"brief_error": error[:1000]}), job_id),
             )
             conn.commit()
+
+    def _run_eval_phase(self, job: FactoryJob) -> None:
+        """Run eval agents + graduation + refinement + demotion sweep.
+
+        Fires at IMPLEMENTING -> REVIEWING. Failure isolation: any
+        exception from the eval pipeline is logged but NOT re-raised, so
+        a flaky LLM doesn't block the state machine from advancing the
+        job to REVIEWING. The architecture/security review (the existing
+        review path) runs immediately after this returns and provides a
+        second line of defense.
+
+        See docs/plans/2026-05-04-step-6-eval-graduation-design.md
+        §Phase 6e for the contract.
+        """
+        # Local imports to avoid circulars at module load — the curator
+        # subpackage doesn't import state_machine, but the eval runner
+        # spawns subprocess.run for `claude` and we want lazy loading.
+        from curator.eval.runner import run_evals
+        from curator.graduation import (
+            apply_feedback_signals,
+            demote_low_precision_rules,
+        )
+        from curator.refinement import refine_applies_when
+
+        try:
+            brief = self._load_brief(job.id)
+            plan = self._load_plan(job.id)
+            diff = self._load_diff(job.id)
+
+            with self._conn() as conn:
+                eval_results = run_evals(conn, job.id, brief, plan, diff)
+                apply_feedback_signals(conn, job.id, brief, eval_results)
+                refine_applies_when(conn, job.project_id)
+                demote_low_precision_rules(conn, job.project_id)
+        except Exception:
+            # Don't block the state machine on eval failures — log and
+            # let the existing review/QA paths catch downstream issues.
+            logger.exception(
+                "Eval phase failed for job %s; continuing to REVIEWING",
+                job.id[:8],
+            )
+
+    def _load_brief(self, job_id: str) -> dict:
+        """Load the curator brief snapshot from factory_jobs.curator_brief.
+
+        Returns an empty dict if no brief was generated (e.g. brief
+        generation failed at QUEUED -> PLANNING). The eval prompts are
+        designed to handle empty input gracefully.
+        """
+        with self._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT curator_brief FROM devbrain.factory_jobs WHERE id = %s",
+                (job_id,),
+            )
+            row = cur.fetchone()
+        if row is None or row[0] is None:
+            return {}
+        return row[0]
+
+    def _load_plan(self, job_id: str) -> str:
+        """Load the implementation plan stored as a planning artifact.
+
+        The orchestrator writes the plan via store_artifact(phase=
+        'planning', artifact_type='plan_doc'). If multiple plan_doc
+        artifacts exist (e.g. after a replan resolution from BLOCKED),
+        the most recent wins.
+        """
+        with self._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT content FROM devbrain.factory_artifacts "
+                "WHERE job_id = %s AND phase = 'planning' "
+                "  AND artifact_type = 'plan_doc' "
+                "ORDER BY created_at DESC LIMIT 1",
+                (job_id,),
+            )
+            row = cur.fetchone()
+        return row[0] if row else ""
+
+    def _load_diff(self, job_id: str) -> str:
+        """Load the implementation diff stored as an artifact.
+
+        v3.0 reads the cached diff artifact written at the end of the
+        implementation phase (orchestrator stores `git diff main...HEAD
+        --stat`). Phase 3.x: regenerate a full diff from the worktree
+        for richer eval context. If no diff artifact exists (e.g. a
+        legacy job or worktree-less job), return empty string — the
+        eval prompts are designed to handle empty diff (the brief still
+        carries the surfaced memories).
+        """
+        # TODO(Phase 3.x): regenerate a full diff via `git diff
+        # main...HEAD` in the job's worktree for richer eval context.
+        with self._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT content FROM devbrain.factory_artifacts "
+                "WHERE job_id = %s AND phase = 'implementation' "
+                "  AND artifact_type = 'diff' "
+                "ORDER BY created_at DESC LIMIT 1",
+                (job_id,),
+            )
+            row = cur.fetchone()
+        return row[0] if row else ""
 
     def update_metadata(self, job_id: str, metadata: dict) -> None:
         """Merge the given dict into a job's metadata JSONB without

--- a/factory/tests/test_step6_e2e.py
+++ b/factory/tests/test_step6_e2e.py
@@ -1,0 +1,178 @@
+"""End-to-end integration test for Step 6 eval phase.
+
+Exercises the full IMPLEMENTING -> REVIEWING pathway:
+  1. State machine fires the eval phase hook
+  2. _load_brief / _load_plan / _load_diff read from substrate storage
+  3. run_evals invokes the eval agents (mocked subprocess.run returns
+     clean — zero findings)
+  4. apply_feedback_signals walks the brief, fires signal #3 for every
+     in-brief memory (no findings -> no signal #1, no signal #2)
+  5. Each lesson at current_streak=2 hits the GRADUATION_STREAK_THRESHOLD
+     of 3 and graduates to tier='rule', graduated_at is stamped
+  6. refine_applies_when no-ops (empty refinement_queue)
+  7. demote_low_precision_rules no-ops (the just-graduated rules have
+     hit_count=0 + effective_hit_count=1 = precision 1.0)
+
+This is the verification gate for Phase 6e Task 6e-3 — confirms the
+state machine wiring works end-to-end across all four curator modules
+(eval/runner, graduation, refinement, plus the brief substrate).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from state_machine import FactoryDB, JobStatus
+
+
+@pytest.fixture
+def db(database_url):
+    return FactoryDB(database_url)
+
+
+def _clean_eval_response() -> str:
+    """JSON payload returned by the mocked claude subprocess — zero findings."""
+    return json.dumps({"findings": []})
+
+
+def _stash_brief_and_advance_to_implementing(
+    conn, job_id, lesson_ids
+):
+    """Write a brief snapshot pointing at the given lesson_ids into
+    factory_jobs.curator_brief, then UPDATE the job into IMPLEMENTING
+    state directly so the state machine has a legal IMPLEMENTING ->
+    REVIEWING transition to fire.
+
+    Walking the QUEUED -> PLANNING -> IMPLEMENTING path naturally would
+    invoke generate_brief at the QUEUED -> PLANNING step (the existing
+    Step 5d hook), which would overwrite our hand-crafted brief — so we
+    UPDATE the row directly here.
+    """
+    brief = {
+        "version": "1.0",
+        "job_id": str(job_id),
+        "rules": [],
+        "lessons": [
+            {
+                "id": str(mid),
+                "kind": "pattern",
+                "title": "test-lesson",
+                "content_excerpt": "...",
+                "tier": "lesson",
+                "strength": "1.0",
+                "last_cascade_at": None,
+            }
+            for mid in lesson_ids
+        ],
+        "relevant_decisions": [],
+        "recent_cascade_signals": [],
+        "generated_at": "2026-05-04T00:00:00+00:00",
+    }
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.factory_jobs "
+            "SET curator_brief = %s::jsonb, status = 'implementing', "
+            "    current_phase = 'implementing' "
+            "WHERE id = %s",
+            (json.dumps(brief), job_id),
+        )
+        # Also write a placeholder plan_doc artifact so _load_plan
+        # returns non-empty (the eval prompts handle either, but this
+        # mirrors the real pipeline shape).
+        cur.execute(
+            "INSERT INTO devbrain.factory_artifacts "
+            "(job_id, phase, artifact_type, content) "
+            "VALUES (%s, 'planning', 'plan_doc', 'placeholder plan')",
+            (job_id,),
+        )
+    conn.commit()
+
+
+@pytest.mark.db
+def test_implementing_to_reviewing_runs_full_eval_pipeline(
+    db, conn, project_factory, memory_factory, factory_job_factory
+):
+    """Full end-to-end: 3 lessons at streak=2 graduate after one clean tick."""
+    project = project_factory("e2e_step6")
+
+    # Three lessons, each pre-seeded at current_streak=2 so a single
+    # signal #3 (success) crosses the GRADUATION_STREAK_THRESHOLD of 3.
+    lessons = [
+        memory_factory(project["id"], tier="lesson", content=f"lesson_{i}")
+        for i in range(3)
+    ]
+    with conn.cursor() as cur:
+        for lesson in lessons:
+            cur.execute(
+                "UPDATE devbrain.memory "
+                "SET current_streak = 2 "
+                "WHERE id = %s",
+                (lesson["id"],),
+            )
+    conn.commit()
+
+    # Need a FactoryJob row owned by this project. The factory_job_factory
+    # commits a queued row by default; we patch it into IMPLEMENTING below.
+    # job_id flows back as a UUID object from psycopg2's UUID adapter;
+    # state_machine.transition expects a str (it slices job_id[:8] for
+    # log lines), so coerce here.
+    job_row = factory_job_factory(project_id=project["id"], spec="e2e step6")
+    job_id = str(job_row["id"])
+
+    _stash_brief_and_advance_to_implementing(
+        conn, job_id, [lesson["id"] for lesson in lessons]
+    )
+
+    # Mock subprocess.run so the eval agents return zero-finding payloads
+    # without invoking real claude. Returns a CompletedProcess-like mock
+    # for both agent calls.
+    clean_proc = MagicMock(
+        returncode=0,
+        stdout=_clean_eval_response(),
+        stderr="",
+    )
+
+    try:
+        with patch(
+            "curator.eval.runner.subprocess.run",
+            return_value=clean_proc,
+        ) as mock_run:
+            # Trigger the IMPLEMENTING -> REVIEWING transition. This fires
+            # _run_eval_phase via the state machine hook.
+            result = db.transition(job_id, JobStatus.REVIEWING)
+
+        assert result.status == JobStatus.REVIEWING
+        # Both eval agents (security + test) should have been invoked.
+        assert mock_run.call_count == 2
+
+        # Assert all 3 lessons graduated to rules with graduated_at set.
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, tier, graduated_at, current_streak "
+                "FROM devbrain.memory "
+                "WHERE id = ANY(%s)",
+                ([lesson["id"] for lesson in lessons],),
+            )
+            rows = cur.fetchall()
+
+        assert len(rows) == 3
+        for _id, tier, graduated_at, streak in rows:
+            assert tier == "rule", f"memory {_id} did not graduate"
+            assert graduated_at is not None
+            assert streak == 3
+    finally:
+        # The eval runner persists per-finding (or per-summary) artifact
+        # rows that FK to factory_jobs.id. The factory_job_factory teardown
+        # would otherwise hit a foreign-key violation deleting the job —
+        # purge artifacts first. project_factory teardown also deletes
+        # factory_artifacts via cascade memory cleanup but factory_jobs
+        # cleanup runs in factory_job_factory which doesn't know about it.
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM devbrain.factory_artifacts WHERE job_id = %s",
+                (job_id,),
+            )
+        conn.commit()

--- a/tests/postulates/test_p5_rule_demotion.py
+++ b/tests/postulates/test_p5_rule_demotion.py
@@ -1,0 +1,89 @@
+"""P5 — Rule demotion.
+
+POSTULATE
+---------
+A tier='rule' row whose effective_hit_count / (hit_count + effective_hit_count)
+< 0.50 within a 30-day window transitions to tier='lesson', demoted_at is
+set, current_streak is reset to 0, and a memory_ledger row records the
+transition (via the AFTER trigger from Step 2 substrate).
+
+This is the verification gate for Phase 6e. It's the end-to-end contract
+that the rule-demotion sweep must honor: a rule that has been recently
+active but is misfiring (precision below 0.5 over a 30-day window) is
+demoted back to tier='lesson' so it has to re-earn graduation through
+the three-signal feedback loop.
+
+STATUS
+------
+Activated in Atlas Step 6e — the state machine integration phase. The
+sweep itself ships in factory/curator/graduation.py
+(demote_low_precision_rules) which is invoked from the IMPLEMENTING ->
+REVIEWING hook in factory/state_machine.py._run_eval_phase.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# The postulate suite runs from repo root; the curator module lives under
+# factory/. Add factory/ to sys.path so the import resolves regardless of
+# where pytest is invoked from.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "factory"))
+
+from curator.graduation import demote_low_precision_rules  # noqa: E402
+
+
+def test_low_precision_rule_demotes_to_lesson(
+    conn, project_factory, memory_factory
+):
+    project = project_factory("p5_demote")
+    rule = memory_factory(project["id"], content="will demote")
+
+    # Pre-seed: hit_count=5 + effective_hit_count=3 -> precision=3/8=0.375 < 0.5
+    # current_streak=10 (will reset to 0 on demotion)
+    # last_hit=NOW (within 30-day window)
+    # The postulate suite's memory_factory inserts at tier='memory' with
+    # zero counters; bump tier='rule' + counters in one UPDATE.
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory "
+            "SET tier = 'rule', hit_count = 5, effective_hit_count = 3, "
+            "    current_streak = 10, last_hit = NOW() "
+            "WHERE id = %s",
+            (rule["id"],),
+        )
+    conn.commit()
+
+    # Capture the ledger seq before the demotion fires so we can assert
+    # the tier transition produced a NEW ledger row.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.memory_ledger WHERE memory_id = %s",
+            (rule["id"],),
+        )
+        ledger_count_before = cur.fetchone()[0]
+
+    demote_low_precision_rules(conn, project["id"])
+
+    # Verify tier flipped, demoted_at set, streak reset.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT tier, demoted_at, current_streak FROM devbrain.memory "
+            "WHERE id = %s",
+            (rule["id"],),
+        )
+        tier, demoted_at, streak = cur.fetchone()
+    assert tier == "lesson"
+    assert demoted_at is not None
+    assert streak == 0
+
+    # The AFTER UPDATE trigger from migration 015 writes a ledger row on
+    # every UPDATE. The demotion UPDATE writes one — the postulate just
+    # asserts the ledger advanced (>= 1 new row), not the exact count.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.memory_ledger WHERE memory_id = %s",
+            (rule["id"],),
+        )
+        ledger_count_after = cur.fetchone()[0]
+    assert ledger_count_after > ledger_count_before


### PR DESCRIPTION
## Summary

**Step 6 is complete after this merge.** Phase 6e wires the eval phase into the state machine and ships the verification postulate for rule demotion.

- State machine integration at `IMPLEMENTING -> REVIEWING` runs eval agents (security + test) over the cached brief + plan + diff, applies the three-signal feedback loop, processes the refinement queue, and runs the rule-demotion sweep
- **P5 postulate green** (rule demotion contract verified end-to-end)
- All 13 postulate tests across 10 postulate files (P1, P2, P3 [×2 tests], P_cycle, P_archived_mid_cascade, P_stuck_surface_able, P_end_session_isolation [×2], P_end_session_idempotent [×2], P4, P5) running in CI on every push
- New `pytest-db` allow-list entries: 9 Step 6 unit/integration test files + 1 e2e test file
- Step 7 (rule engine + per-project compliance profiles + 5 seeded rules) becomes unblocked

## What ships

### Task 6e-1 — state machine hook
`factory/state_machine.py` — adds the `IMPLEMENTING -> REVIEWING` hook in the parallel pattern of the existing `QUEUED -> PLANNING` brief-generation hook. New helpers `_load_brief`, `_load_plan`, `_load_diff` read from existing substrate storage:

- **brief**: `factory_jobs.curator_brief` JSONB (cached at `QUEUED -> PLANNING`)
- **plan**: `factory_artifacts` (`phase='planning'`, `artifact_type='plan_doc'`)
- **diff**: `factory_artifacts` (`phase='implementation'`, `artifact_type='diff'`)

**Failure isolation**: any exception in the eval pipeline is logged but not re-raised so a flaky LLM doesn't block the state machine. The existing arch/security review path runs immediately after and provides a second line of defense.

**v3.0 decision**: reads the cached `--stat` diff artifact rather than regenerating a full diff from the worktree. Phase 3.x will revisit — the eval prompts already handle empty/sparse diff (the brief still carries the surfaced memories).

### Task 6e-2 — P5 postulate
`tests/postulates/test_p5_rule_demotion.py` — verification gate for `demote_low_precision_rules`. Pre-seeds `hit_count=5 + effective_hit_count=3` (precision 0.375 < 0.5) + `current_streak=10` + `last_hit=NOW()` then asserts: `tier='lesson'`, `demoted_at` set, `current_streak=0`, ledger row written by the AFTER UPDATE trigger.

### Task 6e-3 — e2e integration test
`factory/tests/test_step6_e2e.py` — full IMPLEMENTING -> REVIEWING flow:
1. State machine fires the hook
2. `_load_brief` / `_load_plan` / `_load_diff` read from substrate
3. `subprocess.run` mocked to return zero-finding payloads
4. `apply_feedback_signals` fires signal #3 for every in-brief memory
5. 3 lessons at `current_streak=2` cross the threshold of 3 and graduate
6. `refine_applies_when` no-ops (empty queue)
7. `demote_low_precision_rules` no-ops (precision = 1.0)

### Task 6e-4 — DB-CI allow-list
`.github/workflows/test.yml` — adds 10 new test files to the `pytest-db` job: `test_curator_eval_runner.py`, `test_curator_eval_types.py`, `test_curator_graduation.py`, `test_curator_refinement.py`, `test_eval_security.py`, `test_eval_test.py`, `test_migration_019.py`, `test_migration_020.py`, `test_migration_021.py`, `test_step6_e2e.py`.

## Test plan

- [x] P5 postulate passes locally against pgvector:pg16 (DB substrate)
- [x] All 13 postulate tests pass locally (no regressions in P1-P4 + cascade/end-session postulates)
- [x] All 140 DB-available tests in the new allow-list pass (1 skipped, 0 failed)
- [x] State machine `transition()` syntax + import paths validated
- [x] Workflow YAML syntactically valid
- [ ] CI green on push