### PR TITLE
feat(memory): Atlas Step 7a — compliance_profiles migration + P6/P7 postulates

### DIFF
--- a/factory/tests/conftest.py
+++ b/factory/tests/conftest.py
@@ -92,16 +92,31 @@ def project_factory(conn):
     rows, dependency edges, ledger rows, curator queue rows, factory_jobs
     rows) before the project itself — required because committed rows
     are not rolled back by the conn fixture.
+
+    Optional kwarg `compliance_profiles_enabled` (Atlas Step 7a) lets
+    the caller seed devbrain.projects.compliance_profiles_enabled at
+    insert time. Only set when non-None so older installs (pre-022) keep
+    skipping the column.
     """
     created: list[str] = []
 
-    def make(slug_hint: str = "p") -> dict:
+    def make(
+        slug_hint: str = "p",
+        *,
+        compliance_profiles_enabled: list[str] | None = None,
+    ) -> dict:
         slug = f"{TEST_TAG}{slug_hint}_{uuid.uuid4().hex[:8]}"
+        cols = ["slug", "name"]
+        vals: list = [slug, f"Factory Test {slug_hint}"]
+        if compliance_profiles_enabled is not None:
+            cols.append("compliance_profiles_enabled")
+            vals.append(compliance_profiles_enabled)
+        placeholders = ", ".join(["%s"] * len(cols))
         with conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO devbrain.projects (slug, name) VALUES (%s, %s) "
-                "RETURNING id, slug",
-                (slug, f"Factory Test {slug_hint}"),
+                f"INSERT INTO devbrain.projects ({', '.join(cols)}) "
+                f"VALUES ({placeholders}) RETURNING id, slug",
+                vals,
             )
             row = cur.fetchone()
         conn.commit()
@@ -167,9 +182,10 @@ def memory_factory(conn):
     """Insert a devbrain.memory row directly (bypassing the MCP server).
 
     Optional kwargs `tier` and `strength` set those columns at insert time
-    (both ship in migration 010). `compliance_profiles` is silently
-    ignored until that column ships in Step 7 — the kwarg is accepted so
-    forward-compat tests don't have to special-case the call site.
+    (both ship in migration 010). `compliance_profiles` (Atlas Step 7a)
+    sets devbrain.memory.compliance_profiles when non-None — the kwarg
+    was previously a no-op forward-compat slot, now that migration 022
+    has shipped it persists the value.
     """
 
     def make(
@@ -181,7 +197,7 @@ def memory_factory(conn):
         provenance_id: str | None = None,
         tier: str | None = None,
         strength: float | None = None,
-        compliance_profiles: list[str] | None = None,  # noqa: ARG001 — Step 7
+        compliance_profiles: list[str] | None = None,
     ) -> dict:
         title = title or f"{TEST_TAG}title_{uuid.uuid4().hex[:6]}"
         content = content or f"{TEST_TAG}body_{uuid.uuid4().hex[:6]}"
@@ -194,6 +210,9 @@ def memory_factory(conn):
         if strength is not None:
             cols.append("strength")
             vals.append(strength)
+        if compliance_profiles is not None:
+            cols.append("compliance_profiles")
+            vals.append(compliance_profiles)
 
         placeholders = ", ".join(["%s"] * len(cols))
         with conn.cursor() as cur:

--- a/factory/tests/test_curator_brief.py
+++ b/factory/tests/test_curator_brief.py
@@ -18,11 +18,6 @@ from curator.brief import generate_brief
 
 
 @pytest.mark.db
-@pytest.mark.skip(
-    reason="TODO Step 7: re-enable when compliance_profiles + "
-    "compliance_profiles_enabled columns ship. brief.py already handles "
-    "the missing-column case gracefully (try/except around the SELECT)."
-)
 def test_brief_filters_by_compliance_profiles(
     conn, project_factory, memory_factory, factory_job_factory
 ):

--- a/factory/tests/test_migration_022.py
+++ b/factory/tests/test_migration_022.py
@@ -1,0 +1,86 @@
+"""Test migration 022 applies cleanly and creates the expected schema objects.
+
+Migration 022 adds:
+  - devbrain.memory.compliance_profiles TEXT[] — per-rule profile tags
+    (NULL/[] = explicit opt-out from every project's brief)
+  - devbrain.projects.compliance_profiles_enabled TEXT[] — projects opt
+    into specific profiles; curator brief intersects the two arrays
+  - idx_memory_compliance_profiles_gin partial GIN index — predicate
+    `WHERE compliance_profiles IS NOT NULL` keeps the index lean since
+    the vast majority of memory rows will have NULL profiles.
+
+Verification gates for Phase 7a (substrate) live in P6/P7; this file
+only asserts the schema shape so a regression that drops a column,
+flips its type, or alters the index definition fails CI loudly.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.db
+def test_022_memory_has_compliance_profiles_column(conn):
+    """devbrain.memory.compliance_profiles exists and is text[] (array of text)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT data_type, udt_name FROM information_schema.columns "
+            "WHERE table_schema='devbrain' AND table_name='memory' "
+            "  AND column_name='compliance_profiles'"
+        )
+        row = cur.fetchone()
+    assert row is not None, "devbrain.memory.compliance_profiles is missing"
+    data_type, udt_name = row
+    # Postgres reports text[] as data_type='ARRAY' + udt_name='_text'.
+    assert data_type == "ARRAY"
+    assert udt_name == "_text"
+
+
+@pytest.mark.db
+def test_022_projects_has_compliance_profiles_enabled_column(conn):
+    """devbrain.projects.compliance_profiles_enabled exists and is text[]."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT data_type, udt_name FROM information_schema.columns "
+            "WHERE table_schema='devbrain' AND table_name='projects' "
+            "  AND column_name='compliance_profiles_enabled'"
+        )
+        row = cur.fetchone()
+    assert row is not None, (
+        "devbrain.projects.compliance_profiles_enabled is missing"
+    )
+    data_type, udt_name = row
+    assert data_type == "ARRAY"
+    assert udt_name == "_text"
+
+
+@pytest.mark.db
+def test_022_compliance_profiles_gin_index_exists(conn):
+    """idx_memory_compliance_profiles_gin must exist on devbrain.memory."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE schemaname='devbrain' "
+            "  AND tablename='memory' "
+            "  AND indexname='idx_memory_compliance_profiles_gin'"
+        )
+        row = cur.fetchone()
+    assert row is not None, "idx_memory_compliance_profiles_gin is missing"
+
+
+@pytest.mark.db
+def test_022_compliance_profiles_gin_index_uses_partial_predicate(conn):
+    """The GIN index must be partial (`WHERE compliance_profiles IS NOT NULL`)
+    and use the GIN access method. Both checks read from the same indexdef
+    string Postgres gives us, so they're co-located here."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE schemaname='devbrain' "
+            "  AND tablename='memory' "
+            "  AND indexname='idx_memory_compliance_profiles_gin'"
+        )
+        row = cur.fetchone()
+    assert row is not None
+    indexdef = row[0]
+    assert "USING gin" in indexdef
+    assert "compliance_profiles IS NOT NULL" in indexdef

--- a/migrations/022_compliance_profiles.sql
+++ b/migrations/022_compliance_profiles.sql
@@ -1,0 +1,23 @@
+-- Atlas Step 7 — Per-project compliance profiles
+-- ============================================================================
+--
+-- Adds the substrate for filtering rules by compliance profile membership.
+-- Per the playbook §5 + DevBrain decision fc1a62bb (Option A locked):
+--
+--   1. devbrain.memory.compliance_profiles text[] — rules tag themselves
+--      with one or more profiles ('hipaa', 'soc2', 'ferpa', etc.). NULL/[]
+--      means the rule applies to NO project (explicit opt-in semantics).
+--   2. devbrain.projects.compliance_profiles_enabled text[] — projects
+--      enable specific profiles. Curator brief filters rules by intersection.
+--   3. GIN index on memory.compliance_profiles for the curator hot-path
+--      query: WHERE compliance_profiles && %s::text[]
+
+ALTER TABLE devbrain.memory
+    ADD COLUMN IF NOT EXISTS compliance_profiles TEXT[];
+
+ALTER TABLE devbrain.projects
+    ADD COLUMN IF NOT EXISTS compliance_profiles_enabled TEXT[];
+
+CREATE INDEX IF NOT EXISTS idx_memory_compliance_profiles_gin
+    ON devbrain.memory USING GIN (compliance_profiles)
+    WHERE compliance_profiles IS NOT NULL;

--- a/tests/postulates/conftest.py
+++ b/tests/postulates/conftest.py
@@ -68,16 +68,32 @@ def conn(database_url):
 
 @pytest.fixture
 def project_factory(conn):
-    """Create disposable projects with a unique slug. Cleaned up at teardown."""
+    """Create disposable projects with a unique slug. Cleaned up at teardown.
+
+    Optional kwarg `compliance_profiles_enabled` (Atlas Step 7a) seeds
+    devbrain.projects.compliance_profiles_enabled at insert. Only set
+    when non-None so the fixture stays usable on installs that haven't
+    applied migration 022 yet.
+    """
     created: list[str] = []
 
-    def make(slug_hint: str = "p") -> dict:
+    def make(
+        slug_hint: str = "p",
+        *,
+        compliance_profiles_enabled: list[str] | None = None,
+    ) -> dict:
         slug = f"{TEST_TAG}{slug_hint}_{uuid.uuid4().hex[:8]}"
+        cols = ["slug", "name"]
+        vals: list = [slug, f"Postulate Test {slug_hint}"]
+        if compliance_profiles_enabled is not None:
+            cols.append("compliance_profiles_enabled")
+            vals.append(compliance_profiles_enabled)
+        placeholders = ", ".join(["%s"] * len(cols))
         with conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO devbrain.projects (slug, name) VALUES (%s, %s) "
-                "RETURNING id, slug",
-                (slug, f"Postulate Test {slug_hint}"),
+                f"INSERT INTO devbrain.projects ({', '.join(cols)}) "
+                f"VALUES ({placeholders}) RETURNING id, slug",
+                vals,
             )
             row = cur.fetchone()
         conn.commit()
@@ -128,13 +144,26 @@ def project_factory(conn):
             except Exception:
                 conn.rollback()
             cur.execute("DELETE FROM devbrain.memory WHERE project_id = %s", (pid,))
+            # factory_jobs FK project_id; postulates that route through
+            # generate_brief insert real factory_jobs rows (P6/P7), so
+            # clean them up before the project. Older postulates that
+            # didn't touch this table no-op cleanly here.
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE project_id = %s",
+                (pid,),
+            )
             cur.execute("DELETE FROM devbrain.projects WHERE id = %s", (pid,))
     conn.commit()
 
 
 @pytest.fixture
 def memory_factory(conn):
-    """Insert a devbrain.memory row directly (bypassing the MCP server)."""
+    """Insert a devbrain.memory row directly (bypassing the MCP server).
+
+    Optional kwargs `tier`, `strength`, `compliance_profiles` (Atlas
+    Step 7a) set those columns at insert time when non-None — older
+    postulates that don't pass them get the table defaults.
+    """
     def make(
         project_id: str,
         *,
@@ -142,17 +171,80 @@ def memory_factory(conn):
         title: str | None = None,
         content: str | None = None,
         provenance_id: str | None = None,
+        tier: str | None = None,
+        strength: float | None = None,
+        compliance_profiles: list[str] | None = None,
     ) -> dict:
         title = title or f"{TEST_TAG}title_{uuid.uuid4().hex[:6]}"
         content = content or f"{TEST_TAG}body_{uuid.uuid4().hex[:6]}"
+
+        cols = ["project_id", "kind", "title", "content", "provenance_id"]
+        vals: list = [project_id, kind, title, content, provenance_id]
+        if tier is not None:
+            cols.append("tier")
+            vals.append(tier)
+        if strength is not None:
+            cols.append("strength")
+            vals.append(strength)
+        if compliance_profiles is not None:
+            cols.append("compliance_profiles")
+            vals.append(compliance_profiles)
+
+        placeholders = ", ".join(["%s"] * len(cols))
         with conn.cursor() as cur:
             cur.execute(
-                "INSERT INTO devbrain.memory (project_id, kind, title, content, provenance_id) "
-                "VALUES (%s, %s, %s, %s, %s) RETURNING id",
-                (project_id, kind, title, content, provenance_id),
+                f"INSERT INTO devbrain.memory ({', '.join(cols)}) "
+                f"VALUES ({placeholders}) RETURNING id",
+                vals,
             )
             row = cur.fetchone()
         conn.commit()
-        return {"id": row[0], "title": title, "content": content, "kind": kind}
+        return {
+            "id": row[0],
+            "title": title,
+            "content": content,
+            "kind": kind,
+            "tier": tier or "memory",
+        }
 
     return make
+
+
+@pytest.fixture
+def factory_job_factory(conn):
+    """Insert a devbrain.factory_jobs row.
+
+    Cleanup happens at fixture teardown — required because the brief
+    generator opens its own cursor and SELECTs on committed state, so
+    the insert is committed up-front and the conn fixture's rollback
+    won't undo it.
+    """
+    created: list = []
+
+    def make(project_id, spec: str = "test", status: str = "queued",
+             title: str | None = None) -> dict:
+        title = title or f"{TEST_TAG}job_{uuid.uuid4().hex[:6]}"
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.factory_jobs "
+                "(project_id, title, spec, status) "
+                "VALUES (%s, %s, %s, %s) "
+                "RETURNING id, project_id, title, spec, status",
+                (project_id, title, spec, status),
+            )
+            cols = [d[0] for d in cur.description]
+            row = dict(zip(cols, cur.fetchone()))
+        conn.commit()
+        created.append(row["id"])
+        return row
+
+    yield make
+
+    if created:
+        conn.rollback()
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM devbrain.factory_jobs WHERE id = ANY(%s)",
+                (created,),
+            )
+        conn.commit()

--- a/tests/postulates/test_p6_empty_profiles_excludes.py
+++ b/tests/postulates/test_p6_empty_profiles_excludes.py
@@ -1,0 +1,59 @@
+"""P6 — Rules with empty compliance_profiles are NOT included in any project's brief.
+
+POSTULATE
+---------
+A tier='rule' row with compliance_profiles = NULL or [] does NOT appear in
+any project's curator brief.rules — explicit opt-in semantics. Projects
+only get rules they tagged for.
+
+This is one of two verification gates for Phase 7a (the other is P7).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# The postulate suite runs from repo root; the curator module lives under
+# factory/. Add factory/ to sys.path so the import resolves regardless of
+# where pytest is invoked from.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "factory"))
+
+from curator.brief import generate_brief  # noqa: E402
+
+
+def test_null_compliance_profiles_excluded_from_brief(
+    conn, project_factory, memory_factory, factory_job_factory
+):
+    project = project_factory("p6_null", compliance_profiles_enabled=["hipaa"])
+    rule_null = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        content="rule with NULL profiles",
+    )
+    # NULL profiles by default — memory_factory doesn't set compliance_profiles
+    job = factory_job_factory(project["id"], spec="anything")
+
+    brief = generate_brief(conn, job["id"], project["id"], job["spec"])
+
+    assert rule_null["id"] not in {r.id for r in brief.rules}
+
+
+def test_empty_compliance_profiles_excluded_from_brief(
+    conn, project_factory, memory_factory, factory_job_factory
+):
+    project = project_factory("p6_empty", compliance_profiles_enabled=["hipaa"])
+    rule_empty = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        content="rule with empty profiles",
+    )
+    # Explicitly set to empty array
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET compliance_profiles = '{}' WHERE id = %s",
+            (rule_empty["id"],),
+        )
+    conn.commit()
+    job = factory_job_factory(project["id"], spec="anything")
+
+    brief = generate_brief(conn, job["id"], project["id"], job["spec"])
+
+    assert rule_empty["id"] not in {r.id for r in brief.rules}

--- a/tests/postulates/test_p7_profile_intersection.py
+++ b/tests/postulates/test_p7_profile_intersection.py
@@ -1,0 +1,63 @@
+"""P7 — Profile intersection: project enabling 'hipaa' sees only HIPAA-tagged rules.
+
+POSTULATE
+---------
+The curator brief's `rules` section for a project is the set of memories
+where tier='rule' AND archived_at IS NULL AND
+compliance_profiles && project.compliance_profiles_enabled.
+
+This is one of two verification gates for Phase 7a (the other is P6).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# The postulate suite runs from repo root; the curator module lives under
+# factory/. Add factory/ to sys.path so the import resolves regardless of
+# where pytest is invoked from.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "factory"))
+
+from curator.brief import generate_brief  # noqa: E402
+
+
+def test_brief_filters_by_profile_intersection(
+    conn, project_factory, memory_factory, factory_job_factory
+):
+    project = project_factory("p7", compliance_profiles_enabled=["hipaa"])
+
+    rule_hipaa = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        content="HIPAA-only rule",
+    )
+    rule_soc2 = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        content="SOC2-only rule",
+    )
+    rule_both = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        content="Both HIPAA and SOC2",
+    )
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET compliance_profiles = %s WHERE id = %s",
+            (["hipaa"], rule_hipaa["id"]),
+        )
+        cur.execute(
+            "UPDATE devbrain.memory SET compliance_profiles = %s WHERE id = %s",
+            (["soc2"], rule_soc2["id"]),
+        )
+        cur.execute(
+            "UPDATE devbrain.memory SET compliance_profiles = %s WHERE id = %s",
+            (["hipaa", "soc2"], rule_both["id"]),
+        )
+    conn.commit()
+
+    job = factory_job_factory(project["id"], spec="touches phi_log.py")
+    brief = generate_brief(conn, job["id"], project["id"], job["spec"])
+
+    rule_ids = {r.id for r in brief.rules}
+    assert rule_hipaa["id"] in rule_ids
+    assert rule_soc2["id"] not in rule_ids
+    assert rule_both["id"] in rule_ids


### PR DESCRIPTION
## Summary

Phase 7a of Atlas Step 7 — substrate for per-project compliance profile filtering.

- **Migration 022** adds `devbrain.memory.compliance_profiles TEXT[]` (rules opt-in to one or more profiles) + `devbrain.projects.compliance_profiles_enabled TEXT[]` (projects opt into specific profiles) + a partial GIN index `idx_memory_compliance_profiles_gin` on the rules hot-path. Schema-assertion tests in `factory/tests/test_migration_022.py` guard column types and the index predicate.
- **P6 (empty profiles excluded)** + **P7 (profile intersection)** postulates verify the explicit-opt-in semantics of `compliance_profiles` and the intersection contract for the curator brief's `rules` section.
- **`test_brief_filters_by_compliance_profiles`** (deferred from Phase 5d) is re-enabled and passing — `brief.py:_load_rules` already had the if-profiles-present branch from 5d's graceful-fallback, and now `_load_enabled_profiles` returns real data.
- All **prior postulates still pass** (13 -> 16 total in `tests/postulates/`).

Phase 7a is substrate-only. The graceful-fallback in `brief.py` stays — Phase 7b drops it. The rules lint CLI (Phase 7b) and rule seeding (Phase 7c) are out of scope.

## Test plan

- [x] Migration 022 applies cleanly + ledger backfilled in local devbrain-db (and idempotent: re-running is a no-op via `IF NOT EXISTS`).
- [x] 4 schema-assertion tests in `factory/tests/test_migration_022.py` pass.
- [x] `test_brief_filters_by_compliance_profiles` un-skipped + passes.
- [x] Other 4 brief tests still pass.
- [x] P6 + P7 PASS (not xfail/skip): `tests/postulates/test_p6_empty_profiles_excludes.py` (2 tests) + `tests/postulates/test_p7_profile_intersection.py` (1 test).
- [x] All 13 prior postulate tests still pass — full `tests/postulates/` run = 16 PASSED.
- [x] Full factory DB suite green: 69 PASSED.
- [ ] CI green on the PR (DB-available pytest workflow exercises the migration + postulates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)