### PR TITLE
feat(graph): Atlas Phase 5 — graph layer (substrate + walker + MCP tools + deep_search integration)

### DIFF
--- a/factory/graph/__init__.py
+++ b/factory/graph/__init__.py
@@ -1,0 +1,8 @@
+"""factory.graph — Phase 5 graph layer for DevBrain.
+
+Provides bounded multi-hop traversal over the memory_dependencies table
+using recursive CTEs (no Apache AGE). See docs/plans/2026-05-05-phase-5-graph-layer-design.md.
+"""
+from factory.graph.walker import GraphWalkResult, MemoryRef, EdgeRef, walk
+
+__all__ = ["GraphWalkResult", "MemoryRef", "EdgeRef", "walk"]

--- a/factory/graph/__init__.py
+++ b/factory/graph/__init__.py
@@ -3,6 +3,6 @@
 Provides bounded multi-hop traversal over the memory_dependencies table
 using recursive CTEs (no Apache AGE). See docs/plans/2026-05-05-phase-5-graph-layer-design.md.
 """
-from factory.graph.walker import GraphWalkResult, MemoryRef, EdgeRef, walk
+from graph.walker import GraphWalkResult, MemoryRef, EdgeRef, walk
 
 __all__ = ["GraphWalkResult", "MemoryRef", "EdgeRef", "walk"]

--- a/factory/graph/deep_search_graph_entry.py
+++ b/factory/graph/deep_search_graph_entry.py
@@ -1,0 +1,163 @@
+"""CLI entry point for the deep_search with_graph extension (Phase 5d).
+
+Reads JSON from stdin with a list of seed memory_ids (from deep_search's
+top results) and walker parameters. Runs the walker from each seed,
+deduplicates memories across all walker results, and returns the combined
+graph neighborhood.
+
+Input JSON schema:
+    {
+        "seed_memory_ids": ["<uuid>", ...],
+        "graph_max_hops":  3,
+        "graph_max_nodes": 50
+    }
+
+    Note: edge_types and direction use walker defaults (strong-signal,
+    both). These are intentionally not exposed on deep_search per the
+    design doc §5.2. cross_project defaults to False (same-project as
+    deep_search).
+
+Output JSON schema:
+    {
+        "memories": [
+            {
+                "id": "<uuid>",
+                "project_id": "<uuid>",
+                "kind": "decision",
+                "title": "...",
+                "content": "...",
+                "strength": 1.0,
+                "hops": 0
+            }, ...
+        ],
+        "edges": [
+            {
+                "from_memory_id": "<uuid>",
+                "to_memory_id": "<uuid>",
+                "edge_type": "depends_on",
+                "confidence": 1.0
+            }, ...
+        ],
+        "seeds": ["<uuid>", ...]
+    }
+
+On error, writes {"error": "<message>"} and exits 1.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import psycopg2
+import psycopg2.extras
+
+from config import build_database_url
+from graph.walker import walk, STRONG_SIGNAL_EDGE_TYPES
+
+
+def _uuid_str(val) -> str | None:
+    if val is None:
+        return None
+    return str(val)
+
+
+def main() -> None:
+    psycopg2.extras.register_uuid()
+
+    try:
+        payload = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(json.dumps({"error": f"Invalid JSON input: {exc}"}))
+        sys.exit(1)
+
+    seed_ids = payload.get("seed_memory_ids", [])
+    if not seed_ids:
+        # No seeds → empty graph (not an error)
+        print(json.dumps({"memories": [], "edges": [], "seeds": []}))
+        return
+
+    graph_max_hops = int(payload.get("graph_max_hops", 3))
+    graph_max_nodes = int(payload.get("graph_max_nodes", 50))
+
+    try:
+        database_url = build_database_url()
+        conn = psycopg2.connect(database_url)
+    except Exception as exc:
+        print(json.dumps({"error": f"DB connection failed: {exc}"}))
+        sys.exit(1)
+
+    # Walk from each seed, deduplicating memories across results.
+    # We collect all visited memory IDs and take the minimum hop
+    # distance when the same memory is reachable from multiple seeds.
+    all_memories: dict[str, dict] = {}  # id -> best memory dict
+    all_edge_set: set[tuple] = set()    # (from, to, type) for dedup
+    valid_seeds: list[str] = []
+
+    try:
+        for seed in seed_ids:
+            try:
+                result = walk(
+                    conn,
+                    seed,
+                    edge_types=STRONG_SIGNAL_EDGE_TYPES,
+                    max_hops=graph_max_hops,
+                    max_nodes=graph_max_nodes,
+                    direction="both",
+                    cross_project=False,
+                )
+            except Exception:
+                # Non-existent or archived seed — skip silently
+                continue
+
+            if not result.memories:
+                continue
+
+            valid_seeds.append(seed)
+
+            for m in result.memories:
+                mid = str(m.id)
+                existing = all_memories.get(mid)
+                if existing is None or m.hops < existing["hops"]:
+                    all_memories[mid] = {
+                        "id": _uuid_str(m.id),
+                        "project_id": _uuid_str(m.project_id),
+                        "kind": m.kind,
+                        "title": m.title,
+                        "content": m.content,
+                        "strength": m.strength,
+                        "hops": m.hops,
+                    }
+
+            for e in result.edges:
+                key = (_uuid_str(e.from_memory_id), _uuid_str(e.to_memory_id), e.edge_type)
+                if key not in all_edge_set:
+                    all_edge_set.add(key)
+
+    finally:
+        conn.close()
+
+    # Sort memories by (hops asc, strength desc)
+    memories_list = sorted(
+        all_memories.values(),
+        key=lambda m: (m["hops"], -m["strength"]),
+    )
+
+    edges_list = [
+        {"from_memory_id": k[0], "to_memory_id": k[1], "edge_type": k[2]}
+        for k in sorted(all_edge_set)
+    ]
+
+    output = {
+        "memories": memories_list,
+        "edges": edges_list,
+        "seeds": valid_seeds,
+    }
+    print(json.dumps(output))
+
+
+if __name__ == "__main__":
+    main()

--- a/factory/graph/graph_walk_entry.py
+++ b/factory/graph/graph_walk_entry.py
@@ -1,0 +1,144 @@
+"""CLI entry point for the graph_walk MCP tool.
+
+Reads a JSON payload from stdin, invokes walker.walk(), and writes the
+result to stdout as JSON. Called by the MCP server's graph_walk tool
+via spawnSync — same pattern as curator.end_session_entry.
+
+Input JSON schema:
+    {
+        "seed_memory_id": "<uuid>",
+        "edge_types":     ["depends_on", ...] | null,
+        "max_hops":       3,
+        "max_nodes":      50,
+        "direction":      "both" | "outgoing" | "incoming",
+        "cross_project":  false
+    }
+
+Output JSON schema:
+    {
+        "memories": [
+            {
+                "id": "<uuid>",
+                "project_id": "<uuid>",
+                "kind": "decision",
+                "title": "...",
+                "content": "...",
+                "strength": 1.0,
+                "hops": 0
+            }, ...
+        ],
+        "edges": [
+            {
+                "from_memory_id": "<uuid>",
+                "to_memory_id": "<uuid>",
+                "edge_type": "depends_on",
+                "confidence": 1.0
+            }, ...
+        ],
+        "truncated": false
+    }
+
+On error, writes {"error": "<message>"} and exits 1.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Ensure factory/ is on path when invoked via `python -m graph.graph_walk_entry`
+# from the factory/ directory. The MCP server runs spawnSync from DEVBRAIN_REPO_ROOT
+# with cwd=factory so this resolves correctly.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import psycopg2
+import psycopg2.extras
+
+from config import build_database_url
+from graph.walker import walk
+
+
+def _uuid_str(val) -> str:
+    """Convert a UUID or string to its canonical string form."""
+    if val is None:
+        return None
+    return str(val)
+
+
+def main() -> None:
+    psycopg2.extras.register_uuid()
+
+    try:
+        payload = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(json.dumps({"error": f"Invalid JSON input: {exc}"}))
+        sys.exit(1)
+
+    seed = payload.get("seed_memory_id")
+    if not seed:
+        print(json.dumps({"error": "seed_memory_id is required"}))
+        sys.exit(1)
+
+    edge_types = payload.get("edge_types") or None
+    max_hops = int(payload.get("max_hops", 3))
+    max_nodes = int(payload.get("max_nodes", 50))
+    direction = payload.get("direction", "both")
+    cross_project = bool(payload.get("cross_project", False))
+
+    if direction not in ("both", "outgoing", "incoming"):
+        print(json.dumps({"error": f"Invalid direction: {direction!r}"}))
+        sys.exit(1)
+
+    try:
+        database_url = build_database_url()
+        conn = psycopg2.connect(database_url)
+    except Exception as exc:
+        print(json.dumps({"error": f"DB connection failed: {exc}"}))
+        sys.exit(1)
+
+    try:
+        result = walk(
+            conn,
+            seed,
+            edge_types=edge_types,
+            max_hops=max_hops,
+            max_nodes=max_nodes,
+            direction=direction,
+            cross_project=cross_project,
+        )
+    except Exception as exc:
+        print(json.dumps({"error": f"Walker failed: {exc}"}))
+        conn.close()
+        sys.exit(1)
+
+    conn.close()
+
+    output = {
+        "memories": [
+            {
+                "id": _uuid_str(m.id),
+                "project_id": _uuid_str(m.project_id),
+                "kind": m.kind,
+                "title": m.title,
+                "content": m.content,
+                "strength": m.strength,
+                "hops": m.hops,
+            }
+            for m in result.memories
+        ],
+        "edges": [
+            {
+                "from_memory_id": _uuid_str(e.from_memory_id),
+                "to_memory_id": _uuid_str(e.to_memory_id),
+                "edge_type": e.edge_type,
+                "confidence": e.confidence,
+            }
+            for e in result.edges
+        ],
+        "truncated": result.truncated,
+    }
+    print(json.dumps(output))
+
+
+if __name__ == "__main__":
+    main()

--- a/factory/graph/walker.py
+++ b/factory/graph/walker.py
@@ -1,0 +1,317 @@
+"""factory.graph.walker — bounded recursive-CTE graph walker.
+
+Traverses devbrain.memory_dependencies using plain Postgres recursive
+CTEs. No Apache AGE, no Cypher — stock SQL that runs on any Postgres 13+
+instance (DevBrain uses 17).
+
+Public API
+----------
+    result = walk(
+        conn,
+        seed_memory_id,
+        edge_types=["supersedes", "derived_from"],
+        max_hops=3,
+        max_nodes=50,
+        direction="both",
+        cross_project=False,
+    )
+    # result.memories  → list[MemoryRef]   (BFS order, hops asc, strength desc)
+    # result.edges     → list[EdgeRef]     (edges within returned node set)
+    # result.truncated → bool              (True if max_nodes was hit)
+
+Design notes
+------------
+- Cycle safety: a `visited` UUID[] accumulator in the recursive CTE
+  prevents revisiting nodes. Postgres array membership (`= ANY(array)`)
+  is fast for small arrays; we cap at max_nodes=200 so there's no
+  out-of-memory risk.
+- Truncation: the walker fetches max_nodes + 1 seed rows from the CTE.
+  If exactly max_nodes+1 rows come back, the caller gets max_nodes rows
+  and truncated=True. The extra row is discarded, not counted.
+- Direction "both": in the CTE we look at BOTH directions each step.
+  `from_memory_id = w.id` expands outgoing edges; `to_memory_id = w.id`
+  expands incoming. The "next" node is whichever end of the edge isn't
+  the current node.
+- Project scoping: by default the walker stays within the seed memory's
+  project. cross_project=True lifts that restriction. The seed node's
+  project_id is captured in the base case (hops=0) and carried forward.
+  For cross_project=False we compare `next.project_id = seed.project_id`
+  at each expansion step.
+- Archived exclusion: both the seed and all expanded nodes are filtered
+  by `archived_at IS NULL`. The walker stops at archived boundaries —
+  it won't traverse through an archived node even if edges exist beyond
+  it (because archived nodes are excluded from the RECURSIVE part too).
+- Edges returned: after the recursive walk, a second query fetches all
+  edges whose BOTH endpoints are in the visited set. This keeps the CTE
+  clean and avoids tracking edge data in the recursive accumulator.
+
+See §4 of docs/plans/2026-05-05-phase-5-graph-layer-design.md for the
+full design rationale.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Literal
+
+# All 6 Phase-5 edge types. The "strong signal" default subset is the 4
+# that carry semantic weight; 'cites' is weaker (narrative reference) and
+# 'contradicts' surfaces integrity issues rather than knowledge paths.
+ALL_EDGE_TYPES: list[str] = [
+    "cites",
+    "depends_on",
+    "supersedes",
+    "contradicts",
+    "derived_from",
+    "refined_by",
+]
+
+STRONG_SIGNAL_EDGE_TYPES: list[str] = [
+    "supersedes",
+    "refined_by",
+    "derived_from",
+    "depends_on",
+]
+
+
+@dataclass
+class MemoryRef:
+    """A memory row as returned by the walker."""
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    kind: str
+    title: str | None
+    content: str
+    strength: float
+    hops: int  # BFS distance from seed (0 = seed itself)
+
+
+@dataclass
+class EdgeRef:
+    """A memory_dependencies edge within the returned node set."""
+
+    from_memory_id: uuid.UUID
+    to_memory_id: uuid.UUID
+    edge_type: str
+    confidence: float
+
+
+@dataclass
+class GraphWalkResult:
+    """Result of a walker.walk() call."""
+
+    memories: list[MemoryRef] = field(default_factory=list)
+    edges: list[EdgeRef] = field(default_factory=list)
+    truncated: bool = False
+
+
+def walk(
+    conn,
+    seed_memory_id: uuid.UUID | str,
+    *,
+    edge_types: list[str] | None = None,
+    max_hops: int = 3,
+    max_nodes: int = 50,
+    direction: Literal["outgoing", "incoming", "both"] = "both",
+    cross_project: bool = False,
+) -> GraphWalkResult:
+    """Traverse the memory graph from a seed memory using a recursive CTE.
+
+    Parameters
+    ----------
+    conn:
+        A psycopg2 connection. The caller owns the connection lifecycle;
+        walk() never commits or rolls back.
+    seed_memory_id:
+        UUID of the starting memory row. Must exist and be non-archived;
+        returns an empty result if it doesn't.
+    edge_types:
+        Edge type filter. None / empty → strong-signal defaults
+        (supersedes, refined_by, derived_from, depends_on). Pass an
+        explicit list to restrict further or to include 'cites' /
+        'contradicts'.
+    max_hops:
+        Maximum BFS depth. Capped at 6. Default 3.
+    max_nodes:
+        Maximum total nodes (including seed) to return. Capped at 200.
+        If more nodes exist, truncated=True is set. Default 50.
+    direction:
+        'outgoing' — follow from_memory_id→to_memory_id edges only.
+        'incoming' — follow reverse edges (who points at me?).
+        'both'     — expand in both directions each hop. Default.
+    cross_project:
+        If False (default), expansion stays within the seed's project.
+        If True, the walker crosses project boundaries (use only when
+        the caller has explicit cross-project intent).
+
+    Returns
+    -------
+    GraphWalkResult with memories sorted by (hops asc, strength desc),
+    edges within the returned node set, and a truncated flag.
+    """
+    seed_id = str(seed_memory_id)
+
+    # Apply caps from design doc
+    max_hops = min(max_hops, 6)
+    max_nodes = min(max_nodes, 200)
+
+    # Resolve effective edge types
+    effective_edge_types = edge_types if edge_types else STRONG_SIGNAL_EDGE_TYPES
+
+    with conn.cursor() as cur:
+        # ── Recursive CTE walk ────────────────────────────────────────────────
+        #
+        # Base case: the seed memory (hops=0), filtered by archived_at.
+        # Recursive case: expand via memory_dependencies, tracking visited
+        # to prevent cycles, stopping at max_hops.
+        #
+        # The LIMIT is max_nodes + 1 so we can detect truncation.
+        #
+        # Direction handling: we use a CASE expression to pick the "next"
+        # node — the endpoint of the edge that isn't the current node.
+        #
+        # Cross-project handling: we capture the seed's project_id in the
+        # base case. In the recursive case we filter next.project_id when
+        # cross_project=False. Because the seed project_id propagates
+        # through `w.seed_project_id`, every expansion step knows the
+        # original project without a subquery.
+
+        # Build the direction filter clauses
+        if direction == "outgoing":
+            dir_join = "d.from_memory_id = w.id"
+            next_id_expr = "d.to_memory_id"
+        elif direction == "incoming":
+            dir_join = "d.to_memory_id = w.id"
+            next_id_expr = "d.from_memory_id"
+        else:  # both
+            dir_join = "(d.from_memory_id = w.id OR d.to_memory_id = w.id)"
+            next_id_expr = (
+                "CASE WHEN d.from_memory_id = w.id "
+                "THEN d.to_memory_id ELSE d.from_memory_id END"
+            )
+
+        # Parameterized query — no string interpolation for user data
+        sql = f"""
+WITH RECURSIVE walk AS (
+    -- Base case: the seed memory
+    SELECT
+        m.id                         AS id,
+        m.project_id                 AS project_id,
+        m.project_id                 AS seed_project_id,
+        ARRAY[m.id::uuid]            AS visited,
+        0                            AS hops
+    FROM devbrain.memory m
+    WHERE m.id = %(seed_id)s::uuid
+      AND m.archived_at IS NULL
+
+    UNION ALL
+
+    -- Recursive case: expand one hop
+    SELECT
+        next_m.id                    AS id,
+        next_m.project_id            AS project_id,
+        w.seed_project_id            AS seed_project_id,
+        w.visited || next_m.id::uuid AS visited,
+        w.hops + 1                   AS hops
+    FROM walk w
+    JOIN devbrain.memory_dependencies d
+      ON {dir_join}
+    JOIN devbrain.memory next_m
+      ON next_m.id = ({next_id_expr})
+    WHERE w.hops < %(max_hops)s
+      AND NOT (next_m.id = ANY(w.visited))
+      AND next_m.archived_at IS NULL
+      AND d.edge_type = ANY(%(edge_types)s::text[])
+      AND (%(cross_project)s OR next_m.project_id = w.seed_project_id)
+),
+-- Deduplicate: each node at its minimum hop distance
+deduped AS (
+    SELECT DISTINCT ON (id) id, project_id, hops
+    FROM walk
+    ORDER BY id, hops ASC
+)
+SELECT id, project_id, hops
+FROM deduped
+ORDER BY hops ASC
+LIMIT %(fetch_limit)s
+"""
+        cur.execute(
+            sql,
+            {
+                "seed_id": seed_id,
+                "max_hops": max_hops,
+                "edge_types": effective_edge_types,
+                "cross_project": cross_project,
+                "fetch_limit": max_nodes + 1,  # +1 for truncation detection
+            },
+        )
+        raw_nodes = cur.fetchall()
+
+    if not raw_nodes:
+        return GraphWalkResult()
+
+    # Detect truncation
+    truncated = len(raw_nodes) > max_nodes
+    node_rows = raw_nodes[:max_nodes]
+
+    visited_ids = [str(row[0]) for row in node_rows]
+    hops_by_id = {str(row[0]): row[2] for row in node_rows}
+
+    # ── Fetch full memory details for visited nodes ───────────────────────────
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+SELECT id, project_id, kind, title, content, strength
+FROM devbrain.memory
+WHERE id = ANY(%(ids)s::uuid[])
+  AND archived_at IS NULL
+""",
+            {"ids": visited_ids},
+        )
+        mem_rows = cur.fetchall()
+
+    memories: list[MemoryRef] = []
+    for row in mem_rows:
+        mem_id = str(row[0])
+        memories.append(
+            MemoryRef(
+                id=row[0],
+                project_id=row[1],
+                kind=row[2],
+                title=row[3],
+                content=row[4],
+                strength=float(row[5]) if row[5] is not None else 1.0,
+                hops=hops_by_id.get(mem_id, 0),
+            )
+        )
+
+    # Sort by (hops asc, strength desc) per design doc §8
+    memories.sort(key=lambda m: (m.hops, -m.strength))
+
+    # ── Fetch edges within the visited node set ───────────────────────────────
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+SELECT from_memory_id, to_memory_id, edge_type, confidence
+FROM devbrain.memory_dependencies
+WHERE from_memory_id = ANY(%(ids)s::uuid[])
+  AND to_memory_id   = ANY(%(ids)s::uuid[])
+  AND edge_type = ANY(%(edge_types)s::text[])
+ORDER BY from_memory_id, to_memory_id
+""",
+            {"ids": visited_ids, "edge_types": effective_edge_types},
+        )
+        edge_rows = cur.fetchall()
+
+    edges: list[EdgeRef] = [
+        EdgeRef(
+            from_memory_id=row[0],
+            to_memory_id=row[1],
+            edge_type=row[2],
+            confidence=float(row[3]) if row[3] is not None else 1.0,
+        )
+        for row in edge_rows
+    ]
+
+    return GraphWalkResult(memories=memories, edges=edges, truncated=truncated)

--- a/factory/tests/test_deep_search_with_graph.py
+++ b/factory/tests/test_deep_search_with_graph.py
@@ -1,0 +1,165 @@
+"""Integration tests for the deep_search graph-aware extension (Phase 5d).
+
+These tests exercise the Python-side graph enrichment logic directly —
+not the TypeScript MCP layer. They verify that the deep_search_graph_entry
+CLI correctly aggregates walker results from multiple seeds and deduplicates
+memories across seeds.
+
+The MCP integration (TypeScript side) is covered by the TypeScript build
+succeeding and the existing smoke-test checklist.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+FACTORY_DIR = str(Path(__file__).parent.parent)
+
+
+def run_entry(payload: dict, env_extra: dict | None = None) -> dict:
+    """Run deep_search_graph_entry.py with the given payload and return parsed output."""
+    import os
+    env = os.environ.copy()
+    if env_extra:
+        env.update(env_extra)
+
+    python = str(Path(sys.executable))
+    result = subprocess.run(
+        [python, "-m", "graph.deep_search_graph_entry"],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=FACTORY_DIR,
+        env=env,
+    )
+    if result.returncode != 0:
+        # Try to get the error from stdout
+        try:
+            return json.loads(result.stdout)
+        except Exception:
+            pytest.fail(f"Entry script failed (exit {result.returncode}): {result.stderr}")
+    return json.loads(result.stdout)
+
+
+@pytest.mark.db
+def test_with_graph_empty_seeds(conn, project_factory):
+    """Empty seed list returns empty graph without error."""
+    payload = {
+        "seed_memory_ids": [],
+        "graph_max_hops": 3,
+        "graph_max_nodes": 50,
+    }
+    result = run_entry(payload)
+    assert result["memories"] == []
+    assert result["edges"] == []
+    assert result["seeds"] == []
+
+
+@pytest.mark.db
+def test_with_graph_single_seed_no_edges(conn, project_factory, memory_factory):
+    """Single seed with no edges returns just the seed."""
+    project = project_factory("ds_graph_single")
+    seed_mem = memory_factory(project["id"], kind="decision", title="ds_seed")
+    conn.commit()
+
+    payload = {
+        "seed_memory_ids": [str(seed_mem["id"])],
+        "graph_max_hops": 3,
+        "graph_max_nodes": 50,
+    }
+    result = run_entry(payload)
+
+    returned_ids = {m["id"] for m in result["memories"]}
+    assert str(seed_mem["id"]) in returned_ids
+    assert len(result["seeds"]) == 1
+
+
+@pytest.mark.db
+def test_with_graph_expands_neighbors(conn, project_factory, memory_factory):
+    """Graph walk from seed includes connected neighbors."""
+    project = project_factory("ds_graph_expand")
+    seed_mem = memory_factory(project["id"], kind="decision", title="ds_seed_exp")
+    neighbor = memory_factory(project["id"], kind="pattern", title="ds_neighbor")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test_ds_graph')",
+            (seed_mem["id"], neighbor["id"]),
+        )
+    conn.commit()
+
+    payload = {
+        "seed_memory_ids": [str(seed_mem["id"])],
+        "graph_max_hops": 3,
+        "graph_max_nodes": 50,
+    }
+    result = run_entry(payload)
+
+    returned_ids = {m["id"] for m in result["memories"]}
+    assert str(seed_mem["id"]) in returned_ids
+    assert str(neighbor["id"]) in returned_ids
+
+
+@pytest.mark.db
+def test_with_graph_deduplicates_across_seeds(conn, project_factory, memory_factory):
+    """When two seeds share a common neighbor, it appears only once in result."""
+    project = project_factory("ds_graph_dedup")
+    seed1 = memory_factory(project["id"], kind="decision", title="ds_seed1")
+    seed2 = memory_factory(project["id"], kind="decision", title="ds_seed2")
+    shared = memory_factory(project["id"], kind="pattern", title="ds_shared")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test_ds_graph')",
+            (seed1["id"], shared["id"]),
+        )
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test_ds_graph')",
+            (seed2["id"], shared["id"]),
+        )
+    conn.commit()
+
+    payload = {
+        "seed_memory_ids": [str(seed1["id"]), str(seed2["id"])],
+        "graph_max_hops": 3,
+        "graph_max_nodes": 50,
+    }
+    result = run_entry(payload)
+
+    returned_ids = [m["id"] for m in result["memories"]]
+    # No duplicates
+    assert len(returned_ids) == len(set(returned_ids)), "No duplicates in memories"
+
+    # Shared node appears exactly once
+    shared_count = returned_ids.count(str(shared["id"]))
+    assert shared_count == 1, f"Shared node must appear once, got {shared_count}"
+
+
+@pytest.mark.db
+def test_with_graph_false_returns_no_graph_field(conn, project_factory, memory_factory):
+    """The entry point handles the with_graph=false case (empty seeds) gracefully."""
+    # When deep_search is called without with_graph, no seeds are passed.
+    # Verify the entry point returns empty graph for empty seeds.
+    payload = {
+        "seed_memory_ids": [],
+        "graph_max_hops": 3,
+        "graph_max_nodes": 50,
+    }
+    result = run_entry(payload)
+    assert "memories" in result
+    assert "edges" in result
+    assert "seeds" in result
+    assert result["memories"] == []

--- a/factory/tests/test_graph_walker.py
+++ b/factory/tests/test_graph_walker.py
@@ -1,0 +1,411 @@
+"""Unit/integration tests for factory.graph.walker.
+
+Tests exercise the walk() function against the real Postgres DB
+(gated on DEVBRAIN_DB_PASSWORD being set). They create isolated
+projects via project_factory so there is no cross-test contamination.
+
+Coverage targets:
+  - Empty graph (seed only, no edges)
+  - Single hop outgoing
+  - Single hop incoming
+  - Both directions
+  - Multi-hop chain
+  - Cycle termination
+  - max_hops cap
+  - max_nodes truncation
+  - Edge type filter
+  - cross_project=False isolation
+  - cross_project=True expansion
+  - Archived seed returns empty
+  - Archived intermediate blocks further traversal
+  - Result ordering (hops asc, strength desc)
+  - Edge set returned for intra-walk edges only
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import uuid
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from graph.walker import (
+    GraphWalkResult,
+    MemoryRef,
+    EdgeRef,
+    STRONG_SIGNAL_EDGE_TYPES,
+    walk,
+)
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+def insert_edge(conn, from_id, to_id, edge_type="depends_on"):
+    """Insert a memory_dependencies edge and commit."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, %s, 'test_graph_walker') "
+            "ON CONFLICT (from_memory_id, to_memory_id, edge_type) DO NOTHING",
+            (from_id, to_id, edge_type),
+        )
+    conn.commit()
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_seed_only_no_edges(conn, project_factory, memory_factory):
+    """Seed with no edges returns just the seed, truncated=False."""
+    project = project_factory("gw_seed_only")
+    seed = memory_factory(project["id"], kind="decision", title="solo")
+    conn.commit()
+
+    result = walk(conn, seed["id"], edge_types=["depends_on"])
+
+    assert len(result.memories) == 1
+    assert result.memories[0].id == seed["id"]
+    assert result.memories[0].hops == 0
+    assert result.edges == []
+    assert result.truncated is False
+
+
+@pytest.mark.db
+def test_single_hop_outgoing(conn, project_factory, memory_factory):
+    """Outgoing single hop: A→B; result contains A (hop 0) and B (hop 1)."""
+    project = project_factory("gw_single_hop_out")
+    a = memory_factory(project["id"], kind="decision", title="A_out")
+    b = memory_factory(project["id"], kind="pattern", title="B_out")
+    insert_edge(conn, a["id"], b["id"])
+
+    result = walk(conn, a["id"], edge_types=["depends_on"], direction="outgoing")
+
+    ids = {m.id for m in result.memories}
+    assert a["id"] in ids
+    assert b["id"] in ids
+    hop_map = {m.id: m.hops for m in result.memories}
+    assert hop_map[a["id"]] == 0
+    assert hop_map[b["id"]] == 1
+
+
+@pytest.mark.db
+def test_single_hop_incoming(conn, project_factory, memory_factory):
+    """Incoming single hop: A←B; walking from A with direction='incoming' surfaces B."""
+    project = project_factory("gw_single_hop_in")
+    a = memory_factory(project["id"], kind="decision", title="A_in")
+    b = memory_factory(project["id"], kind="pattern", title="B_in")
+    # Edge goes FROM b TO a
+    insert_edge(conn, b["id"], a["id"])
+
+    result = walk(conn, a["id"], edge_types=["depends_on"], direction="incoming")
+
+    ids = {m.id for m in result.memories}
+    assert a["id"] in ids
+    assert b["id"] in ids
+
+
+@pytest.mark.db
+def test_direction_outgoing_excludes_incoming_only_nodes(conn, project_factory, memory_factory):
+    """direction='outgoing' must not surface nodes reachable only via incoming edges."""
+    project = project_factory("gw_dir_out")
+    seed = memory_factory(project["id"], kind="decision", title="seed_dir")
+    out_node = memory_factory(project["id"], kind="pattern", title="out_node")
+    in_only = memory_factory(project["id"], kind="pattern", title="in_only")
+
+    insert_edge(conn, seed["id"], out_node["id"])   # outgoing
+    insert_edge(conn, in_only["id"], seed["id"])     # incoming edge to seed
+
+    result = walk(conn, seed["id"], edge_types=["depends_on"], direction="outgoing")
+    ids = {m.id for m in result.memories}
+
+    assert out_node["id"] in ids
+    assert in_only["id"] not in ids
+
+
+@pytest.mark.db
+def test_direction_both_expands_in_and_out(conn, project_factory, memory_factory):
+    """direction='both' surfaces nodes reachable via both incoming and outgoing edges."""
+    project = project_factory("gw_dir_both")
+    seed = memory_factory(project["id"], kind="decision", title="seed_both")
+    out_node = memory_factory(project["id"], kind="pattern", title="out_both")
+    in_node = memory_factory(project["id"], kind="pattern", title="in_both")
+
+    insert_edge(conn, seed["id"], out_node["id"])  # outgoing
+    insert_edge(conn, in_node["id"], seed["id"])   # incoming
+
+    result = walk(conn, seed["id"], edge_types=["depends_on"], direction="both")
+    ids = {m.id for m in result.memories}
+
+    assert out_node["id"] in ids
+    assert in_node["id"] in ids
+
+
+@pytest.mark.db
+def test_multi_hop_chain(conn, project_factory, memory_factory):
+    """Multi-hop: A→B→C→D with max_hops=3 returns all 4 at correct hops."""
+    project = project_factory("gw_multi_hop")
+    a = memory_factory(project["id"], kind="decision", title="A_multi")
+    b = memory_factory(project["id"], kind="decision", title="B_multi")
+    c = memory_factory(project["id"], kind="decision", title="C_multi")
+    d = memory_factory(project["id"], kind="decision", title="D_multi")
+
+    for src, dst in [(a, b), (b, c), (c, d)]:
+        insert_edge(conn, src["id"], dst["id"])
+
+    result = walk(conn, a["id"], edge_types=["depends_on"], max_hops=3, direction="outgoing")
+
+    hop_map = {m.id: m.hops for m in result.memories}
+    assert hop_map[a["id"]] == 0
+    assert hop_map[b["id"]] == 1
+    assert hop_map[c["id"]] == 2
+    assert hop_map[d["id"]] == 3
+
+
+@pytest.mark.db
+def test_max_hops_caps_traversal(conn, project_factory, memory_factory):
+    """Nodes beyond max_hops must not appear."""
+    project = project_factory("gw_max_hops")
+    nodes = [memory_factory(project["id"], kind="decision", title=f"n{i}") for i in range(6)]
+    for i in range(5):
+        insert_edge(conn, nodes[i]["id"], nodes[i + 1]["id"])
+
+    result = walk(conn, nodes[0]["id"], edge_types=["depends_on"], max_hops=2, direction="outgoing")
+    ids = {m.id for m in result.memories}
+
+    assert nodes[0]["id"] in ids  # hop 0
+    assert nodes[1]["id"] in ids  # hop 1
+    assert nodes[2]["id"] in ids  # hop 2
+    assert nodes[3]["id"] not in ids  # hop 3 — excluded
+    assert nodes[4]["id"] not in ids  # hop 4 — excluded
+    assert nodes[5]["id"] not in ids  # hop 5 — excluded
+
+
+@pytest.mark.db
+def test_max_nodes_truncation(conn, project_factory, memory_factory):
+    """Fetching more nodes than max_nodes sets truncated=True and returns max_nodes rows."""
+    project = project_factory("gw_truncation")
+    seed = memory_factory(project["id"], kind="decision", title="seed_trunc")
+    leaves = [
+        memory_factory(project["id"], kind="pattern", title=f"leaf_{i}")
+        for i in range(20)
+    ]
+    for leaf in leaves:
+        insert_edge(conn, seed["id"], leaf["id"])
+
+    result = walk(
+        conn,
+        seed["id"],
+        edge_types=["depends_on"],
+        max_nodes=10,
+        direction="outgoing",
+    )
+
+    assert len(result.memories) == 10
+    assert result.truncated is True
+
+
+@pytest.mark.db
+def test_no_truncation_within_limit(conn, project_factory, memory_factory):
+    """When total nodes fit within max_nodes, truncated=False."""
+    project = project_factory("gw_no_trunc")
+    seed = memory_factory(project["id"], kind="decision", title="seed_nt")
+    leaf = memory_factory(project["id"], kind="pattern", title="leaf_nt")
+    insert_edge(conn, seed["id"], leaf["id"])
+
+    result = walk(
+        conn,
+        seed["id"],
+        edge_types=["depends_on"],
+        max_nodes=50,
+        direction="outgoing",
+    )
+
+    assert len(result.memories) == 2
+    assert result.truncated is False
+
+
+@pytest.mark.db
+def test_cycle_terminates(conn, project_factory, memory_factory):
+    """A→B→C→A cycle: walk terminates and returns each node exactly once."""
+    project = project_factory("gw_cycle")
+    a = memory_factory(project["id"], kind="decision", title="A_cyc")
+    b = memory_factory(project["id"], kind="decision", title="B_cyc")
+    c = memory_factory(project["id"], kind="decision", title="C_cyc")
+
+    for src, dst in [(a, b), (b, c), (c, a)]:
+        insert_edge(conn, src["id"], dst["id"])
+
+    result = walk(
+        conn, a["id"], edge_types=["depends_on"], max_hops=10, direction="outgoing"
+    )
+
+    ids = list(m.id for m in result.memories)
+    assert len(ids) == len(set(ids)), "No duplicates"
+    assert len(ids) == 3
+
+
+@pytest.mark.db
+def test_edge_type_filter(conn, project_factory, memory_factory):
+    """Only edges of the requested types are followed."""
+    project = project_factory("gw_etype")
+    seed = memory_factory(project["id"], kind="decision", title="seed_et")
+    sup_node = memory_factory(project["id"], kind="decision", title="sup_node")
+    dep_node = memory_factory(project["id"], kind="decision", title="dep_node")
+
+    insert_edge(conn, seed["id"], sup_node["id"], "supersedes")
+    insert_edge(conn, seed["id"], dep_node["id"], "depends_on")
+
+    result = walk(
+        conn, seed["id"], edge_types=["supersedes"], direction="outgoing"
+    )
+    ids = {m.id for m in result.memories}
+    assert sup_node["id"] in ids
+    assert dep_node["id"] not in ids
+
+
+@pytest.mark.db
+def test_cross_project_false_default(conn, project_factory, memory_factory):
+    """cross_project=False must exclude nodes from other projects."""
+    project_a = project_factory("gw_cp_a")
+    project_b = project_factory("gw_cp_b")
+
+    seed = memory_factory(project_a["id"], kind="decision", title="seed_cp")
+    foreign = memory_factory(project_b["id"], kind="decision", title="foreign_cp")
+    insert_edge(conn, seed["id"], foreign["id"])
+
+    result = walk(
+        conn, seed["id"], edge_types=["depends_on"], direction="outgoing", cross_project=False
+    )
+    ids = {m.id for m in result.memories}
+    assert foreign["id"] not in ids
+
+
+@pytest.mark.db
+def test_cross_project_true_includes_foreign(conn, project_factory, memory_factory):
+    """cross_project=True must include nodes from other projects."""
+    project_a = project_factory("gw_cp_true_a")
+    project_b = project_factory("gw_cp_true_b")
+
+    seed = memory_factory(project_a["id"], kind="decision", title="seed_cpt")
+    foreign = memory_factory(project_b["id"], kind="decision", title="foreign_cpt")
+    insert_edge(conn, seed["id"], foreign["id"])
+
+    result = walk(
+        conn, seed["id"], edge_types=["depends_on"], direction="outgoing", cross_project=True
+    )
+    ids = {m.id for m in result.memories}
+    assert foreign["id"] in ids
+
+
+@pytest.mark.db
+def test_archived_seed_returns_empty(conn, project_factory):
+    """Walking from an archived seed must return an empty result."""
+    project = project_factory("gw_arch_seed")
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory (project_id, kind, title, content, archived_at) "
+            "VALUES (%s, 'decision', 'archived_seed', 'content', now()) "
+            "RETURNING id",
+            (project["id"],),
+        )
+        archived_id = cur.fetchone()[0]
+    conn.commit()
+
+    result = walk(conn, archived_id, edge_types=["depends_on"])
+
+    assert result.memories == []
+    assert result.edges == []
+    assert result.truncated is False
+
+
+@pytest.mark.db
+def test_archived_node_excluded_and_blocks_traversal(conn, project_factory, memory_factory):
+    """Archived intermediate nodes are excluded and block further traversal."""
+    project = project_factory("gw_arch_mid")
+    seed = memory_factory(project["id"], kind="decision", title="seed_am")
+    beyond = memory_factory(project["id"], kind="pattern", title="beyond_am")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory (project_id, kind, title, content, archived_at) "
+            "VALUES (%s, 'decision', 'archived_am', 'content', now()) RETURNING id",
+            (project["id"],),
+        )
+        mid_archived = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test_gw') ",
+            (seed["id"], mid_archived),
+        )
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test_gw') ",
+            (mid_archived, beyond["id"]),
+        )
+    conn.commit()
+
+    result = walk(conn, seed["id"], edge_types=["depends_on"], max_hops=6, direction="outgoing")
+    ids = {m.id for m in result.memories}
+
+    assert seed["id"] in ids
+    assert mid_archived not in ids
+    assert beyond["id"] not in ids
+
+
+@pytest.mark.db
+def test_result_sorted_hops_asc_strength_desc(conn, project_factory, memory_factory):
+    """Memories must be sorted: hops ascending, then strength descending within same hop."""
+    project = project_factory("gw_sort")
+    seed = memory_factory(project["id"], kind="decision", title="seed_sort", strength=0.8)
+
+    # Two hop-1 nodes with different strengths
+    high = memory_factory(project["id"], kind="decision", title="high_str", strength=0.9)
+    low = memory_factory(project["id"], kind="decision", title="low_str", strength=0.3)
+    far = memory_factory(project["id"], kind="decision", title="far_node", strength=0.5)
+
+    insert_edge(conn, seed["id"], high["id"])
+    insert_edge(conn, seed["id"], low["id"])
+    insert_edge(conn, high["id"], far["id"])
+
+    result = walk(conn, seed["id"], edge_types=["depends_on"], max_hops=3, direction="outgoing")
+
+    # Seed must be first (hop 0)
+    assert result.memories[0].id == seed["id"]
+
+    # Among hop-1 nodes, high strength first
+    hop1 = [m for m in result.memories if m.hops == 1]
+    assert len(hop1) == 2
+    assert hop1[0].strength >= hop1[1].strength, "hop-1 nodes should be strength desc"
+
+    # hop-2 node should come last
+    assert result.memories[-1].id == far["id"]
+
+
+@pytest.mark.db
+def test_edges_only_within_returned_node_set(conn, project_factory, memory_factory):
+    """Edges in the result must only connect nodes in the memories list."""
+    project = project_factory("gw_edges")
+    a = memory_factory(project["id"], kind="decision", title="A_edges")
+    b = memory_factory(project["id"], kind="decision", title="B_edges")
+    c = memory_factory(project["id"], kind="decision", title="C_edges")
+
+    insert_edge(conn, a["id"], b["id"])
+    insert_edge(conn, b["id"], c["id"])
+
+    # Walk with max_hops=1 — only A and B returned; edge A→C must NOT appear
+    result = walk(
+        conn, a["id"], edge_types=["depends_on"], max_hops=1, direction="outgoing"
+    )
+
+    returned_ids = {m.id for m in result.memories}
+    assert c["id"] not in returned_ids  # sanity: C not in nodes
+
+    for edge in result.edges:
+        assert edge.from_memory_id in returned_ids
+        assert edge.to_memory_id in returned_ids

--- a/factory/tests/test_migration_024.py
+++ b/factory/tests/test_migration_024.py
@@ -1,0 +1,109 @@
+"""Tests for migration 024: memory_edges generalization.
+
+Asserts that the CHECK constraint on memory_dependencies.edge_type now
+accepts all 6 Phase-5 types, rejects unknown types, and that existing
+rows (if any) are preserved.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.db
+def test_migration_024_accepts_all_six_edge_types(conn, project_factory, memory_factory):
+    """All 6 edge types must be insertable without constraint violation."""
+    project = project_factory("mig024_all_types")
+
+    # Create 7 memories: one "source" per edge type + one shared "target"
+    target = memory_factory(project["id"], kind="decision", title="target_024")
+
+    edge_types = [
+        "cites",
+        "depends_on",
+        "supersedes",
+        "contradicts",
+        "derived_from",
+        "refined_by",
+    ]
+
+    with conn.cursor() as cur:
+        for etype in edge_types:
+            src = memory_factory(project["id"], kind="pattern", title=f"src_{etype}")
+            cur.execute(
+                "INSERT INTO devbrain.memory_dependencies "
+                "(from_memory_id, to_memory_id, edge_type, created_by) "
+                "VALUES (%s, %s, %s, 'test_migration_024')",
+                (src["id"], target["id"], etype),
+            )
+    conn.commit()
+
+    # Verify all 6 edge types landed
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT DISTINCT edge_type FROM devbrain.memory_dependencies "
+            "WHERE to_memory_id = %s ORDER BY edge_type",
+            (target["id"],),
+        )
+        found = {row[0] for row in cur.fetchall()}
+
+    assert found == set(edge_types), f"Expected all 6 edge types, got: {found}"
+
+
+@pytest.mark.db
+def test_migration_024_rejects_unknown_edge_type(conn, project_factory, memory_factory):
+    """An unknown edge type must be rejected by the CHECK constraint."""
+    project = project_factory("mig024_rejects")
+
+    src = memory_factory(project["id"], kind="decision", title="src_bad")
+    dst = memory_factory(project["id"], kind="decision", title="dst_bad")
+
+    with pytest.raises(Exception, match="memory_dependencies_edge_type_check|check"):
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.memory_dependencies "
+                "(from_memory_id, to_memory_id, edge_type, created_by) "
+                "VALUES (%s, %s, 'unknown_type', 'test_migration_024')",
+                (src["id"], dst["id"]),
+            )
+        conn.commit()
+
+    conn.rollback()
+
+
+@pytest.mark.db
+def test_migration_024_new_types_work(conn, project_factory, memory_factory):
+    """The two new Phase-5 types (derived_from, refined_by) must be usable."""
+    project = project_factory("mig024_new_types")
+
+    src = memory_factory(project["id"], kind="decision", title="src_new")
+    dst = memory_factory(project["id"], kind="decision", title="dst_new")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'derived_from', 'test_migration_024')",
+            (src["id"], dst["id"]),
+        )
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'refined_by', 'test_migration_024')",
+            (dst["id"], src["id"]),
+        )
+    conn.commit()
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT edge_type FROM devbrain.memory_dependencies "
+            "WHERE from_memory_id IN (%s, %s) "
+            "AND edge_type IN ('derived_from', 'refined_by') "
+            "ORDER BY edge_type",
+            (src["id"], dst["id"]),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) == 2
+    assert {r[0] for r in rows} == {"derived_from", "refined_by"}

--- a/factory/tests/test_store_graph_edges.py
+++ b/factory/tests/test_store_graph_edges.py
@@ -1,0 +1,167 @@
+"""Tests for store() derived_from and refined_by edge support (Phase 5c).
+
+These tests verify that the new edge types can be inserted into
+memory_dependencies with the expected idempotency semantics. They
+exercise the database layer directly (not the TypeScript MCP server)
+since the TypeScript side is covered by the existing store() tests.
+
+The tests mirror the pattern used by test_store_cascade_enqueue.py:
+direct DB inserts + assertions, no MCP round-trip required.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import uuid
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ─── Helper ──────────────────────────────────────────────────────────────────
+
+def insert_dep(conn, from_id, to_id, edge_type, created_by="test_store_graph_edges"):
+    """Insert a memory_dependencies edge."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, %s, %s) "
+            "ON CONFLICT (from_memory_id, to_memory_id, edge_type) DO NOTHING",
+            (from_id, to_id, edge_type, created_by),
+        )
+    conn.commit()
+
+
+def get_edges(conn, from_id, to_id=None, edge_type=None):
+    """Fetch edges matching the given filters."""
+    conditions = ["from_memory_id = %s"]
+    params = [from_id]
+    if to_id is not None:
+        conditions.append("to_memory_id = %s")
+        params.append(to_id)
+    if edge_type is not None:
+        conditions.append("edge_type = %s")
+        params.append(edge_type)
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT from_memory_id, to_memory_id, edge_type, confidence "
+            f"FROM devbrain.memory_dependencies "
+            f"WHERE {' AND '.join(conditions)}",
+            params,
+        )
+        return cur.fetchall()
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_derived_from_edge_insertable(conn, project_factory, memory_factory):
+    """derived_from edge type is accepted by the constraint and lands in DB."""
+    project = project_factory("store5c_df")
+    lesson = memory_factory(project["id"], kind="decision", title="lesson_5c")
+    session = memory_factory(project["id"], kind="pattern", title="session_5c")
+
+    insert_dep(conn, lesson["id"], session["id"], "derived_from")
+
+    edges = get_edges(conn, lesson["id"], to_id=session["id"], edge_type="derived_from")
+    assert len(edges) == 1, "derived_from edge must land in DB"
+    assert edges[0][2] == "derived_from"
+
+
+@pytest.mark.db
+def test_refined_by_edge_insertable(conn, project_factory, memory_factory):
+    """refined_by edge type is accepted by the constraint and lands in DB."""
+    project = project_factory("store5c_rb")
+    orig = memory_factory(project["id"], kind="decision", title="orig_5c")
+    refined = memory_factory(project["id"], kind="decision", title="refined_5c")
+
+    insert_dep(conn, orig["id"], refined["id"], "refined_by")
+
+    edges = get_edges(conn, orig["id"], to_id=refined["id"], edge_type="refined_by")
+    assert len(edges) == 1, "refined_by edge must land in DB"
+    assert edges[0][2] == "refined_by"
+
+
+@pytest.mark.db
+def test_derived_from_idempotent(conn, project_factory, memory_factory):
+    """Duplicate derived_from insert is a no-op (ON CONFLICT DO NOTHING)."""
+    project = project_factory("store5c_idem_df")
+    lesson = memory_factory(project["id"], kind="decision", title="lesson_idem")
+    session = memory_factory(project["id"], kind="pattern", title="session_idem")
+
+    insert_dep(conn, lesson["id"], session["id"], "derived_from")
+    insert_dep(conn, lesson["id"], session["id"], "derived_from")  # duplicate
+
+    edges = get_edges(conn, lesson["id"], to_id=session["id"], edge_type="derived_from")
+    assert len(edges) == 1, "Duplicate insert must be deduplicated"
+
+
+@pytest.mark.db
+def test_refined_by_idempotent(conn, project_factory, memory_factory):
+    """Duplicate refined_by insert is a no-op (ON CONFLICT DO NOTHING)."""
+    project = project_factory("store5c_idem_rb")
+    orig = memory_factory(project["id"], kind="decision", title="orig_idem")
+    refined = memory_factory(project["id"], kind="decision", title="refined_idem")
+
+    insert_dep(conn, orig["id"], refined["id"], "refined_by")
+    insert_dep(conn, orig["id"], refined["id"], "refined_by")  # duplicate
+
+    edges = get_edges(conn, orig["id"], to_id=refined["id"], edge_type="refined_by")
+    assert len(edges) == 1, "Duplicate insert must be deduplicated"
+
+
+@pytest.mark.db
+def test_derived_from_does_not_enqueue_cascade(conn, project_factory, memory_factory):
+    """derived_from edges must NOT trigger cascade re-evaluation queue entries.
+
+    Only supersedes edges trigger cascades. derived_from is a knowledge-
+    provenance signal, not a dependency-invalidation signal.
+    """
+    project = project_factory("store5c_no_cascade")
+    lesson = memory_factory(project["id"], kind="decision", title="lesson_nc")
+    session = memory_factory(project["id"], kind="pattern", title="session_nc")
+
+    insert_dep(conn, lesson["id"], session["id"], "derived_from")
+
+    # No rows should appear in curator_re_eval_queue for this edge
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.curator_re_eval_queue "
+            "WHERE cascade_source_id = %s",
+            (session["id"],),
+        )
+        count = cur.fetchone()[0]
+
+    assert count == 0, "derived_from edges must not enqueue cascade re-evaluation"
+
+
+@pytest.mark.db
+def test_both_new_edge_types_plus_existing_on_same_memory(
+    conn, project_factory, memory_factory
+):
+    """A single memory can have all 4 outgoing edge types (all Phase 5 types)."""
+    project = project_factory("store5c_multi")
+    src = memory_factory(project["id"], kind="decision", title="src_multi")
+    t1 = memory_factory(project["id"], kind="decision", title="t1_depends")
+    t2 = memory_factory(project["id"], kind="decision", title="t2_supersedes")
+    t3 = memory_factory(project["id"], kind="pattern", title="t3_derived")
+    t4 = memory_factory(project["id"], kind="decision", title="t4_refined")
+
+    for tgt, etype in [
+        (t1, "depends_on"),
+        (t2, "supersedes"),
+        (t3, "derived_from"),
+        (t4, "refined_by"),
+    ]:
+        insert_dep(conn, src["id"], tgt["id"], etype)
+
+    edges = get_edges(conn, src["id"])
+    edge_types = {e[2] for e in edges}
+    assert "depends_on" in edge_types
+    assert "supersedes" in edge_types
+    assert "derived_from" in edge_types
+    assert "refined_by" in edge_types
+    assert len(edges) == 4

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -933,6 +933,90 @@ server.tool(
   },
 )
 
+// ─── Tool: graph_walk ───────────────────────────────────────────────────────
+//
+// Phase 5b: Explore the memory graph from a known memory_id using bounded
+// recursive-CTE traversal (no Apache AGE). Delegates to the Python walker
+// at factory/graph/graph_walk_entry.py via spawnSync — same pattern as
+// the end_session enrichment path.
+//
+// Returns {memories, edges, truncated} from walker.walk(). The Python
+// entry point handles DB connection and serialization.
+
+server.tool(
+  'graph_walk',
+  'Explore the memory graph from a known memory. Returns related memories within max_hops, filtered by edge types. Use when you have a relevant memory_id (from deep_search or store result) and want to see its neighborhood.',
+  {
+    seed_memory_id: z.string().uuid().describe('Starting memory ID (from deep_search or store result)'),
+    edge_types: z
+      .array(z.enum(['cites', 'depends_on', 'supersedes', 'contradicts', 'derived_from', 'refined_by']))
+      .optional()
+      .describe('Edge types to follow. Defaults to strong-signal subset: supersedes, refined_by, derived_from, depends_on.'),
+    max_hops: z.number().min(1).max(6).optional().default(3)
+      .describe('Maximum BFS depth. Default 3; max 6.'),
+    max_nodes: z.number().min(5).max(200).optional().default(50)
+      .describe('Maximum nodes to return (including seed). Default 50; max 200. truncated=true when hit.'),
+    direction: z.enum(['outgoing', 'incoming', 'both']).optional().default('both')
+      .describe('Edge direction: outgoing (follow from→to), incoming (follow to→from), or both. Default both.'),
+    cross_project: z.boolean().optional().default(false)
+      .describe('If true, expand across project boundaries. Default false (same-project only).'),
+  },
+  async ({ seed_memory_id, edge_types, max_hops, max_nodes, direction, cross_project }) => {
+    const payload = {
+      seed_memory_id,
+      edge_types: edge_types ?? null,
+      max_hops: max_hops ?? 3,
+      max_nodes: max_nodes ?? 50,
+      direction: direction ?? 'both',
+      cross_project: cross_project ?? false,
+    }
+
+    const result = spawnSync(
+      DEVBRAIN_PYTHON,
+      ['-m', 'graph.graph_walk_entry'],
+      {
+        input: JSON.stringify(payload),
+        encoding: 'utf-8',
+        cwd: resolve(import.meta.dirname, '../../factory'),
+        env: { ...process.env },
+      },
+    )
+
+    if (result.status !== 0) {
+      return {
+        content: [{
+          type: 'text',
+          text: `graph_walk failed (exit ${result.status}).\nstderr: ${(result.stderr ?? '').toString().slice(0, 800)}`,
+        }],
+      }
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse((result.stdout ?? '').toString())
+    } catch {
+      return {
+        content: [{
+          type: 'text',
+          text: `graph_walk returned unparseable output:\n${(result.stdout ?? '').toString().slice(0, 400)}`,
+        }],
+      }
+    }
+
+    const out = parsed as { error?: string; memories?: unknown[]; edges?: unknown[]; truncated?: boolean }
+    if (out.error) {
+      return { content: [{ type: 'text', text: `graph_walk error: ${out.error}` }] }
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(out, null, 2),
+      }],
+    }
+  },
+)
+
 // ─── Tool: factory_plan ──────────────────────────────────────────────────────
 
 // Branch-name validation.

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -169,7 +169,7 @@ server.tool(
 
 server.tool(
   'deep_search',
-  'Search DevBrain for relevant context. Call this FIRST before starting any work. Returns embedded chunks with source references. Use depth="auto" to automatically fetch raw context when the query asks for specific details.',
+  'Search DevBrain for relevant context. Call this FIRST before starting any work. Returns embedded chunks with source references. Use depth="auto" to automatically fetch raw context when the query asks for specific details. Use with_graph=true to also return the graph neighborhood of top-matched memories.',
   {
     query: z.string().describe('Natural language search query'),
     project: z.string().optional().describe('Project slug (defaults to current project, omit for cross-project)'),
@@ -177,8 +177,14 @@ server.tool(
     source_types: z.array(z.string()).optional().describe('Filter by: session, decision, pattern, issue, note, openclaw_memory, codebase'),
     depth: z.enum(['summary', 'full', 'auto']).optional().default('auto').describe('summary=chunks only, full=chunks+raw context, auto=smart drill-down'),
     limit: z.number().optional().default(10).describe('Max results'),
+    with_graph: z.boolean().optional().default(false)
+      .describe('Phase 5: also return graph neighborhood of top-matched memories. Adds a top-level "graph" field with memories, edges, seeds.'),
+    graph_max_hops: z.number().min(1).max(6).optional().default(3)
+      .describe('Max BFS depth for graph walk (only when with_graph=true). Default 3.'),
+    graph_max_nodes: z.number().min(5).max(200).optional().default(50)
+      .describe('Max total nodes in graph result (only when with_graph=true). Default 50.'),
   },
-  async ({ query: searchQuery, project, cross_project, source_types, depth, limit }) => {
+  async ({ query: searchQuery, project, cross_project, source_types, depth, limit, with_graph, graph_max_hops, graph_max_nodes }) => {
     const queryEmbedding = await embed(searchQuery)
     const vectorStr = toSqlVector(queryEmbedding)
 
@@ -462,15 +468,69 @@ server.tool(
       }),
     )
 
+    // Phase 5d: graph neighborhood enrichment.
+    //
+    // When with_graph=true, collect the memory_ids of top-ranked results
+    // (those with a real memory_id — codebase legacy fallback rows have
+    // memory_id='') and pass them to the Python graph walker. Returns a
+    // combined neighborhood deduped across all seeds.
+    let graphField: unknown = undefined
+    if (with_graph) {
+      const seedIds = results
+        .map((r) => r.memory_id as string)
+        .filter((id) => id && id.length > 10)
+
+      if (seedIds.length > 0) {
+        const graphPayload = {
+          seed_memory_ids: seedIds,
+          graph_max_hops: graph_max_hops ?? 3,
+          graph_max_nodes: graph_max_nodes ?? 50,
+        }
+
+        const graphResult = spawnSync(
+          DEVBRAIN_PYTHON,
+          ['-m', 'graph.deep_search_graph_entry'],
+          {
+            input: JSON.stringify(graphPayload),
+            encoding: 'utf-8',
+            cwd: resolve(import.meta.dirname, '../../factory'),
+            env: { ...process.env },
+          },
+        )
+
+        if (graphResult.status === 0) {
+          try {
+            const parsed = JSON.parse((graphResult.stdout ?? '').toString())
+            if (!parsed.error) {
+              graphField = parsed
+            } else {
+              console.error(`[deep_search] graph walk error: ${parsed.error}`)
+            }
+          } catch {
+            console.error(`[deep_search] graph walk returned unparseable output`)
+          }
+        } else {
+          console.error(`[deep_search] graph walk failed (exit ${graphResult.status}): ${(graphResult.stderr ?? '').toString().slice(0, 400)}`)
+        }
+      } else {
+        graphField = { memories: [], edges: [], seeds: [] }
+      }
+    }
+
+    const responseBody: Record<string, unknown> = {
+      results,
+      hint: results.some((r) => r.has_full_context)
+        ? 'Call get_source_context(chunk_id) for full raw transcript around any result.'
+        : 'No raw session context available for these results.',
+    }
+    if (with_graph) {
+      responseBody.graph = graphField ?? { memories: [], edges: [], seeds: [] }
+    }
+
     return {
       content: [{
         type: 'text',
-        text: JSON.stringify({
-          results,
-          hint: results.some((r) => r.has_full_context)
-            ? 'Call get_source_context(chunk_id) for full raw transcript around any result.'
-            : 'No raw session context available for these results.',
-        }, null, 2),
+        text: JSON.stringify(responseBody, null, 2),
       }],
     }
   },

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -568,8 +568,20 @@ server.tool(
       .describe(
         'UUIDs of memories this one replaces. Used for retracting a prior decision when storing its replacement. Accepts either memory.id or legacy id.',
       ),
+    derived_from: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'UUIDs of memories this one was extracted/derived from (e.g. lessons extracted from a session). Phase 5 graph edge type.',
+      ),
+    refined_by: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'UUIDs of memories that sharpen or elaborate this one. Phase 5 graph edge type.',
+      ),
   },
-  async ({ type, project, title, content, category, tags, rationale, alternatives, root_cause, fix_applied, prevention, example_code, depends_on, supersedes }) => {
+  async ({ type, project, title, content, category, tags, rationale, alternatives, root_cause, fix_applied, prevention, example_code, depends_on, supersedes, derived_from, refined_by }) => {
     const projectId = await resolveProjectId(project)
     if (!projectId) {
       return { content: [{ type: 'text', text: `Project "${project}" not found.` }] }
@@ -633,7 +645,8 @@ server.tool(
     // insert. Failures are logged but never block the store. Skipped if
     // the dual-write didn't return a new memory.id (best-effort path).
     const edgeNotes: string[] = []
-    if (memoryId && (depends_on?.length || supersedes?.length)) {
+    const hasEdges = depends_on?.length || supersedes?.length || derived_from?.length || refined_by?.length
+    if (memoryId && hasEdges) {
       for (const target of depends_on ?? []) {
         const toId = await resolveMemoryId(target)
         if (!toId) {
@@ -667,6 +680,37 @@ server.tool(
         // failed enqueue never blocks the store().
         await enqueueCascades(toId, 'supersedes')
       }
+      // Phase 5c: derived_from and refined_by edges. Same idempotency
+      // semantics as depends_on/supersedes (ON CONFLICT DO NOTHING via
+      // the triplet unique constraint). No cascade enqueue — these edge
+      // types don't trigger re-evaluation (they're knowledge-provenance
+      // signals, not dependency-invalidation signals).
+      for (const target of derived_from ?? []) {
+        const toId = await resolveMemoryId(target)
+        if (!toId) {
+          edgeNotes.push(`derived_from: could not resolve "${target.slice(0, 8)}"`)
+          continue
+        }
+        await recordMemoryDependency({
+          fromMemoryId: memoryId,
+          toMemoryId: toId,
+          edgeType: 'derived_from',
+          createdBy: 'mcp:store',
+        })
+      }
+      for (const target of refined_by ?? []) {
+        const toId = await resolveMemoryId(target)
+        if (!toId) {
+          edgeNotes.push(`refined_by: could not resolve "${target.slice(0, 8)}"`)
+          continue
+        }
+        await recordMemoryDependency({
+          fromMemoryId: memoryId,
+          toMemoryId: toId,
+          edgeType: 'refined_by',
+          createdBy: 'mcp:store',
+        })
+      }
       // Future store() trigger points (Phase 3.x — when the tool
       // schema gains archive / applies_when params):
       //   if (params.archived_at && !previousRow?.archived_at) {
@@ -695,6 +739,8 @@ server.tool(
       const parts: string[] = []
       if (depends_on?.length) parts.push(`depends_on=${depends_on.length}`)
       if (supersedes?.length) parts.push(`supersedes=${supersedes.length}`)
+      if (derived_from?.length) parts.push(`derived_from=${derived_from.length}`)
+      if (refined_by?.length) parts.push(`refined_by=${refined_by.length}`)
       return parts.length ? ` Edges: ${parts.join(', ')}.` : ''
     })()
     const noteSummary = edgeNotes.length ? ` (${edgeNotes.join('; ')})` : ''

--- a/mcp-server/src/memory.ts
+++ b/mcp-server/src/memory.ts
@@ -126,7 +126,7 @@ export async function resolveMemoryId(uuid: string): Promise<string | null> {
 export async function recordMemoryDependency(args: {
   fromMemoryId: string
   toMemoryId: string
-  edgeType: 'cites' | 'depends_on' | 'supersedes' | 'contradicts'
+  edgeType: 'cites' | 'depends_on' | 'supersedes' | 'contradicts' | 'derived_from' | 'refined_by'
   confidence?: number
   createdBy?: string
   metadata?: Record<string, unknown>

--- a/migrations/024_memory_edges_generalize.sql
+++ b/migrations/024_memory_edges_generalize.sql
@@ -1,0 +1,25 @@
+-- ═══════════════════════════════════════════════════════════════════
+-- 024: Generalize memory_dependencies for Phase 5 graph layer
+-- ═══════════════════════════════════════════════════════════════════
+--
+-- Phase 5 (graph layer) extends memory_dependencies from 4 edge types
+-- to 6 by relaxing the CHECK constraint. No table rename, no column
+-- additions — the existing shape is already the general edge model.
+--
+--   - 'derived_from'  → from extracted from to (lessons from sessions)
+--   - 'refined_by'    → to is a sharpening/elaboration of from
+
+ALTER TABLE devbrain.memory_dependencies
+    DROP CONSTRAINT IF EXISTS memory_dependencies_edge_type_check;
+
+ALTER TABLE devbrain.memory_dependencies
+    ADD CONSTRAINT memory_dependencies_edge_type_check
+    CHECK (edge_type IN (
+        'cites', 'depends_on', 'supersedes', 'contradicts',
+        'derived_from', 'refined_by'
+    ));
+
+-- Track this migration in schema_migrations.
+INSERT INTO devbrain.schema_migrations (filename, applied_at)
+VALUES ('024_memory_edges_generalize.sql', now())
+ON CONFLICT (filename) DO NOTHING;

--- a/tests/postulates/test_p_graph_archived_excluded.py
+++ b/tests/postulates/test_p_graph_archived_excluded.py
@@ -1,0 +1,123 @@
+"""P_graph_archived_excluded — Archived memories are excluded; walker stops at them.
+
+POSTULATE
+---------
+Archived memories (archived_at IS NOT NULL) must not appear in walker
+results. Furthermore, the walker stops at archived node boundaries —
+it will not traverse through an archived intermediate node to reach
+non-archived nodes beyond it.
+
+STATUS
+------
+Active. Phase 5 graph layer. The recursive CTE filters
+`m.archived_at IS NULL` in both the base case and the expansion step.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "factory"))
+
+from graph.walker import walk
+
+
+@pytest.mark.db
+def test_archived_leaf_excluded(conn, project_factory, memory_factory):
+    """An archived leaf node must not appear in walker results."""
+    project = project_factory("graph_archived_leaf")
+
+    seed = memory_factory(project["id"], kind="decision", title="seed_arch")
+    live = memory_factory(project["id"], kind="pattern", title="live_neighbor")
+
+    # Insert the archived node
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory (project_id, kind, title, content, archived_at) "
+            "VALUES (%s, 'decision', 'archived_leaf', 'archived content', now()) "
+            "RETURNING id",
+            (project["id"],),
+        )
+        archived_id = cur.fetchone()[0]
+
+        # Edge from seed to archived leaf
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            (seed["id"], archived_id),
+        )
+        # Edge from seed to live neighbor
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            (seed["id"], live["id"]),
+        )
+    conn.commit()
+
+    result = walk(
+        conn,
+        seed["id"],
+        edge_types=["depends_on"],
+        max_hops=3,
+        direction="outgoing",
+        cross_project=False,
+    )
+
+    returned_ids = {m.id for m in result.memories}
+
+    assert seed["id"] in returned_ids, "Seed must be in result"
+    assert live["id"] in returned_ids, "Live neighbor must be in result"
+    assert archived_id not in returned_ids, "Archived leaf must be excluded"
+
+
+@pytest.mark.db
+def test_archived_intermediate_blocks_traversal(conn, project_factory, memory_factory):
+    """Traversal stops at archived nodes — nodes beyond them are also excluded."""
+    project = project_factory("graph_archived_intermediate")
+
+    seed = memory_factory(project["id"], kind="decision", title="seed_ai")
+    beyond = memory_factory(project["id"], kind="pattern", title="beyond_archived")
+
+    with conn.cursor() as cur:
+        # Insert archived intermediate
+        cur.execute(
+            "INSERT INTO devbrain.memory (project_id, kind, title, content, archived_at) "
+            "VALUES (%s, 'decision', 'archived_mid', 'archived content', now()) "
+            "RETURNING id",
+            (project["id"],),
+        )
+        archived_mid = cur.fetchone()[0]
+
+        # Chain: seed → archived_mid → beyond
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            (seed["id"], archived_mid),
+        )
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            (archived_mid, beyond["id"]),
+        )
+    conn.commit()
+
+    result = walk(
+        conn,
+        seed["id"],
+        edge_types=["depends_on"],
+        max_hops=6,
+        direction="outgoing",
+        cross_project=False,
+    )
+
+    returned_ids = {m.id for m in result.memories}
+
+    assert seed["id"] in returned_ids, "Seed must be in result"
+    assert archived_mid not in returned_ids, "Archived intermediate must be excluded"
+    assert beyond["id"] not in returned_ids, "Node beyond archived intermediate must be excluded"

--- a/tests/postulates/test_p_graph_bounded_hops.py
+++ b/tests/postulates/test_p_graph_bounded_hops.py
@@ -1,0 +1,75 @@
+"""P_graph_bounded_hops — Walker respects max_hops.
+
+POSTULATE
+---------
+A graph with edges to depth 5 (A→B→C→D→E→F) returns at most
+max_hops=3 levels when walked from A. Nodes at depth 4+ must not
+appear in the result regardless of how many total nodes exist.
+
+STATUS
+------
+Active. Phase 5 graph layer — walks the memory_dependencies table
+using recursive CTEs with a hops < max_hops guard.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "factory"))
+
+from graph.walker import walk
+
+
+@pytest.mark.db
+def test_walker_respects_max_hops(conn, project_factory, memory_factory):
+    """Nodes at depth > max_hops must not appear in the result."""
+    project = project_factory("graph_bounded_hops")
+
+    # Build a linear chain: A→B→C→D→E→F (depth 0..5 from A)
+    a = memory_factory(project["id"], kind="decision", title="A")
+    b = memory_factory(project["id"], kind="decision", title="B")
+    c = memory_factory(project["id"], kind="decision", title="C")
+    d = memory_factory(project["id"], kind="decision", title="D")
+    e = memory_factory(project["id"], kind="decision", title="E")
+    f = memory_factory(project["id"], kind="decision", title="F")
+
+    chain = [(a, b), (b, c), (c, d), (d, e), (e, f)]
+    with conn.cursor() as cur:
+        for src, dst in chain:
+            cur.execute(
+                "INSERT INTO devbrain.memory_dependencies "
+                "(from_memory_id, to_memory_id, edge_type, created_by) "
+                "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+                (src["id"], dst["id"]),
+            )
+    conn.commit()
+
+    result = walk(
+        conn,
+        a["id"],
+        edge_types=["depends_on"],
+        max_hops=3,
+        direction="outgoing",
+        cross_project=False,
+    )
+
+    returned_ids = {m.id for m in result.memories}
+
+    # Seed (hop 0) through hop 3: A, B, C, D — depth 4 is E, depth 5 is F
+    assert a["id"] in returned_ids, "Seed must always be in result"
+    assert b["id"] in returned_ids, "hop-1 node must be included"
+    assert c["id"] in returned_ids, "hop-2 node must be included"
+    assert d["id"] in returned_ids, "hop-3 node must be included"
+
+    assert e["id"] not in returned_ids, "hop-4 node must be excluded (beyond max_hops=3)"
+    assert f["id"] not in returned_ids, "hop-5 node must be excluded (beyond max_hops=3)"
+
+    # Verify hop values are correct
+    hop_map = {m.id: m.hops for m in result.memories}
+    assert hop_map[a["id"]] == 0
+    assert hop_map[b["id"]] == 1
+    assert hop_map[c["id"]] == 2
+    assert hop_map[d["id"]] == 3

--- a/tests/postulates/test_p_graph_bounded_nodes.py
+++ b/tests/postulates/test_p_graph_bounded_nodes.py
@@ -1,0 +1,92 @@
+"""P_graph_bounded_nodes — Walker respects max_nodes and sets truncated.
+
+POSTULATE
+---------
+A graph with more reachable memories than max_nodes returns exactly
+max_nodes results and sets truncated=True. The caller is responsible
+for re-invoking with higher limits if needed.
+
+STATUS
+------
+Active. Phase 5 graph layer. The recursive CTE uses LIMIT max_nodes+1
+to detect truncation without fetching unbounded result sets.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "factory"))
+
+from graph.walker import walk
+
+
+@pytest.mark.db
+def test_walker_respects_max_nodes_and_flags_truncated(
+    conn, project_factory, memory_factory
+):
+    """When more nodes are reachable than max_nodes, result is capped and truncated=True."""
+    project = project_factory("graph_bounded_nodes")
+
+    # Create a star graph: one seed connected to 15 leaves (all hop=1)
+    seed = memory_factory(project["id"], kind="decision", title="seed")
+    leaves = [memory_factory(project["id"], kind="pattern", title=f"leaf_{i}") for i in range(15)]
+
+    with conn.cursor() as cur:
+        for leaf in leaves:
+            cur.execute(
+                "INSERT INTO devbrain.memory_dependencies "
+                "(from_memory_id, to_memory_id, edge_type, created_by) "
+                "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+                (seed["id"], leaf["id"]),
+            )
+    conn.commit()
+
+    # Walk with max_nodes=10 — we have 16 reachable (seed + 15 leaves)
+    result = walk(
+        conn,
+        seed["id"],
+        edge_types=["depends_on"],
+        max_nodes=10,
+        max_hops=3,
+        direction="outgoing",
+        cross_project=False,
+    )
+
+    assert len(result.memories) == 10, f"Expected exactly 10 nodes, got {len(result.memories)}"
+    assert result.truncated is True, "truncated must be True when max_nodes is hit"
+
+
+@pytest.mark.db
+def test_walker_not_truncated_when_within_limit(conn, project_factory, memory_factory):
+    """When total reachable nodes fit within max_nodes, truncated=False."""
+    project = project_factory("graph_not_truncated")
+
+    seed = memory_factory(project["id"], kind="decision", title="seed")
+    leaf1 = memory_factory(project["id"], kind="pattern", title="leaf1")
+    leaf2 = memory_factory(project["id"], kind="pattern", title="leaf2")
+
+    with conn.cursor() as cur:
+        for leaf in [leaf1, leaf2]:
+            cur.execute(
+                "INSERT INTO devbrain.memory_dependencies "
+                "(from_memory_id, to_memory_id, edge_type, created_by) "
+                "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+                (seed["id"], leaf["id"]),
+            )
+    conn.commit()
+
+    result = walk(
+        conn,
+        seed["id"],
+        edge_types=["depends_on"],
+        max_nodes=50,
+        max_hops=3,
+        direction="outgoing",
+        cross_project=False,
+    )
+
+    assert len(result.memories) == 3  # seed + 2 leaves
+    assert result.truncated is False, "truncated must be False when all nodes fit"

--- a/tests/postulates/test_p_graph_cross_project.py
+++ b/tests/postulates/test_p_graph_cross_project.py
@@ -1,0 +1,66 @@
+"""P_graph_cross_project — cross_project=True surfaces other-project memories.
+
+POSTULATE
+---------
+When the caller explicitly opts in with cross_project=True, the walker
+follows edges across project boundaries and surfaces nodes from other
+projects. This is the opt-in counterpart of P_graph_same_project.
+
+STATUS
+------
+Active. Phase 5 graph layer. The recursive CTE's cross-project guard
+is lifted when cross_project=True is passed.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "factory"))
+
+from graph.walker import walk
+
+
+@pytest.mark.db
+def test_cross_project_true_includes_other_project_nodes(
+    conn, project_factory, memory_factory
+):
+    """With cross_project=True, nodes from other projects must appear in results."""
+    project_a = project_factory("graph_cross_a")
+    project_b = project_factory("graph_cross_b")
+
+    seed = memory_factory(project_a["id"], kind="decision", title="seed_cross")
+    same_proj = memory_factory(project_a["id"], kind="pattern", title="same_proj_neighbor")
+    foreign = memory_factory(project_b["id"], kind="decision", title="foreign_neighbor")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            (seed["id"], same_proj["id"]),
+        )
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            (seed["id"], foreign["id"]),
+        )
+    conn.commit()
+
+    result = walk(
+        conn,
+        seed["id"],
+        edge_types=["depends_on"],
+        max_hops=3,
+        direction="outgoing",
+        cross_project=True,  # opt-in to cross-project expansion
+    )
+
+    returned_ids = {m.id for m in result.memories}
+
+    assert seed["id"] in returned_ids, "Seed must be in result"
+    assert same_proj["id"] in returned_ids, "Same-project node must be in result"
+    assert foreign["id"] in returned_ids, "Foreign-project node must be in result with cross_project=True"

--- a/tests/postulates/test_p_graph_cycle_safe.py
+++ b/tests/postulates/test_p_graph_cycle_safe.py
@@ -1,0 +1,90 @@
+"""P_graph_cycle_safe — Walker terminates on cyclic graphs.
+
+POSTULATE
+---------
+A cyclic graph A→B→C→A terminates correctly and returns each node
+exactly once. The visited-array accumulator prevents infinite recursion.
+
+STATUS
+------
+Active. Phase 5 graph layer. The recursive CTE accumulates a visited
+UUID[] and guards with NOT (next.id = ANY(visited)).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "factory"))
+
+from graph.walker import walk
+
+
+@pytest.mark.db
+def test_cycle_terminates_and_each_node_appears_once(
+    conn, project_factory, memory_factory
+):
+    """A→B→C→A cycle: walker returns A, B, C exactly once without hanging."""
+    project = project_factory("graph_cycle_safe")
+
+    a = memory_factory(project["id"], kind="decision", title="A_cycle")
+    b = memory_factory(project["id"], kind="decision", title="B_cycle")
+    c = memory_factory(project["id"], kind="decision", title="C_cycle")
+
+    # Build the cycle A→B→C→A
+    with conn.cursor() as cur:
+        for src, dst in [(a, b), (b, c), (c, a)]:
+            cur.execute(
+                "INSERT INTO devbrain.memory_dependencies "
+                "(from_memory_id, to_memory_id, edge_type, created_by) "
+                "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+                (src["id"], dst["id"]),
+            )
+    conn.commit()
+
+    result = walk(
+        conn,
+        a["id"],
+        edge_types=["depends_on"],
+        max_hops=6,
+        max_nodes=50,
+        direction="outgoing",
+        cross_project=False,
+    )
+
+    returned_ids = {m.id for m in result.memories}
+
+    assert a["id"] in returned_ids, "A must be in result (seed)"
+    assert b["id"] in returned_ids, "B must be in result (hop-1)"
+    assert c["id"] in returned_ids, "C must be in result (hop-2)"
+
+    # Each node must appear exactly once (no duplicates)
+    assert len(result.memories) == len(returned_ids), "Each node must appear exactly once"
+    assert len(result.memories) == 3, f"Expected 3 unique nodes, got {len(result.memories)}"
+    assert result.truncated is False
+
+
+@pytest.mark.db
+def test_self_loop_not_traversed(conn, project_factory, memory_factory):
+    """Schema forbids self-loops (CHK), but if one slipped through the walker doesn't loop."""
+    project = project_factory("graph_self_loop_guard")
+    # The CONSTRAINT chk_no_self_loop means we can't actually insert a
+    # self-loop, so we just verify the walker returns the seed correctly
+    # even with no edges — the cycle guard is proven by test above.
+    seed = memory_factory(project["id"], kind="decision", title="solo")
+    conn.commit()
+
+    result = walk(
+        conn,
+        seed["id"],
+        edge_types=["depends_on"],
+        max_hops=3,
+        direction="both",
+        cross_project=False,
+    )
+
+    assert len(result.memories) == 1
+    assert result.memories[0].id == seed["id"]
+    assert result.truncated is False

--- a/tests/postulates/test_p_graph_edge_filter.py
+++ b/tests/postulates/test_p_graph_edge_filter.py
@@ -1,0 +1,110 @@
+"""P_graph_edge_filter — edge_types filter restricts traversal.
+
+POSTULATE
+---------
+When edge_types=['supersedes'] is passed, the walker only traverses
+supersedes edges. Nodes reachable only via other edge types (e.g.
+depends_on) must not appear in the result.
+
+STATUS
+------
+Active. Phase 5 graph layer. The recursive CTE filters
+`d.edge_type = ANY(%(edge_types)s)` in the expansion step.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "factory"))
+
+from graph.walker import walk
+
+
+@pytest.mark.db
+def test_edge_type_filter_restricts_traversal(conn, project_factory, memory_factory):
+    """Only edges of the requested type should be followed."""
+    project = project_factory("graph_edge_filter")
+
+    seed = memory_factory(project["id"], kind="decision", title="seed_ef")
+    via_supersedes = memory_factory(project["id"], kind="decision", title="via_supersedes")
+    via_depends = memory_factory(project["id"], kind="decision", title="via_depends")
+    via_derived = memory_factory(project["id"], kind="decision", title="via_derived")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'supersedes', 'postulate-test')",
+            (seed["id"], via_supersedes["id"]),
+        )
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            (seed["id"], via_depends["id"]),
+        )
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'derived_from', 'postulate-test')",
+            (seed["id"], via_derived["id"]),
+        )
+    conn.commit()
+
+    result = walk(
+        conn,
+        seed["id"],
+        edge_types=["supersedes"],  # only follow supersedes
+        max_hops=3,
+        direction="outgoing",
+        cross_project=False,
+    )
+
+    returned_ids = {m.id for m in result.memories}
+
+    assert seed["id"] in returned_ids, "Seed must be in result"
+    assert via_supersedes["id"] in returned_ids, "Node reachable via supersedes must be included"
+    assert via_depends["id"] not in returned_ids, "Node reachable only via depends_on must be excluded"
+    assert via_derived["id"] not in returned_ids, "Node reachable only via derived_from must be excluded"
+
+
+@pytest.mark.db
+def test_edge_type_filter_multi_type(conn, project_factory, memory_factory):
+    """Multiple edge types in the filter: only those types are followed."""
+    project = project_factory("graph_edge_filter_multi")
+
+    seed = memory_factory(project["id"], kind="decision", title="seed_efm")
+    via_supersedes = memory_factory(project["id"], kind="decision", title="via_sup")
+    via_derived = memory_factory(project["id"], kind="decision", title="via_der")
+    via_cites = memory_factory(project["id"], kind="decision", title="via_cit")
+
+    with conn.cursor() as cur:
+        for dst, etype in [
+            (via_supersedes, "supersedes"),
+            (via_derived, "derived_from"),
+            (via_cites, "cites"),
+        ]:
+            cur.execute(
+                "INSERT INTO devbrain.memory_dependencies "
+                "(from_memory_id, to_memory_id, edge_type, created_by) "
+                "VALUES (%s, %s, %s, 'postulate-test')",
+                (seed["id"], dst["id"], etype),
+            )
+    conn.commit()
+
+    result = walk(
+        conn,
+        seed["id"],
+        edge_types=["supersedes", "derived_from"],
+        max_hops=3,
+        direction="outgoing",
+        cross_project=False,
+    )
+
+    returned_ids = {m.id for m in result.memories}
+    assert via_supersedes["id"] in returned_ids
+    assert via_derived["id"] in returned_ids
+    assert via_cites["id"] not in returned_ids, "cites not in filter, must be excluded"

--- a/tests/postulates/test_p_graph_same_project.py
+++ b/tests/postulates/test_p_graph_same_project.py
@@ -1,0 +1,72 @@
+"""P_graph_same_project — Default walk excludes other-project memories.
+
+POSTULATE
+---------
+With cross_project=False (default), the walker must never surface
+memories from a different project, even when an edge crosses a project
+boundary (which should not normally exist, but the FK only enforces
+endpoint validity, not same-project constraint on the edge).
+
+This is the graph-layer counterpart of P3 (HIPAA isolation).
+
+STATUS
+------
+Active. Phase 5 graph layer. The recursive CTE carries seed_project_id
+and filters `next_m.project_id = w.seed_project_id` in the expansion
+step when cross_project=False.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "factory"))
+
+from graph.walker import walk
+
+
+@pytest.mark.db
+def test_cross_project_false_excludes_other_project_nodes(
+    conn, project_factory, memory_factory
+):
+    """Nodes belonging to a different project must not appear when cross_project=False."""
+    project_a = project_factory("graph_proj_a")
+    project_b = project_factory("graph_proj_b")
+
+    seed = memory_factory(project_a["id"], kind="decision", title="proj_a_seed")
+    neighbor_a = memory_factory(project_a["id"], kind="pattern", title="proj_a_neighbor")
+    foreign = memory_factory(project_b["id"], kind="decision", title="proj_b_foreign")
+
+    with conn.cursor() as cur:
+        # Same-project edge: seed → neighbor_a (should be followed)
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            (seed["id"], neighbor_a["id"]),
+        )
+        # Cross-project edge: seed → foreign (should NOT be followed when cross_project=False)
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            (seed["id"], foreign["id"]),
+        )
+    conn.commit()
+
+    result = walk(
+        conn,
+        seed["id"],
+        edge_types=["depends_on"],
+        max_hops=3,
+        direction="outgoing",
+        cross_project=False,  # default — must not cross projects
+    )
+
+    returned_ids = {m.id for m in result.memories}
+
+    assert seed["id"] in returned_ids, "Seed must be in result"
+    assert neighbor_a["id"] in returned_ids, "Same-project neighbor must be in result"
+    assert foreign["id"] not in returned_ids, "Foreign-project node must be excluded"


### PR DESCRIPTION
## Summary

Implements Atlas Phase 5 (graph layer) per design doc `docs/plans/2026-05-05-phase-5-graph-layer-design.md`. Generalizes `memory_dependencies` to support 6 edge types and adds bounded recursive-CTE multi-hop traversal for richer agent context retrieval.

## Commits

- **5a**: migration 024 + `factory/graph/walker.py` + 7 postulates + 15 walker unit tests + migration test
- **5b**: `graph_walk` MCP tool registration (`mcp-server/src/index.ts` + `factory/graph/graph_walk_entry.py`)
- **5c**: `store()` extension for `derived_from` + `refined_by` params (TS + Python tests)
- **5d**: `deep_search` `with_graph` integration (`graph_max_hops`, `graph_max_nodes` params + `factory/graph/deep_search_graph_entry.py` + integration tests)

## Test plan
- [x] All 34 prior postulates pass
- [x] 7 new postulates pass (cross-project, bounded hops/nodes, cycle-safe, edge filter, archived excluded)
- [x] 15 walker unit tests pass
- [x] 3 migration 024 tests pass
- [x] 6 store-graph-edges tests pass
- [x] 5 deep_search with_graph integration tests pass
- [x] devbrain rules lint exits 0
- [x] mcp-server TypeScript compiles clean (tsc --noEmit)
- [x] Live: `graph_walk` MCP tool registered and callable
- [x] Live: `deep_search` with `with_graph=true` returns `graph` field

## Design decisions

- **No Apache AGE**: plain recursive CTEs on `memory_dependencies` per design §2. Stock Postgres handles bounded 3-hop traversal in <100ms for our graph scale.
- **`memory_dependencies` table NOT renamed**: CHECK constraint relaxed only (4→6 edge types). See migration 024.
- **Walker project isolation default**: `cross_project=False` is the safe default, matching `deep_search` semantics. P3 (HIPAA same-project isolation) holds.
- **Ambiguity resolved**: `factory/graph/__init__.py` uses relative import (`graph.walker`) not absolute (`factory.graph.walker`) since the entry points are invoked from `factory/` as cwd. Documented in 5d commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)