### PR TITLE
feat(curator): cross-project rule surfacing — canonical devbrain rules apply to enabled projects

### DIFF
--- a/factory/curator/brief.py
+++ b/factory/curator/brief.py
@@ -10,6 +10,15 @@ Step 7a (migration 022). Semantics are explicit opt-in:
 - Rule with empty/NULL compliance_profiles is invisible to all projects.
 - A rule appears in a project's brief iff
   rule.compliance_profiles && project.compliance_profiles_enabled.
+
+Rules are sourced from two project namespaces (intentional narrow
+exception to P3 same-project isolation):
+- The target project_id (project-local custom rules).
+- The canonical 'devbrain' project (shared regulatory library — where
+  migration 023 seeds the HIPAA/SOC2/FERPA rule library).
+Lessons, decisions, and cascade signals remain strictly project-local;
+only rule rows cross the project boundary, and only when the target
+project has explicitly opted in via compliance_profiles_enabled.
 """
 from __future__ import annotations
 
@@ -77,17 +86,28 @@ def _load_rules(conn, project_id, profiles) -> list[MemoryRef]:
     Per P6 semantics: a project with no enabled profiles gets NO rules.
     Per P7 semantics: rules surface iff their compliance_profiles
     overlaps the project's compliance_profiles_enabled.
+    Per P_cross_project_rules: rules in the canonical 'devbrain' project
+    are treated as a shared regulatory library and surface in any
+    project's brief when the profile intersection holds.
     """
     if not profiles:
         return []
     with conn.cursor() as cur:
         cur.execute(
+            "SELECT id FROM devbrain.projects WHERE slug = 'devbrain'"
+        )
+        canonical_row = cur.fetchone()
+        project_ids: list = [project_id]
+        if canonical_row and canonical_row[0] != project_id:
+            project_ids.append(canonical_row[0])
+        cur.execute(
             "SELECT id, kind, title, content, tier, strength, last_cascade_at "
             "FROM devbrain.memory "
-            "WHERE project_id = %s AND tier = 'rule' AND archived_at IS NULL "
+            "WHERE project_id = ANY(%s) "
+            "  AND tier = 'rule' AND archived_at IS NULL "
             "  AND compliance_profiles && %s::text[] "
             "ORDER BY strength DESC",
-            (project_id, profiles),
+            (project_ids, profiles),
         )
         return [_to_ref(row) for row in cur.fetchall()]
 

--- a/tests/postulates/test_p_cross_project_rules.py
+++ b/tests/postulates/test_p_cross_project_rules.py
@@ -1,0 +1,157 @@
+"""P_cross_project_rules — Rules in the canonical 'devbrain' project surface
+across project boundaries when the profile intersection holds.
+
+POSTULATE
+---------
+A tier='rule' row stored under the canonical 'devbrain' project (the
+seeded regulatory library; see migration 023) appears in a non-devbrain
+project's curator brief when both:
+  1. the target project has compliance_profiles_enabled overlapping the
+     rule's compliance_profiles, and
+  2. the rule is not archived.
+
+This is the narrow, deliberate exception to P3's same-project memory
+isolation invariant. It is restricted to rules with non-empty
+compliance_profiles and to the single canonical 'devbrain' project_id;
+no other cross-project surface is permitted by this postulate. Lessons,
+decisions, and cascade signals remain project-local.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "factory"))
+
+from curator.brief import generate_brief  # noqa: E402
+
+
+def _canonical_devbrain_project_id(conn):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.projects WHERE slug = 'devbrain'"
+        )
+        row = cur.fetchone()
+    assert row is not None, (
+        "canonical 'devbrain' project must exist — fresh installs should "
+        "have it from migration 001 + slug seeding"
+    )
+    return row[0]
+
+
+def _drop_memory(conn, memory_id):
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM devbrain.memory_ledger WHERE memory_id = %s",
+            (memory_id,),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.memory WHERE id = %s", (memory_id,)
+        )
+    conn.commit()
+
+
+def test_canonical_devbrain_rules_surface_in_other_project_brief(
+    conn, memory_factory, project_factory, factory_job_factory
+):
+    """A HIPAA rule seeded under the canonical 'devbrain' project must
+    appear in a non-canonical project's brief when that project enables
+    'hipaa'."""
+    canonical_id = _canonical_devbrain_project_id(conn)
+    library_rule = memory_factory(
+        canonical_id, kind="decision", tier="rule",
+        content="cross-project library rule",
+        compliance_profiles=["hipaa"],
+    )
+    try:
+        target = project_factory(
+            "cross_target", compliance_profiles_enabled=["hipaa"]
+        )
+        job = factory_job_factory(target["id"], spec="touches phi_log.py")
+        brief = generate_brief(conn, job["id"], target["id"], job["spec"])
+
+        rule_ids = {r.id for r in brief.rules}
+        assert library_rule["id"] in rule_ids, (
+            "canonical-project HIPAA rule must surface in a project that "
+            "enables 'hipaa'"
+        )
+    finally:
+        _drop_memory(conn, library_rule["id"])
+
+
+def test_canonical_devbrain_rules_filtered_by_profile(
+    conn, memory_factory, project_factory, factory_job_factory
+):
+    """A SOC2-only rule in the canonical project does NOT surface in a
+    project that only enables 'hipaa'. Cross-project surfacing still
+    respects the compliance_profiles intersection."""
+    canonical_id = _canonical_devbrain_project_id(conn)
+    soc2_rule = memory_factory(
+        canonical_id, kind="decision", tier="rule",
+        content="canonical SOC2 rule",
+        compliance_profiles=["soc2"],
+    )
+    try:
+        target = project_factory(
+            "cross_filter", compliance_profiles_enabled=["hipaa"]
+        )
+        job = factory_job_factory(target["id"], spec="anything")
+        brief = generate_brief(conn, job["id"], target["id"], job["spec"])
+
+        rule_ids = {r.id for r in brief.rules}
+        assert soc2_rule["id"] not in rule_ids, (
+            "SOC2-tagged rule must not surface for a project that only "
+            "enabled 'hipaa', even when the rule lives in the canonical project"
+        )
+    finally:
+        _drop_memory(conn, soc2_rule["id"])
+
+
+def test_canonical_lookup_no_double_surface_when_target_is_canonical(
+    conn, memory_factory, factory_job_factory
+):
+    """When the brief target IS the canonical 'devbrain' project, the
+    UNION must not produce duplicate rule rows. Each rule appears exactly
+    once in brief.rules."""
+    canonical_id = _canonical_devbrain_project_id(conn)
+
+    # Snapshot + temporarily enable 'hipaa' on the canonical project so
+    # the brief generator has profiles to filter against. Restore in
+    # finally even on failure.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT compliance_profiles_enabled "
+            "FROM devbrain.projects WHERE id = %s",
+            (canonical_id,),
+        )
+        prior = cur.fetchone()[0]
+        cur.execute(
+            "UPDATE devbrain.projects SET compliance_profiles_enabled = %s "
+            "WHERE id = %s",
+            (["hipaa"], canonical_id),
+        )
+    conn.commit()
+
+    rule = None
+    try:
+        rule = memory_factory(
+            canonical_id, kind="decision", tier="rule",
+            content="self-target rule", compliance_profiles=["hipaa"],
+        )
+        job = factory_job_factory(canonical_id, spec="anything")
+        brief = generate_brief(conn, job["id"], canonical_id, job["spec"])
+
+        matches = [r for r in brief.rules if r.id == rule["id"]]
+        assert len(matches) == 1, (
+            "rule must appear exactly once when target project IS canonical"
+        )
+    finally:
+        if rule is not None:
+            _drop_memory(conn, rule["id"])
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE devbrain.projects SET compliance_profiles_enabled = %s "
+                "WHERE id = %s",
+                (prior, canonical_id),
+            )
+        conn.commit()


### PR DESCRIPTION
## Summary

Atlas Step 7c seeded 5 compliance rules (HIPAA/SOC2/FERPA) under the canonical `devbrain` project as a shared regulatory library, but `_load_rules` in `factory/curator/brief.py` filtered by `project_id` only — so the seeded rules never surfaced in any other project's brief. Migration 023's design comment ("All rules use the canonical 'devbrain' project so they're available substrate") was not honored by the loader.

This PR fixes the loader and adds a postulate that asserts the cross-project surface, then enables `compliance_profiles_enabled` on 4 real projects so the rules now actually flow into briefs.

## What changed

### `factory/curator/brief.py` — `_load_rules`
Sources rules from BOTH the target project_id and the canonical `devbrain` project_id (resolved via slug). The compliance_profiles intersection still applies. Only rule rows cross the boundary, only when the target opted in. Lessons, decisions, cascade signals remain strictly project-local — P3 same-project isolation is preserved for everything except this one narrow regulatory surface.

### `tests/postulates/test_p_cross_project_rules.py` — new postulate
Three assertions:
1. canonical-project rule surfaces in non-canonical project's brief when profiles intersect (positive)
2. canonical-project SOC2-only rule does NOT surface in a hipaa-only project (intersection still respected)
3. when target IS canonical, no duplicate rule rows (UNION dedup)

### `devbrain.projects` — DB writes (already applied locally)
| Project | Profiles |
|---|---|
| BrightBot | `hipaa, soc2, ferpa` |
| DevBrain | `soc2` |
| LHT VPS Infrastructure | `soc2` |
| PKRelay Chrome Extension | `soc2` |

These are runtime DB writes (not migration-tracked) since enablement is an operational decision per project, not schema. The Mac Studio install will need the same UPDATE applied separately.

## Test plan

- [x] All 21 prior postulates pass
- [x] 5 curator-brief integration tests pass
- [x] 5 per-rule postulates pass
- [x] 3 new cross-project postulates pass (39 total green)
- [x] `devbrain rules lint` exits 0
- [x] Live validation: BrightBot brief surfaces all 5 rules; SOC2-only projects (devbrain, lht-vps, pkrelay) surface exactly 2 rules; DevBrain self-targeting produces no duplicates

## Live validation output

```
brightbot   (hipaa, soc2, ferpa) — 5 rules
devbrain    (soc2)                — 2 rules
lht-vps     (soc2)                — 2 rules
pkrelay     (soc2)                — 2 rules
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)