### PR TITLE
fix(memory): archive tier=rule pollution + dedup seeded rules + scope rules_lint

### DIFF
--- a/factory/curator/rules_lint.py
+++ b/factory/curator/rules_lint.py
@@ -51,17 +51,37 @@ class UnverifiedRule:
     compliance_profiles: list[str]
 
 
-def find_unverified_rules(conn: Any) -> list[UnverifiedRule]:
-    """Return profile-tagged rules with no matching postulate test."""
+def find_unverified_rules(
+    conn: Any, project_id: UUID | None = None
+) -> list[UnverifiedRule]:
+    """Return profile-tagged rules with no matching postulate test.
+
+    Optional ``project_id`` scopes the scan to a single project — useful for
+    tests that seed their own rules in a disposable project and don't want
+    to see seeded rules from migration 023 in the canonical 'devbrain'
+    project. Production CLI invocation passes None (scans all projects).
+    """
     with conn.cursor() as cur:
-        cur.execute(
-            "SELECT id, title, compliance_profiles "
-            "FROM devbrain.memory "
-            "WHERE tier = 'rule' "
-            "  AND compliance_profiles IS NOT NULL "
-            "  AND array_length(compliance_profiles, 1) > 0 "
-            "  AND archived_at IS NULL"
-        )
+        if project_id is not None:
+            cur.execute(
+                "SELECT id, title, compliance_profiles "
+                "FROM devbrain.memory "
+                "WHERE tier = 'rule' "
+                "  AND project_id = %s "
+                "  AND compliance_profiles IS NOT NULL "
+                "  AND array_length(compliance_profiles, 1) > 0 "
+                "  AND archived_at IS NULL",
+                (project_id,),
+            )
+        else:
+            cur.execute(
+                "SELECT id, title, compliance_profiles "
+                "FROM devbrain.memory "
+                "WHERE tier = 'rule' "
+                "  AND compliance_profiles IS NOT NULL "
+                "  AND array_length(compliance_profiles, 1) > 0 "
+                "  AND archived_at IS NULL"
+            )
         rows = cur.fetchall()
 
     if not rows:
@@ -82,9 +102,14 @@ def find_unverified_rules(conn: Any) -> list[UnverifiedRule]:
     return unverified
 
 
-def run_lint(conn: Any) -> int:
-    """CLI entry point. Exit 0 if clean, 1 if violations found."""
-    unverified = find_unverified_rules(conn)
+def run_lint(conn: Any, project_id: UUID | None = None) -> int:
+    """CLI entry point. Exit 0 if clean, 1 if violations found.
+
+    Optional ``project_id`` scopes the scan to a single project (passed
+    through to find_unverified_rules). CLI callers leave it as None to
+    scan all projects.
+    """
+    unverified = find_unverified_rules(conn, project_id=project_id)
     if not unverified:
         print("[rules lint] All profile-tagged rules have postulate tests. OK")
         return 0

--- a/factory/tests/test_curator_rules_lint.py
+++ b/factory/tests/test_curator_rules_lint.py
@@ -52,10 +52,15 @@ def _redirect_postulates_dir(monkeypatch, tmp_path):
 
 
 @pytest.mark.db
-def test_no_rules_returns_empty(conn, monkeypatch, tmp_path):
-    """Clean DB (no profile-tagged rules) -> empty list."""
+def test_no_rules_returns_empty(conn, project_factory, monkeypatch, tmp_path):
+    """Empty test project (no profile-tagged rules) -> empty list.
+
+    Scope to a freshly-created project so seeded rules from migration 023
+    in the canonical 'devbrain' project don't pollute the assertion.
+    """
+    project = project_factory("rl_empty")
     _redirect_postulates_dir(monkeypatch, tmp_path)
-    assert rules_lint.find_unverified_rules(conn) == []
+    assert rules_lint.find_unverified_rules(conn, project_id=project["id"]) == []
 
 
 @pytest.mark.db
@@ -76,7 +81,7 @@ def test_rule_with_uuid_in_postulate_passes(
     )
     _redirect_postulates_dir(monkeypatch, tmp_path)
 
-    assert rules_lint.find_unverified_rules(conn) == []
+    assert rules_lint.find_unverified_rules(conn, project_id=project["id"]) == []
 
 
 @pytest.mark.db
@@ -98,7 +103,7 @@ def test_rule_with_title_slug_in_postulate_passes(
     )
     _redirect_postulates_dir(monkeypatch, tmp_path)
 
-    assert rules_lint.find_unverified_rules(conn) == []
+    assert rules_lint.find_unverified_rules(conn, project_id=project["id"]) == []
 
 
 @pytest.mark.db
@@ -119,7 +124,7 @@ def test_rule_without_postulate_fails(
     _seed_postulate(tmp_path, "unrelated", "# nothing relevant here\n")
     _redirect_postulates_dir(monkeypatch, tmp_path)
 
-    unverified = rules_lint.find_unverified_rules(conn)
+    unverified = rules_lint.find_unverified_rules(conn, project_id=project["id"])
     flagged_ids = {r.id for r in unverified}
     assert rule["id"] in flagged_ids
 
@@ -138,7 +143,7 @@ def test_empty_profiles_rule_skipped(
     )
     _redirect_postulates_dir(monkeypatch, tmp_path)
     # No matching postulate exists, but lint should not flag.
-    assert rules_lint.find_unverified_rules(conn) == []
+    assert rules_lint.find_unverified_rules(conn, project_id=project["id"]) == []
 
 
 @pytest.mark.db
@@ -160,13 +165,21 @@ def test_archived_rule_skipped(
     conn.commit()
     _redirect_postulates_dir(monkeypatch, tmp_path)
 
-    assert rules_lint.find_unverified_rules(conn) == []
+    assert rules_lint.find_unverified_rules(conn, project_id=project["id"]) == []
 
 
 @pytest.mark.db
-def test_run_lint_exit_code_clean(conn, monkeypatch, tmp_path, capsys):
+def test_run_lint_exit_code_clean(
+    conn, project_factory, monkeypatch, tmp_path, capsys
+):
+    """Empty test project + matching postulates dir → exit 0.
+
+    Uses a fresh project to scope away from canonical 'devbrain' seeded
+    rules (which live in production-shape state and aren't subject to
+    test invariants)."""
+    project = project_factory("rl_clean")
     _redirect_postulates_dir(monkeypatch, tmp_path)
-    rc = rules_lint.run_lint(conn)
+    rc = rules_lint.run_lint(conn, project_id=project["id"])
     assert rc == 0
     captured = capsys.readouterr()
     assert "OK" in captured.out
@@ -185,7 +198,7 @@ def test_run_lint_exit_code_violations(
         compliance_profiles=["hipaa"],
     )
     _redirect_postulates_dir(monkeypatch, tmp_path)
-    rc = rules_lint.run_lint(conn)
+    rc = rules_lint.run_lint(conn, project_id=project["id"])
     assert rc == 1
     captured = capsys.readouterr()
     assert str(rule["id"]) in captured.err
@@ -206,7 +219,7 @@ def test_unverified_rule_has_full_payload(
         compliance_profiles=["hipaa", "soc2"],
     )
     _redirect_postulates_dir(monkeypatch, tmp_path)
-    unverified = rules_lint.find_unverified_rules(conn)
+    unverified = rules_lint.find_unverified_rules(conn, project_id=project["id"])
     target = next((r for r in unverified if r.id == rule["id"]), None)
     assert target is not None
     assert target.title == title

--- a/migrations/025_cognify_run_log.sql
+++ b/migrations/025_cognify_run_log.sql
@@ -6,7 +6,7 @@
 --
 -- Phase 6 design: docs/plans/2026-05-05-phase-6-cognify-memify-design.md §7
 
-CREATE TABLE devbrain.cognify_run_log (
+CREATE TABLE IF NOT EXISTS devbrain.cognify_run_log (
     id              BIGSERIAL PRIMARY KEY,
     pass_name       TEXT NOT NULL,                          -- 'extract', 'decay', etc.
     project_id      UUID REFERENCES devbrain.projects(id),
@@ -18,11 +18,12 @@ CREATE TABLE devbrain.cognify_run_log (
     metadata        JSONB
 );
 
-CREATE INDEX idx_cognify_run_log_pass_started
+CREATE INDEX IF NOT EXISTS idx_cognify_run_log_pass_started
     ON devbrain.cognify_run_log (pass_name, started_at DESC);
 
-CREATE INDEX idx_cognify_run_log_project_pass
+CREATE INDEX IF NOT EXISTS idx_cognify_run_log_project_pass
     ON devbrain.cognify_run_log (project_id, pass_name, started_at DESC);
 
 INSERT INTO devbrain.schema_migrations (filename)
-VALUES ('025_cognify_run_log.sql');
+VALUES ('025_cognify_run_log.sql')
+ON CONFLICT (filename) DO NOTHING;

--- a/migrations/026_archive_rule_tier_pollution.sql
+++ b/migrations/026_archive_rule_tier_pollution.sql
@@ -1,0 +1,71 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 026: Archive tier='rule' rows that lack compliance_profiles
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- Background. As of Phase 7c (migration 023) only rows with non-empty
+-- compliance_profiles can legitimately surface as rules in any project's
+-- curator brief. Per P6 semantics: a rule with empty/NULL
+-- compliance_profiles is invisible to all projects — explicit opt-in.
+-- Such rows are functionally inert.
+--
+-- During heavy autonomous-worker traffic on 2026-05-05, ~35k rule-tier
+-- rows accumulated in the canonical 'devbrain' project with NULL
+-- compliance_profiles. Source is unclear (graduated_at is NULL on these
+-- rows, so they didn't go through factory/cognify/strengthen.py;
+-- multiple writer-path candidates remain under investigation). They
+-- have no functional effect (P6 invisibility) but they pollute the
+-- rules_lint discovery scan and confuse counts.
+--
+-- This migration archives them (sets archived_at = NOW()) so they're
+-- excluded from all readers (curator brief, walker, deep_search) and
+-- the rules_lint scan. We do NOT DELETE — preserves the audit trail
+-- and matches GC policy from Phase 6 design (archive only, never delete).
+--
+-- The 5 legitimately seeded rules from migration 023 are unaffected —
+-- they have non-empty compliance_profiles so the WHERE clause excludes
+-- them.
+
+-- Step 1: archive rule rows that lack compliance_profiles (the
+-- pollution).
+UPDATE devbrain.memory
+SET archived_at = NOW()
+WHERE tier = 'rule'
+  AND (compliance_profiles IS NULL OR array_length(compliance_profiles, 1) = 0)
+  AND archived_at IS NULL;
+
+-- Step 2: dedup legitimate rule rows. Migration 023 ran multiple times
+-- on this DB at some prior point because its INSERT ... ON CONFLICT
+-- DO NOTHING relies on a unique constraint that doesn't apply to the
+-- columns it inserts (provenance_id is NULL on seed rows; the partial
+-- unique index `(provenance_id, kind) WHERE provenance_id IS NOT NULL`
+-- never fires). Each application created fresh duplicates of the 5
+-- seeded rules.
+--
+-- Strategy: per (project_id, title) within tier='rule', keep only the
+-- oldest row; archive the rest. The remaining row preserves the original
+-- seed semantics (compliance_profiles, content). Cleanest dedup since
+-- all dupes have identical content.
+WITH ranked_rules AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY project_id, title
+               ORDER BY created_at ASC
+           ) AS rn
+    FROM devbrain.memory
+    WHERE tier = 'rule'
+      AND archived_at IS NULL
+      AND compliance_profiles IS NOT NULL
+      AND array_length(compliance_profiles, 1) > 0
+)
+UPDATE devbrain.memory m
+SET archived_at = NOW()
+FROM ranked_rules r
+WHERE m.id = r.id AND r.rn > 1;
+
+-- Comment on the migration's effect for future readers.
+COMMENT ON TABLE devbrain.memory IS
+    'Phase 2 unified memory store. Migration 026 archived tier=rule + '
+    'NULL compliance_profiles rows (pollution from autonomous worker '
+    'traffic 2026-05-05) AND deduplicated legitimate seed rule rows '
+    '(migration 023 had a non-functional ON CONFLICT clause) — keeping '
+    'the oldest row per (project_id, title) within tier=rule.';


### PR DESCRIPTION
## Summary

Cleans up local DB pollution (~34,650 tier='rule' rows with NULL `compliance_profiles` accumulated yesterday during heavy autonomous-worker traffic) AND fixes the 11 local-dev-only test failures that resulted. Three coordinated fixes:

### Migration 026 — archive pollution + dedup seeds
- Archives the 34,650 polluted rows (verbatim duplicates of the 5 seeded compliance rule contents; functionally inert per P6).
- Dedups the legitimate seeded rules: migration 023's `ON CONFLICT DO NOTHING` was a no-op (no matching unique constraint on the inserted columns), so each migration 023 application created fresh duplicates. Migration 026 keeps the oldest row per `(project_id, title)` within `tier='rule'`.
- Result: canonical 'devbrain' has 5 active rule rows (one per seed) + 34,660 archived rows (audit preserved per HIPAA).

### Migration 025 — make re-runnable
- Adds `IF NOT EXISTS` to `CREATE TABLE` / `CREATE INDEX` and `ON CONFLICT (filename) DO NOTHING` to the `schema_migrations` INSERT. Matches the pattern in other migrations.
- Fixes `test_schema_migrate.py::test_migrate_end_to_end_when_tracking_table_missing` which exercises a re-application path.

### `rules_lint` — optional project_id scope
- `find_unverified_rules()` and `run_lint()` get an optional `project_id: UUID | None` parameter.
- Tests in `test_curator_rules_lint.py` updated to pass `project_id` explicitly so they don't trip on the canonical 'devbrain' project's seeded rules.
- Production CLI behavior unchanged (scans all projects when `project_id=None`).

## Test plan

- [x] All 11 local failures resolved (test_curator_rules_lint × 6, test_migration_023 × 4, test_schema_migrate × 1)
- [x] CI subset green: 332 tests pass
- [x] Live verification: canonical 'devbrain' now has exactly 5 active tier='rule' rows, one per seeded compliance rule with proper `compliance_profiles` tagging
- [x] Run `devbrain rules lint` — exits 0
- [x] No code changes affect non-test production paths (lint CLI behavior unchanged)

## Out of scope (follow-up)

The actual writer that produced the 34,650 polluted rows is unidentified. Sample rows have NULL `provenance_id` + NULL `applies_when` + `tier='rule'` + `graduated_at=NULL` — a combination that doesn't match any writer in current code. Likely cross-instance replication from a machine running an earlier-shape migration 023, or a code path that's been refactored away.

A more durable fix would be a unique constraint on `(project_id, kind, title)` where `tier='rule' AND compliance_profiles IS NOT NULL` to prevent future legitimate-rule duplication. Requires content-hash column and a separate migration. Deferred since the partial unique index on `(provenance_id, kind)` suffices for the ingest path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)