### PR TITLE
feat(curator): Atlas Step 7b — filter activation + rules lint CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,19 @@ jobs:
             psql -h localhost -p 5432 -U devbrain -d devbrain -v ON_ERROR_STOP=1 -f "$f"
           done
 
+      - name: Lint compliance rules (devbrain rules lint)
+        # Atlas Step 7b: every profile-tagged rule must ship with a
+        # matching postulate test. The lint runs against the empty CI
+        # database (no rules seeded yet) and exits 0 — once Phase 7c
+        # seeds rules, missing postulates will fail this step before
+        # pytest runs, surfacing the gap quickly.
+        # config.py reads DEVBRAIN_DATABASE_URL when set (short-circuits
+        # the yaml lookup), so that single env var is all the lint needs.
+        env:
+          DEVBRAIN_DATABASE_URL: postgresql://devbrain:devbrain-ci@localhost:5432/devbrain
+        run: |
+          cd factory && python -m curator.rules_lint
+
       - name: Run postulates (rootdir = repo root)
         # Conftest gates on DEVBRAIN_DB_PASSWORD and reads
         # DEVBRAIN_DB_HOST_PORT (not DEVBRAIN_DB_PORT) — see

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2784,5 +2784,31 @@ def cmd_queue_stuck():
         )
 
 
+# ---------------------------------------------------------------------------
+# Compliance-rule subcommands — the lint check enforces that every
+# profile-tagged rule ships with a postulate test (Atlas Step 7b).
+# ---------------------------------------------------------------------------
+
+@cli.group()
+def rules():
+    """Compliance rule operations."""
+
+
+@rules.command("lint")
+def cmd_rules_lint():
+    """Verify every profile-tagged rule has a matching postulate test.
+
+    A rule is "profile-tagged" if its compliance_profiles array is
+    non-empty. The lint heuristic: scan tests/postulates/*.py for either
+    the rule's UUID or a slugified title token. Exits 1 if any tagged
+    rule has no matching postulate, 0 otherwise.
+    """
+    from curator.rules_lint import run_lint
+
+    db = get_db()
+    with db._conn() as conn:
+        sys.exit(run_lint(conn))
+
+
 if __name__ == "__main__":
     cli()

--- a/factory/curator/brief.py
+++ b/factory/curator/brief.py
@@ -4,10 +4,12 @@ Synchronous; called from FactoryDB.transition() at the QUEUED -> PLANNING
 edge. Pure filtering + ranking — no LLM in v3.0. Could become LLM-driven
 later without breaking the CuratorBrief v1.0 contract.
 
-Profile filtering depends on the compliance_profiles columns shipped in
-Step 7. Until then, all tier='rule' rows are loaded (no profile filter)
-— the SELECT is wrapped in try/except + rollback so the same code keeps
-working before and after the column ships.
+Profile filtering uses the compliance_profiles columns shipped in
+Step 7a (migration 022). Semantics are explicit opt-in:
+- Project with empty/NULL compliance_profiles_enabled => NO rules apply.
+- Rule with empty/NULL compliance_profiles is invisible to all projects.
+- A rule appears in a project's brief iff
+  rule.compliance_profiles && project.compliance_profiles_enabled.
 """
 from __future__ import annotations
 
@@ -32,10 +34,7 @@ def generate_brief(
     """Generate a CuratorBrief and persist to factory_jobs.curator_brief.
 
     The conn must already be in a clean state (no aborted transaction).
-    On success the brief is committed via _persist_to_job. On any
-    SELECT-level failure caused by missing Step 7 columns, the function
-    rolls back the failed query and falls through to a no-filter SELECT
-    so the rest of the brief still builds.
+    On success the brief is committed via _persist_to_job.
     """
     profiles = _load_enabled_profiles(conn, project_id)
     rules = _load_rules(conn, project_id, profiles)
@@ -59,40 +58,37 @@ def generate_brief(
 
 
 def _load_enabled_profiles(conn, project_id) -> list[str]:
-    """Step 7 column. Returns [] if column doesn't exist yet."""
+    """Return the project's enabled compliance profiles, or [] if NULL/absent."""
     with conn.cursor() as cur:
-        try:
-            cur.execute(
-                "SELECT compliance_profiles_enabled FROM devbrain.projects "
-                "WHERE id = %s",
-                (project_id,),
-            )
-            row = cur.fetchone()
-            return list(row[0] or []) if row and row[0] else []
-        except Exception:
-            conn.rollback()
+        cur.execute(
+            "SELECT compliance_profiles_enabled FROM devbrain.projects "
+            "WHERE id = %s",
+            (project_id,),
+        )
+        row = cur.fetchone()
+        if not row:
             return []
+        return list(row[0] or [])
 
 
 def _load_rules(conn, project_id, profiles) -> list[MemoryRef]:
-    """Filter by profile intersection if Step 7 column exists; else all rules."""
-    base = (
-        "SELECT id, kind, title, content, tier, strength, last_cascade_at "
-        "FROM devbrain.memory "
-        "WHERE project_id = %s AND tier = 'rule' AND archived_at IS NULL"
-    )
+    """Filter rules by compliance-profile intersection.
+
+    Per P6 semantics: a project with no enabled profiles gets NO rules.
+    Per P7 semantics: rules surface iff their compliance_profiles
+    overlaps the project's compliance_profiles_enabled.
+    """
+    if not profiles:
+        return []
     with conn.cursor() as cur:
-        if profiles:
-            try:
-                cur.execute(
-                    base + " AND compliance_profiles && %s "
-                    "ORDER BY strength DESC",
-                    (project_id, profiles),
-                )
-                return [_to_ref(row) for row in cur.fetchall()]
-            except Exception:
-                conn.rollback()
-        cur.execute(base + " ORDER BY strength DESC", (project_id,))
+        cur.execute(
+            "SELECT id, kind, title, content, tier, strength, last_cascade_at "
+            "FROM devbrain.memory "
+            "WHERE project_id = %s AND tier = 'rule' AND archived_at IS NULL "
+            "  AND compliance_profiles && %s::text[] "
+            "ORDER BY strength DESC",
+            (project_id, profiles),
+        )
         return [_to_ref(row) for row in cur.fetchall()]
 
 

--- a/factory/curator/rules_lint.py
+++ b/factory/curator/rules_lint.py
@@ -1,0 +1,165 @@
+"""Lint compliance-profile-tagged rules.
+
+Contract enforced
+-----------------
+Every devbrain.memory row with tier='rule' AND non-empty
+compliance_profiles MUST ship with a postulate test in
+tests/postulates/ that mentions either:
+  - the rule's UUID (string form), or
+  - a slugified version of its title.
+
+Rationale: profile-tagged rules are auto-applied by the curator brief
+to projects that enable matching profiles (P7). Auto-application
+without a verification gate lets a buggy or stale rule silently
+contaminate downstream agents. The postulate is the gate.
+
+The discovery here is a heuristic — it doesn't prove the postulate
+verifies the right thing, only that *some* postulate file references
+the rule. Phase 3.x can replace it with a structured rule->postulate
+mapping (e.g., a rule_postulates table or a metadata field on the
+rule). Until then, "the postulate file mentions the rule" is the
+contract.
+
+Public API
+----------
+- find_unverified_rules(conn) -> list[UnverifiedRule]
+- run_lint(conn) -> int  # exit code, 0 if clean, 1 if violations
+
+CLI entry: `python -m curator.rules_lint`
+"""
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+
+# Path to postulates dir — resolved relative to this module's repo location.
+# factory/curator/rules_lint.py -> ../../tests/postulates
+_POSTULATES_DIR = Path(__file__).parent.parent.parent / "tests" / "postulates"
+
+
+@dataclass(frozen=True)
+class UnverifiedRule:
+    """A profile-tagged rule with no matching postulate test."""
+
+    id: UUID
+    title: str
+    compliance_profiles: list[str]
+
+
+def find_unverified_rules(conn: Any) -> list[UnverifiedRule]:
+    """Return profile-tagged rules with no matching postulate test."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, title, compliance_profiles "
+            "FROM devbrain.memory "
+            "WHERE tier = 'rule' "
+            "  AND compliance_profiles IS NOT NULL "
+            "  AND array_length(compliance_profiles, 1) > 0 "
+            "  AND archived_at IS NULL"
+        )
+        rows = cur.fetchall()
+
+    if not rows:
+        return []
+
+    postulate_corpus = _read_postulates_corpus()
+    unverified: list[UnverifiedRule] = []
+    for rule_id, title, profiles in rows:
+        if _has_matching_postulate(rule_id, title, postulate_corpus):
+            continue
+        unverified.append(
+            UnverifiedRule(
+                id=rule_id,
+                title=title,
+                compliance_profiles=list(profiles),
+            )
+        )
+    return unverified
+
+
+def run_lint(conn: Any) -> int:
+    """CLI entry point. Exit 0 if clean, 1 if violations found."""
+    unverified = find_unverified_rules(conn)
+    if not unverified:
+        print("[rules lint] All profile-tagged rules have postulate tests. OK")
+        return 0
+
+    print(
+        f"[rules lint] Found {len(unverified)} profile-tagged rules without "
+        f"matching postulate tests:",
+        file=sys.stderr,
+    )
+    for r in unverified:
+        print(
+            f"  - {r.id}  profiles={r.compliance_profiles}  "
+            f"title={r.title!r}",
+            file=sys.stderr,
+        )
+    print(
+        "\nEvery rule with non-empty compliance_profiles MUST ship with a "
+        "postulate test in tests/postulates/ that references either the "
+        "rule's UUID or a slugified version of its title.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _read_postulates_corpus() -> str:
+    """Concatenate all postulate test source for heuristic matching."""
+    if not _POSTULATES_DIR.exists():
+        return ""
+    chunks: list[str] = []
+    for path in _POSTULATES_DIR.rglob("test_*.py"):
+        try:
+            chunks.append(path.read_text())
+        except Exception:  # noqa: BLE001
+            continue
+    return "\n".join(chunks)
+
+
+def _has_matching_postulate(rule_id: UUID, title: str, corpus: str) -> bool:
+    """Check whether the corpus references the rule by UUID or title slug."""
+    if str(rule_id) in corpus:
+        return True
+    slug = _slugify(title)
+    if not slug:
+        return False
+    return slug in corpus
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(text: str) -> str:
+    """Lowercase + collapse non-alphanumerics to underscore.
+
+    Used to derive a human-readable token from a rule title for
+    postulate-corpus search. Title `"PHI must not appear in unstructured
+    logs"` -> `phi_must_not_appear_in_unstructured_logs`.
+    """
+    return _SLUG_RE.sub("_", text.lower()).strip("_")
+
+
+def main() -> None:
+    """Module entry point: ``python -m curator.rules_lint``.
+
+    Lazy-imports state_machine so that the lint check can run before the
+    full factory CLI parser loads. Uses FactoryDB._conn() (the project's
+    canonical psycopg2-connection helper) — the same pattern Phase 5c's
+    `curator queue-stuck` uses.
+    """
+    from config import DATABASE_URL
+    from state_machine import FactoryDB
+
+    db = FactoryDB(DATABASE_URL)
+    with db._conn() as conn:
+        sys.exit(run_lint(conn))
+
+
+if __name__ == "__main__":
+    main()

--- a/factory/tests/test_curator_rules_lint.py
+++ b/factory/tests/test_curator_rules_lint.py
@@ -1,0 +1,251 @@
+"""Tests for curator.rules_lint — postulate-coverage enforcement.
+
+Strategy
+--------
+The lint reads tests/postulates/*.py for its corpus. Tests use
+`monkeypatch` to redirect _POSTULATES_DIR to a tmp dir so the test
+harness fully controls the corpus. This avoids false positives from
+the real postulate suite and false negatives from rules whose titles
+happen to collide with real postulate words.
+
+DB-touching tests are gated on @pytest.mark.db; the slugify helper
+test runs without a DB.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from curator import rules_lint
+
+
+# ---------------------------------------------------------------------------
+# Pure helper tests (no DB).
+# ---------------------------------------------------------------------------
+
+def test_slugify():
+    assert rules_lint._slugify("PHI must not appear in unstructured logs") == (
+        "phi_must_not_appear_in_unstructured_logs"
+    )
+    assert rules_lint._slugify("HIPAA: log scrubbing") == "hipaa_log_scrubbing"
+    assert rules_lint._slugify("  leading & trailing  ") == "leading_trailing"
+    assert rules_lint._slugify("") == ""
+    assert rules_lint._slugify("   ") == ""
+    # Unicode characters that aren't ASCII alphanumerics get collapsed too.
+    assert rules_lint._slugify("rule—em-dash") == "rule_em_dash"
+
+
+# ---------------------------------------------------------------------------
+# DB tests — exercise the SELECT + corpus-matching logic end-to-end.
+# ---------------------------------------------------------------------------
+
+def _seed_postulate(tmp_dir, name: str, body: str) -> None:
+    """Write a fake postulate file under tmp_dir."""
+    p = tmp_dir / f"test_{name}.py"
+    p.write_text(body)
+
+
+def _redirect_postulates_dir(monkeypatch, tmp_path):
+    """Point the lint at a tmp postulates dir for hermetic testing."""
+    monkeypatch.setattr(rules_lint, "_POSTULATES_DIR", tmp_path)
+
+
+@pytest.mark.db
+def test_no_rules_returns_empty(conn, monkeypatch, tmp_path):
+    """Clean DB (no profile-tagged rules) -> empty list."""
+    _redirect_postulates_dir(monkeypatch, tmp_path)
+    assert rules_lint.find_unverified_rules(conn) == []
+
+
+@pytest.mark.db
+def test_rule_with_uuid_in_postulate_passes(
+    conn, project_factory, memory_factory, monkeypatch, tmp_path
+):
+    """A postulate that names the rule's UUID counts as verified."""
+    project = project_factory("rl_uuid")
+    rule = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        content="HIPAA log scrubbing rule",
+        compliance_profiles=["hipaa"],
+    )
+    _seed_postulate(
+        tmp_path,
+        "rl_uuid_match",
+        f"# this postulate verifies rule {rule['id']}\n",
+    )
+    _redirect_postulates_dir(monkeypatch, tmp_path)
+
+    assert rules_lint.find_unverified_rules(conn) == []
+
+
+@pytest.mark.db
+def test_rule_with_title_slug_in_postulate_passes(
+    conn, project_factory, memory_factory, monkeypatch, tmp_path
+):
+    """A postulate referencing the slugified title counts as verified."""
+    project = project_factory("rl_slug")
+    title = "PHI must not appear in unstructured logs"
+    memory_factory(
+        project["id"], kind="decision", tier="rule",
+        title=title, content="rule body",
+        compliance_profiles=["hipaa"],
+    )
+    _seed_postulate(
+        tmp_path,
+        "rl_slug_match",
+        "def test_phi_must_not_appear_in_unstructured_logs():\n    pass\n",
+    )
+    _redirect_postulates_dir(monkeypatch, tmp_path)
+
+    assert rules_lint.find_unverified_rules(conn) == []
+
+
+@pytest.mark.db
+def test_rule_without_postulate_fails(
+    conn, project_factory, memory_factory, monkeypatch, tmp_path
+):
+    """A profile-tagged rule with no matching postulate is flagged."""
+    project = project_factory("rl_miss")
+    # Use a deliberately-unique title so even an empty-corpus accident
+    # won't produce a false negative via substring overlap.
+    unique = uuid.uuid4().hex
+    rule = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        title=f"unverified_rule_{unique}",
+        content="missing postulate",
+        compliance_profiles=["hipaa"],
+    )
+    _seed_postulate(tmp_path, "unrelated", "# nothing relevant here\n")
+    _redirect_postulates_dir(monkeypatch, tmp_path)
+
+    unverified = rules_lint.find_unverified_rules(conn)
+    flagged_ids = {r.id for r in unverified}
+    assert rule["id"] in flagged_ids
+
+
+@pytest.mark.db
+def test_empty_profiles_rule_skipped(
+    conn, project_factory, memory_factory, monkeypatch, tmp_path
+):
+    """Rules with empty/NULL compliance_profiles are not subject to lint
+    (they're invisible by P6 anyway — no enforcement needed)."""
+    project = project_factory("rl_emptyprof")
+    # No compliance_profiles kwarg -> column stays NULL.
+    memory_factory(
+        project["id"], kind="decision", tier="rule",
+        content="rule with no profiles",
+    )
+    _redirect_postulates_dir(monkeypatch, tmp_path)
+    # No matching postulate exists, but lint should not flag.
+    assert rules_lint.find_unverified_rules(conn) == []
+
+
+@pytest.mark.db
+def test_archived_rule_skipped(
+    conn, project_factory, memory_factory, monkeypatch, tmp_path
+):
+    """Archived rules don't surface in any brief, so no postulate needed."""
+    project = project_factory("rl_archived")
+    rule = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        content="archived hipaa rule",
+        compliance_profiles=["hipaa"],
+    )
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET archived_at = NOW() WHERE id = %s",
+            (rule["id"],),
+        )
+    conn.commit()
+    _redirect_postulates_dir(monkeypatch, tmp_path)
+
+    assert rules_lint.find_unverified_rules(conn) == []
+
+
+@pytest.mark.db
+def test_run_lint_exit_code_clean(conn, monkeypatch, tmp_path, capsys):
+    _redirect_postulates_dir(monkeypatch, tmp_path)
+    rc = rules_lint.run_lint(conn)
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "OK" in captured.out
+
+
+@pytest.mark.db
+def test_run_lint_exit_code_violations(
+    conn, project_factory, memory_factory, monkeypatch, tmp_path, capsys
+):
+    project = project_factory("rl_violation")
+    unique = uuid.uuid4().hex
+    rule = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        title=f"violating_rule_{unique}",
+        content="needs postulate",
+        compliance_profiles=["hipaa"],
+    )
+    _redirect_postulates_dir(monkeypatch, tmp_path)
+    rc = rules_lint.run_lint(conn)
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert str(rule["id"]) in captured.err
+    assert "hipaa" in captured.err
+
+
+@pytest.mark.db
+def test_unverified_rule_has_full_payload(
+    conn, project_factory, memory_factory, monkeypatch, tmp_path
+):
+    """The UnverifiedRule dataclass carries id, title, profiles."""
+    project = project_factory("rl_payload")
+    unique = uuid.uuid4().hex
+    title = f"payload_rule_{unique}"
+    rule = memory_factory(
+        project["id"], kind="decision", tier="rule",
+        title=title, content="x",
+        compliance_profiles=["hipaa", "soc2"],
+    )
+    _redirect_postulates_dir(monkeypatch, tmp_path)
+    unverified = rules_lint.find_unverified_rules(conn)
+    target = next((r for r in unverified if r.id == rule["id"]), None)
+    assert target is not None
+    assert target.title == title
+    assert set(target.compliance_profiles) == {"hipaa", "soc2"}
+
+
+def test_read_corpus_missing_dir(monkeypatch, tmp_path):
+    """If _POSTULATES_DIR doesn't exist, _read_postulates_corpus returns ''."""
+    monkeypatch.setattr(rules_lint, "_POSTULATES_DIR", tmp_path / "nope")
+    assert rules_lint._read_postulates_corpus() == ""
+
+
+def test_read_corpus_unreadable_file_skipped(monkeypatch, tmp_path):
+    """If a candidate file errors on read_text, the lint silently skips it
+    rather than aborting — keeps a single bad file from masking real
+    violations elsewhere."""
+    good = tmp_path / "test_good.py"
+    good.write_text("good content")
+    bad = tmp_path / "test_bad.py"
+    bad.write_text("bad content")
+
+    real_read_text = type(bad).read_text
+
+    def stub_read_text(self, *args, **kwargs):
+        if self.name == "test_bad.py":
+            raise OSError("simulated read failure")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(type(bad), "read_text", stub_read_text)
+    monkeypatch.setattr(rules_lint, "_POSTULATES_DIR", tmp_path)
+
+    corpus = rules_lint._read_postulates_corpus()
+    assert "good content" in corpus
+    assert "bad content" not in corpus
+
+
+def test_has_matching_postulate_empty_title():
+    """_has_matching_postulate returns False for an empty title with no
+    UUID hit (slug becomes '', which would otherwise match every corpus)."""
+    rid = uuid.uuid4()
+    assert rules_lint._has_matching_postulate(rid, "", "anything") is False
+    assert rules_lint._has_matching_postulate(rid, "   ", "anything") is False

--- a/tests/postulates/test_p2_archived_excluded.py
+++ b/tests/postulates/test_p2_archived_excluded.py
@@ -28,7 +28,12 @@ from curator.brief import generate_brief  # noqa: E402
 def test_archived_memory_not_in_curator_brief(
     conn, project_factory, memory_factory
 ):
-    project = project_factory("p2")
+    # Step 7 semantics: a rule only surfaces if the project enables a
+    # matching compliance profile. Tag the project + rules so the live
+    # rule is reachable (the archived rule is the actual subject of the
+    # postulate, but we need a positive control so the assertion is
+    # meaningful).
+    project = project_factory("p2", compliance_profiles_enabled=["hipaa"])
 
     # Live memory + lesson + rule — every section the brief surfaces.
     live_decision = memory_factory(
@@ -66,17 +71,19 @@ def test_archived_memory_not_in_curator_brief(
         stale_lesson_id = cur.fetchone()[0]
         cur.execute(
             "INSERT INTO devbrain.memory "
-            "(project_id, kind, title, content, tier) "
-            "VALUES (%s, 'decision', 'live-rule', 'live rule', 'rule') "
+            "(project_id, kind, title, content, tier, compliance_profiles) "
+            "VALUES (%s, 'decision', 'live-rule', 'live rule', 'rule', "
+            "        ARRAY['hipaa']) "
             "RETURNING id",
             (project["id"],),
         )
         live_rule_id = cur.fetchone()[0]
         cur.execute(
             "INSERT INTO devbrain.memory "
-            "(project_id, kind, title, content, tier, archived_at) "
+            "(project_id, kind, title, content, tier, compliance_profiles, "
+            "        archived_at) "
             "VALUES (%s, 'decision', 'stale-rule', 'stale rule', 'rule', "
-            "        now()) "
+            "        ARRAY['hipaa'], now()) "
             "RETURNING id",
             (project["id"],),
         )


### PR DESCRIPTION
## Summary

Phase 7b of the Atlas Step 7 rule engine plan. Three commits:

- **`refactor(curator)`** — drop the dead try/except graceful-fallback in `brief.py`. With migration 022 (Phase 7a) shipped, `compliance_profiles_enabled` and `compliance_profiles` are guaranteed to exist. The fallback also accidentally inverted P6 (no enabled profiles surfaced ALL rules); the simplified `_load_rules` returns `[]` in that case, the correct opt-in semantic.
- **`feat(curator)`** — `devbrain rules lint` enforces "every profile-tagged rule MUST have a postulate test". Heuristic: scan `tests/postulates/` for the rule's UUID or a slugified title. Phase 3.x can replace with structured mapping; this is the v3.0 gate.
- **`ci(tests)`** — pytest-db job runs the lint before postulates, against the empty pre-7c DB (exits 0). Once Phase 7c seeds rules, missing postulates fail this step early.

## Changes

| File | What |
| --- | --- |
| `factory/curator/brief.py` | Drop try/except + fix P6 semantic |
| `factory/curator/rules_lint.py` (NEW) | `find_unverified_rules`, `run_lint`, `python -m` entry |
| `factory/cli.py` | `devbrain rules lint` subcommand (mirrors `curator queue-stuck` shape) |
| `factory/tests/test_curator_rules_lint.py` (NEW) | 13 tests, 91% coverage on `rules_lint.py` |
| `tests/postulates/test_p2_archived_excluded.py` | Opt project + live rule into HIPAA so positive control survives Step 7 semantics |
| `.github/workflows/test.yml` | New "Lint compliance rules" step in `pytest-db` job |

## Test plan

- [x] `pytest tests/postulates/` — 16/16 pass (P1-P7 + the unnumbered ones)
- [x] `pytest factory/tests/` (DB-marked subset) — 154/154 pass
- [x] `pytest factory/tests/test_curator_rules_lint.py` — 13/13 pass
- [x] Coverage on `factory/curator/rules_lint.py` = 91% (gate ≥85%)
- [x] `python -m curator.rules_lint` smoke-tested locally (clean DB → exit 0)
- [x] `devbrain rules lint` smoke-tested via Click CLI

## Self-review notes

- The P2 fixture change is load-bearing: under the corrected rule semantics, P2's positive control ("live rule appears in brief") only holds when project + rule share a profile. Documented inline.
- Coverage gap is `main()` and the `if __name__` block — exercised in CI but hard to drive in pytest without subprocess.
- Heuristic match is intentional v3.0 scope. A rule's UUID or title-slug appearing anywhere in `tests/postulates/*.py` counts. Phase 3.x can swap for structured rule→postulate mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)