### PR TITLE
feat: worker.py multi-hop cascade + edge-level memory_ledger trigger

### DIFF
--- a/factory/curator/worker.py
+++ b/factory/curator/worker.py
@@ -8,7 +8,10 @@ Each batch:
 2. For each: load memory, compute new_strength, UPDATE memory, DELETE
    queue row.
 3. Multi-hop: if penalty was significant (> MULTI_HOP_THRESHOLD after
-   freshness decay), walk the row's own dependents and enqueue them.
+   freshness decay), walk ALL transitive dependents in one pass using the
+   Phase 5 graph walker (factory.graph.walker.walk with direction='incoming')
+   and enqueue them all at once. This replaces the old 1-hop SQL JOIN that
+   required multiple drain cycles to propagate deep cascades.
 
 On exception: increment attempt_count, persist last_error, leave queue
 row in place. After 3 failures, the row is filtered out by both the
@@ -20,6 +23,12 @@ Cycle prevention: each row carries an enqueued_at timestamp. The worker
 also reads memory.last_cascade_at; if that timestamp is at-or-after the
 queue row's enqueued_at the row is dropped without doing work — this
 breaks dependency cycles (A -> B -> A) cleanly.
+
+Multi-hop cycle prevention: the walker's own visited-set accumulator in
+the recursive CTE prevents revisiting nodes within a single walk. The
+`last_cascade_at >= enqueued_at` guard provides the second layer:
+transitive dependents whose last_cascade_at is already at-or-after the
+cascade wave's enqueued_at are skipped at enqueue time.
 """
 from __future__ import annotations
 
@@ -36,6 +45,11 @@ logger = logging.getLogger(__name__)
 # freshness decay) is smaller than this, don't bother propagating to the
 # dependent's own dependents — too small to matter.
 MULTI_HOP_THRESHOLD = Decimal("0.05")
+
+# Walker bounds for transitive dependent enumeration. max_hops=5 matches
+# the Phase 5.x design spec; max_nodes=200 matches the walker's hard cap.
+_WALK_MAX_HOPS = 5
+_WALK_MAX_NODES = 200
 
 
 def drain_one_batch(conn: Any, batch_size: int = 50) -> int:
@@ -153,36 +167,62 @@ def _process_one(
             (queue_id,),
         )
 
-        # Multi-hop propagation. Cycle prevention is two-layer:
+        # Multi-hop propagation via Phase 5 graph walker.
         #
-        #   1. Propagate the cascade wave's timestamp (this row's
-        #      enqueued_at) into the new row instead of letting NOW()
-        #      win. A multi-hop row is logically "from the same wave"
-        #      as its parent, so its enqueued_at must match — that's
-        #      what lets the `last_cascade_at >= enqueued_at` guard in
-        #      _process_one short-circuit a repeat visit.
-        #   2. Filter out dependents whose memory.last_cascade_at is
-        #      at-or-after this row's enqueued_at — they were already
-        #      touched by this same wave.
+        # Instead of the old 1-hop SQL JOIN, we walk ALL transitive
+        # dependents of memory_id in one pass (direction='incoming' —
+        # "who depends on me?"). The walker uses a recursive CTE with a
+        # visited-set accumulator, so cycles are already handled at the
+        # SQL level. We then INSERT all discovered dependents (excluding
+        # the seed itself) into the queue in one bulk INSERT.
+        #
+        # Cycle prevention is two-layer:
+        #   1. The walker's visited-set CTE prevents revisiting nodes
+        #      within this walk pass.
+        #   2. The `last_cascade_at >= enqueued_at` WHERE filter below
+        #      skips dependents already touched by this cascade wave.
+        #
+        # The cascade wave's enqueued_at is propagated into new rows
+        # (not NOW()) so that `_process_one`'s guard correctly
+        # short-circuits revisits of the same wave.
         #
         # Combined with the dedup partial unique index
         # (idx_re_eval_queue_dedup, partial WHERE attempt_count < 3) on
         # (memory_id, cascade_source_id, edge_type), this guarantees a
         # cycle (A->B->A) converges in one wave.
         if penalty > MULTI_HOP_THRESHOLD:
-            cur.execute(
-                "INSERT INTO devbrain.curator_re_eval_queue "
-                "(memory_id, cascade_source_id, edge_type, enqueued_at) "
-                "SELECT d.from_memory_id, %s, %s, %s "
-                "FROM devbrain.memory_dependencies d "
-                "JOIN devbrain.memory m ON m.id = d.from_memory_id "
-                "WHERE d.to_memory_id = %s "
-                "  AND d.edge_type = 'depends_on' "
-                "  AND (m.last_cascade_at IS NULL "
-                "       OR m.last_cascade_at < %s) "
-                "ON CONFLICT (memory_id, cascade_source_id, edge_type) "
-                "WHERE attempt_count < 3 DO NOTHING",
-                (memory_id, edge_type, enqueued_at, memory_id, enqueued_at),
+            from graph.walker import walk as _graph_walk  # local import avoids circular dep
+
+            walk_result = _graph_walk(
+                conn,
+                memory_id,
+                edge_types=["depends_on"],
+                max_hops=_WALK_MAX_HOPS,
+                max_nodes=_WALK_MAX_NODES,
+                direction="incoming",
+                cross_project=False,
             )
+            # Collect all transitive dependent IDs excluding the seed
+            # (hops=0 is the seed itself, not a dependent).
+            dependent_ids = [
+                str(ref.id)
+                for ref in walk_result.memories
+                if ref.hops > 0
+            ]
+            if dependent_ids:
+                # Bulk-enqueue transitive dependents. Filter at the DB
+                # level to skip any already touched by this cascade wave.
+                cur.execute(
+                    "INSERT INTO devbrain.curator_re_eval_queue "
+                    "(memory_id, cascade_source_id, edge_type, enqueued_at) "
+                    "SELECT m.id, %s, %s, %s "
+                    "FROM devbrain.memory m "
+                    "WHERE m.id = ANY(%s::uuid[]) "
+                    "  AND (m.last_cascade_at IS NULL "
+                    "       OR m.last_cascade_at < %s) "
+                    "ON CONFLICT (memory_id, cascade_source_id, edge_type) "
+                    "WHERE attempt_count < 3 DO NOTHING",
+                    (memory_id, edge_type, enqueued_at, dependent_ids, enqueued_at),
+                )
 
     conn.commit()

--- a/factory/tests/test_migration_027.py
+++ b/factory/tests/test_migration_027.py
@@ -1,0 +1,252 @@
+"""Tests for migration 027: memory_dependencies ledger trigger.
+
+Asserts that:
+  1. The three new edge-event operation values are accepted by the
+     memory_ledger CHECK constraint.
+  2. An INSERT into memory_dependencies writes an 'edge_added' ledger row
+     with the correct memory_id (from_memory_id), operation, and JSONB details.
+  3. A DELETE from memory_dependencies writes an 'edge_removed' ledger row.
+  4. An UPDATE to memory_dependencies writes an 'edge_updated' ledger row.
+  5. The trigger function and triggers exist in the database.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.mark.db
+def test_027_trigger_function_exists(conn):
+    """The _memory_dependencies_ledger_record trigger function must exist."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT routine_name FROM information_schema.routines "
+            "WHERE routine_schema = 'devbrain' "
+            "AND routine_name = '_memory_dependencies_ledger_record'"
+        )
+        assert cur.fetchone() is not None, (
+            "_memory_dependencies_ledger_record function not found in devbrain schema"
+        )
+
+
+@pytest.mark.db
+def test_027_insert_trigger_exists(conn):
+    """AFTER INSERT trigger on memory_dependencies must exist."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT trigger_name FROM information_schema.triggers "
+            "WHERE event_object_schema = 'devbrain' "
+            "  AND event_object_table = 'memory_dependencies' "
+            "  AND trigger_name = 'trg_memory_dep_ledger_insert'"
+        )
+        assert cur.fetchone() is not None, "trg_memory_dep_ledger_insert not found"
+
+
+@pytest.mark.db
+def test_027_delete_trigger_exists(conn):
+    """AFTER DELETE trigger on memory_dependencies must exist."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT trigger_name FROM information_schema.triggers "
+            "WHERE event_object_schema = 'devbrain' "
+            "  AND event_object_table = 'memory_dependencies' "
+            "  AND trigger_name = 'trg_memory_dep_ledger_delete'"
+        )
+        assert cur.fetchone() is not None, "trg_memory_dep_ledger_delete not found"
+
+
+@pytest.mark.db
+def test_027_update_trigger_exists(conn):
+    """AFTER UPDATE trigger on memory_dependencies must exist."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT trigger_name FROM information_schema.triggers "
+            "WHERE event_object_schema = 'devbrain' "
+            "  AND event_object_table = 'memory_dependencies' "
+            "  AND trigger_name = 'trg_memory_dep_ledger_update'"
+        )
+        assert cur.fetchone() is not None, "trg_memory_dep_ledger_update not found"
+
+
+@pytest.mark.db
+def test_027_ledger_constraint_accepts_edge_operations(conn):
+    """The memory_ledger operation column must accept the three new edge event values."""
+    # We verify the constraint by checking the information_schema check constraint
+    # definition includes all three new values, without doing a raw INSERT into
+    # the ledger (which would require a valid project and chain state).
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT cc.check_clause
+            FROM information_schema.check_constraints cc
+            JOIN information_schema.table_constraints tc
+              ON tc.constraint_name = cc.constraint_name
+             AND tc.constraint_schema = cc.constraint_schema
+            WHERE tc.table_schema = 'devbrain'
+              AND tc.table_name = 'memory_ledger'
+              AND tc.constraint_type = 'CHECK'
+              AND cc.check_clause LIKE '%edge_added%'
+            """
+        )
+        row = cur.fetchone()
+    assert row is not None, (
+        "memory_ledger CHECK constraint does not include 'edge_added'; "
+        "migration 027 may not have been applied"
+    )
+    clause = row[0]
+    assert "edge_updated" in clause, f"'edge_updated' missing from CHECK: {clause}"
+    assert "edge_removed" in clause, f"'edge_removed' missing from CHECK: {clause}"
+
+
+@pytest.mark.db
+def test_027_edge_insert_writes_edge_added_ledger_row(
+    conn, project_factory, memory_factory
+):
+    """Inserting an edge must produce an 'edge_added' ledger row with correct fields."""
+    project = project_factory("mig027_insert")
+    src = memory_factory(project["id"], kind="decision", title="src_027")
+    dst = memory_factory(project["id"], kind="decision", title="dst_027")
+
+    # Capture ledger high-water mark before inserting the edge.
+    with conn.cursor() as cur:
+        cur.execute("SELECT COALESCE(MAX(seq), 0) FROM devbrain.memory_ledger")
+        seq_before = cur.fetchone()[0]
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test_027')",
+            (src["id"], dst["id"]),
+        )
+    conn.commit()
+
+    # Expect exactly one new ledger row after our high-water mark for this edge.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT memory_id, operation, project_slug, payload_hash "
+            "FROM devbrain.memory_ledger "
+            "WHERE seq > %s "
+            "  AND memory_id = %s "
+            "  AND operation = 'edge_added'",
+            (seq_before, src["id"]),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) >= 1, (
+        f"Expected at least 1 'edge_added' ledger row for {src['id']}, got {len(rows)}"
+    )
+    ledger_row = rows[-1]
+    assert str(ledger_row[0]) == str(src["id"]), "memory_id should be from_memory_id"
+    assert ledger_row[1] == "edge_added"
+    # project_slug must be non-empty (resolved from from_memory_id).
+    assert ledger_row[2], "project_slug should be non-empty"
+    # payload_hash must be a non-empty bytea.
+    assert ledger_row[3], "payload_hash should be non-empty"
+
+
+@pytest.mark.db
+def test_027_edge_delete_writes_edge_removed_ledger_row(
+    conn, project_factory, memory_factory
+):
+    """Deleting an edge must produce an 'edge_removed' ledger row."""
+    project = project_factory("mig027_delete")
+    src = memory_factory(project["id"], kind="decision", title="src_027_del")
+    dst = memory_factory(project["id"], kind="decision", title="dst_027_del")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test_027')",
+            (src["id"], dst["id"]),
+        )
+    conn.commit()
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT COALESCE(MAX(seq), 0) FROM devbrain.memory_ledger")
+        seq_before = cur.fetchone()[0]
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM devbrain.memory_dependencies "
+            "WHERE from_memory_id = %s AND to_memory_id = %s",
+            (src["id"], dst["id"]),
+        )
+    conn.commit()
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT memory_id, operation FROM devbrain.memory_ledger "
+            "WHERE seq > %s "
+            "  AND memory_id = %s "
+            "  AND operation = 'edge_removed'",
+            (seq_before, src["id"]),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) >= 1, (
+        f"Expected at least 1 'edge_removed' ledger row for {src['id']}, got {len(rows)}"
+    )
+
+
+@pytest.mark.db
+def test_027_edge_update_writes_edge_updated_ledger_row(
+    conn, project_factory, memory_factory
+):
+    """Updating an edge (e.g. confidence) must produce an 'edge_updated' ledger row."""
+    project = project_factory("mig027_update")
+    src = memory_factory(project["id"], kind="decision", title="src_027_upd")
+    dst = memory_factory(project["id"], kind="decision", title="dst_027_upd")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by, confidence) "
+            "VALUES (%s, %s, 'depends_on', 'test_027', 1.0)",
+            (src["id"], dst["id"]),
+        )
+    conn.commit()
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT COALESCE(MAX(seq), 0) FROM devbrain.memory_ledger")
+        seq_before = cur.fetchone()[0]
+
+    # Update the confidence column.
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory_dependencies "
+            "SET confidence = 0.75 "
+            "WHERE from_memory_id = %s AND to_memory_id = %s",
+            (src["id"], dst["id"]),
+        )
+    conn.commit()
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT memory_id, operation FROM devbrain.memory_ledger "
+            "WHERE seq > %s "
+            "  AND memory_id = %s "
+            "  AND operation = 'edge_updated'",
+            (seq_before, src["id"]),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) >= 1, (
+        f"Expected at least 1 'edge_updated' ledger row for {src['id']}, got {len(rows)}"
+    )
+
+
+@pytest.mark.db
+def test_027_migration_recorded_in_schema_migrations(conn):
+    """Migration 027 must be recorded in devbrain.schema_migrations."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT filename FROM devbrain.schema_migrations "
+            "WHERE filename = '027_memory_dependencies_ledger_trigger.sql'"
+        )
+        assert cur.fetchone() is not None, (
+            "Migration 027 not found in schema_migrations; "
+            "apply the migration before running these tests."
+        )

--- a/migrations/027_memory_dependencies_ledger_trigger.sql
+++ b/migrations/027_memory_dependencies_ledger_trigger.sql
@@ -1,0 +1,173 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 027: memory_dependencies ledger trigger — edge-level audit trail
+-- ═══════════════════════════════════════════════════════════════════════════
+--
+-- Phase 5.x (worker multi-hop + edge audit). Adds an AFTER trigger on
+-- devbrain.memory_dependencies so that every edge INSERT/UPDATE/DELETE writes
+-- a corresponding row to devbrain.memory_ledger for full audit coverage.
+--
+-- Design rationale
+-- ────────────────
+-- Migration 015 wired ledger triggers on devbrain.memory (the node table).
+-- But memory_dependencies (the edge table) was never covered — an edge
+-- insert or delete left no audit trail. Phase 5 graph semantics make edges
+-- first-class objects (six typed edges, confidence, metadata) so edge
+-- mutations must be audited too.
+--
+-- The ledger row for an edge event:
+--   memory_id    = from_memory_id   — the dependent side; primary subject
+--   operation    = 'edge_added' | 'edge_updated' | 'edge_removed'
+--   actor        = devbrain.actor GUC or current_user
+--   project_slug = resolved from from_memory_id → memory → projects
+--   payload_hash = sha256(JSONB of edge fields: edge_type, to_memory_id,
+--                          confidence, metadata)
+--   prev_hash / row_hash = same hash-chain mechanics as migration 015
+--
+-- The operation column CHECK constraint is extended to include the three new
+-- edge event values so both memory-row events and edge events share the same
+-- ledger table.
+--
+-- Determinism guarantee: the trigger always uses to_jsonb(ROW(...)::text) with
+-- a fixed column order so the same edge state always produces the same
+-- payload_hash. This is equivalent to the memory trigger's `to_jsonb(NEW)`.
+--
+-- Cost: one additional ledger row per edge mutation. Edge mutations are less
+-- frequent than memory writes; negligible overhead.
+--
+-- Note: ledger rows for edge events share the same hash chain as memory-row
+-- ledger rows (seq is global to the table). This means verify_chain() will
+-- cross-validate both kinds of events together — intentional, since the goal
+-- is a single tamper-evident log of all devbrain mutations.
+--
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- ── 1. Extend the operation CHECK constraint to include edge event types ──────
+ALTER TABLE devbrain.memory_ledger
+    DROP CONSTRAINT IF EXISTS memory_ledger_operation_check;
+
+ALTER TABLE devbrain.memory_ledger
+    ADD CONSTRAINT memory_ledger_operation_check
+    CHECK (operation IN (
+        'create', 'update', 'archive', 'restore', 'delete',
+        'edge_added', 'edge_updated', 'edge_removed'
+    ));
+
+-- ── 2. Trigger function for memory_dependencies edge events ──────────────────
+CREATE OR REPLACE FUNCTION devbrain._memory_dependencies_ledger_record()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    op            TEXT;
+    edge_row      RECORD;
+    payload_text  TEXT;
+    payload_h     BYTEA;
+    prev_h        BYTEA;
+    next_seq      BIGINT;
+    cur_row_hash  BYTEA;
+    actor_name    TEXT;
+    proj_id       UUID;
+    proj_slug     TEXT;
+    target_id     UUID;  -- from_memory_id (dependent side, primary subject)
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        op       := 'edge_added';
+        edge_row := NEW;
+    ELSIF TG_OP = 'UPDATE' THEN
+        op       := 'edge_updated';
+        edge_row := NEW;
+    ELSIF TG_OP = 'DELETE' THEN
+        op       := 'edge_removed';
+        edge_row := OLD;
+    ELSE
+        -- Defensive: TRUNCATE etc.; do nothing rather than corrupt the chain.
+        RETURN NULL;
+    END IF;
+
+    -- Primary subject = from_memory_id (the dependent side whose state is
+    -- implicated by the edge). This matches the audit spec in migration 027.
+    target_id := edge_row.from_memory_id;
+
+    -- Canonical payload: stable JSONB of the edge fields that matter for audit.
+    -- Fixed key order via jsonb_build_object so hash is deterministic regardless
+    -- of column addition order in future migrations.
+    payload_text := jsonb_build_object(
+        'edge_type',     edge_row.edge_type,
+        'to_memory_id',  edge_row.to_memory_id,
+        'confidence',    edge_row.confidence,
+        'metadata',      edge_row.metadata
+    )::text;
+
+    payload_h := digest(payload_text, 'sha256');
+
+    -- Resolve project_slug from the from_memory row. May be NULL if the
+    -- memory was hard-deleted (edge DELETE fires before cascade from memory).
+    SELECT p.slug INTO proj_slug
+    FROM devbrain.memory m
+    JOIN devbrain.projects p ON p.id = m.project_id
+    WHERE m.id = target_id;
+
+    IF proj_slug IS NULL THEN
+        proj_slug := 'unknown';
+    END IF;
+
+    -- Actor: prefer app-set GUC; fall back to current_user.
+    actor_name := COALESCE(current_setting('devbrain.actor', true), current_user);
+
+    -- Serialize concurrent ledger writes (same lock as migration 015 so
+    -- memory-row events and edge events are serialized against each other,
+    -- preserving a single coherent hash chain).
+    PERFORM pg_advisory_xact_lock(hashtext('devbrain.memory_ledger'));
+
+    -- Reserve next seq + read prev_hash atomically (within the lock).
+    next_seq := nextval(pg_get_serial_sequence('devbrain.memory_ledger', 'seq'));
+    SELECT row_hash INTO prev_h
+    FROM devbrain.memory_ledger
+    ORDER BY seq DESC
+    LIMIT 1;
+
+    -- Compose the row hash using the same formula as migration 015 so
+    -- verify_chain() validates both kinds of events uniformly.
+    cur_row_hash := digest(
+        next_seq::text
+            || '|' || target_id::text
+            || '|' || op
+            || '|' || actor_name
+            || '|' || proj_slug
+            || '|' || encode(payload_h, 'hex')
+            || '|' || COALESCE(encode(prev_h, 'hex'), ''),
+        'sha256'
+    );
+
+    INSERT INTO devbrain.memory_ledger (
+        seq, memory_id, operation, actor, project_slug,
+        payload_hash, prev_hash, row_hash
+    ) VALUES (
+        next_seq, target_id, op, actor_name, proj_slug,
+        payload_h, prev_h, cur_row_hash
+    );
+
+    RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+-- ── 3. Attach triggers to memory_dependencies ────────────────────────────────
+DROP TRIGGER IF EXISTS trg_memory_dep_ledger_insert ON devbrain.memory_dependencies;
+CREATE TRIGGER trg_memory_dep_ledger_insert
+    AFTER INSERT ON devbrain.memory_dependencies
+    FOR EACH ROW EXECUTE FUNCTION devbrain._memory_dependencies_ledger_record();
+
+DROP TRIGGER IF EXISTS trg_memory_dep_ledger_update ON devbrain.memory_dependencies;
+CREATE TRIGGER trg_memory_dep_ledger_update
+    AFTER UPDATE ON devbrain.memory_dependencies
+    FOR EACH ROW EXECUTE FUNCTION devbrain._memory_dependencies_ledger_record();
+
+DROP TRIGGER IF EXISTS trg_memory_dep_ledger_delete ON devbrain.memory_dependencies;
+CREATE TRIGGER trg_memory_dep_ledger_delete
+    AFTER DELETE ON devbrain.memory_dependencies
+    FOR EACH ROW EXECUTE FUNCTION devbrain._memory_dependencies_ledger_record();
+
+-- ── 4. Track this migration ───────────────────────────────────────────────────
+INSERT INTO devbrain.schema_migrations (filename, applied_at)
+VALUES ('027_memory_dependencies_ledger_trigger.sql', now())
+ON CONFLICT (filename) DO NOTHING;

--- a/tests/postulates/test_p_edge_ledger_audit.py
+++ b/tests/postulates/test_p_edge_ledger_audit.py
@@ -1,0 +1,114 @@
+"""P_edge_ledger_audit — every memory_dependencies INSERT produces a ledger row.
+
+POSTULATE
+---------
+Every INSERT into devbrain.memory_dependencies produces a corresponding
+row in devbrain.memory_ledger with:
+  - memory_id   = from_memory_id of the inserted edge
+  - operation   = 'edge_added'
+
+This is the audit guarantee introduced in migration 027. The ledger
+trigger fires AFTER INSERT on memory_dependencies so the guaranteee is
+enforced at the database level, not at application level.
+
+SECONDARY ASSERTIONS
+--------------------
+The ledger row's project_slug must be non-empty (resolved from
+from_memory_id → memory → projects). The payload_hash must be a
+non-empty BYTEA.
+
+STATUS
+------
+Activated by migration 027 (edge-level ledger trigger, Phase 5.x).
+"""
+from __future__ import annotations
+
+
+def test_edge_insert_always_produces_ledger_row(
+    conn, project_factory, memory_factory
+):
+    """Every memory_dependencies INSERT must produce an 'edge_added' ledger row."""
+    project = project_factory("p_ela")
+    src = memory_factory(project["id"], kind="decision", content="src for edge audit")
+    dst = memory_factory(project["id"], kind="pattern", content="dst for edge audit")
+
+    # Capture the ledger high-water mark before the edge insert.
+    with conn.cursor() as cur:
+        cur.execute("SELECT COALESCE(MAX(seq), 0) FROM devbrain.memory_ledger")
+        seq_before = cur.fetchone()[0]
+
+    # Insert the edge.
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            (src["id"], dst["id"]),
+        )
+    conn.commit()
+
+    # The ledger must have a new 'edge_added' row for from_memory_id.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT memory_id, operation, project_slug, payload_hash "
+            "FROM devbrain.memory_ledger "
+            "WHERE seq > %s "
+            "  AND memory_id = %s "
+            "  AND operation = 'edge_added'",
+            (seq_before, src["id"]),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) >= 1, (
+        f"Expected at least 1 'edge_added' ledger row for edge "
+        f"from_memory_id={src['id']}, got {len(rows)}. "
+        "Migration 027 may not have been applied."
+    )
+
+    ledger_row = rows[-1]
+    memory_id, operation, project_slug, payload_hash = ledger_row
+
+    assert str(memory_id) == str(src["id"]), (
+        f"Ledger memory_id {memory_id!r} != from_memory_id {src['id']!r}"
+    )
+    assert operation == "edge_added"
+    assert project_slug, "project_slug must be non-empty (resolved from project)"
+    assert payload_hash, "payload_hash must be non-empty BYTEA"
+
+
+def test_multiple_edge_inserts_each_produce_ledger_row(
+    conn, project_factory, memory_factory
+):
+    """Each edge insert must produce its own distinct 'edge_added' ledger row."""
+    project = project_factory("p_ela_multi")
+    a = memory_factory(project["id"], content="a")
+    b = memory_factory(project["id"], content="b")
+    c = memory_factory(project["id"], content="c")
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT COALESCE(MAX(seq), 0) FROM devbrain.memory_ledger")
+        seq_before = cur.fetchone()[0]
+
+    # Insert two edges.
+    with conn.cursor() as cur:
+        cur.executemany(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'postulate-test')",
+            [(b["id"], a["id"]), (c["id"], b["id"])],
+        )
+    conn.commit()
+
+    # Each edge must produce its own ledger row.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT memory_id FROM devbrain.memory_ledger "
+            "WHERE seq > %s "
+            "  AND operation = 'edge_added' "
+            "  AND memory_id = ANY(%s::uuid[])",
+            (seq_before, [str(b["id"]), str(c["id"])]),
+        )
+        found = {row[0] for row in cur.fetchall()}
+
+    assert b["id"] in found, f"No 'edge_added' ledger row for b={b['id']}"
+    assert c["id"] in found, f"No 'edge_added' ledger row for c={c['id']}"

--- a/tests/postulates/test_p_worker_multi_hop.py
+++ b/tests/postulates/test_p_worker_multi_hop.py
@@ -1,0 +1,139 @@
+"""P_worker_multi_hop — cascade worker enqueues all transitive dependents in one pass.
+
+POSTULATE
+---------
+When drain_one_batch() processes a queued memory B (which depends_on A),
+and B itself has a transitive chain of dependents (C depends_on B,
+D depends_on C), the worker enqueues ALL of C and D in the same drain
+pass — not just the immediate 1-hop dependent.
+
+This exercises the Phase 5.x multi-hop refactor where the old 1-hop SQL
+JOIN was replaced with factory.graph.walker.walk(direction='incoming') to
+enumerate all transitive dependents in one recursive CTE pass.
+
+MECHANISM
+---------
+Before this refactor, a 3-node chain A→B→C→D required two drain cycles:
+  Cycle 1: process B → enqueues C (1-hop)
+  Cycle 2: process C → enqueues D (1-hop)
+
+After this refactor, one drain cycle processes B and enqueues both C and D
+simultaneously via the recursive CTE walker.
+
+STATUS
+------
+Activated in Phase 5.x worker multi-hop refactor (PR fix/worker-ledger).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_FACTORY = Path(__file__).resolve().parents[2] / "factory"
+if str(_FACTORY) not in sys.path:
+    sys.path.insert(0, str(_FACTORY))
+
+from curator.worker import drain_one_batch  # noqa: E402
+
+
+def test_worker_enqueues_all_transitive_dependents_in_one_pass(
+    conn, project_factory, memory_factory
+):
+    """A 3-hop chain A→B→C→D: processing B enqueues both C and D immediately."""
+    project = project_factory("p_wmh")
+    a = memory_factory(project["id"], content="a — root source")
+    b = memory_factory(project["id"], content="b — depends on a")
+    c = memory_factory(project["id"], content="c — depends on b")
+    d = memory_factory(project["id"], content="d — depends on c")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET strength = 0.85 WHERE id IN (%s,%s,%s,%s)",
+            (a["id"], b["id"], c["id"], d["id"]),
+        )
+        # Build the dependency chain: b→a, c→b, d→c
+        cur.executemany(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test')",
+            [
+                (b["id"], a["id"]),
+                (c["id"], b["id"]),
+                (d["id"], c["id"]),
+            ],
+        )
+        # Enqueue B for cascade (triggered by A being superseded)
+        cur.execute(
+            "INSERT INTO devbrain.curator_re_eval_queue "
+            "(memory_id, cascade_source_id, edge_type) "
+            "VALUES (%s, %s, 'supersedes')",
+            (b["id"], a["id"]),
+        )
+    conn.commit()
+
+    # Single drain pass — should process B and enqueue C AND D transitively.
+    drained = drain_one_batch(conn, batch_size=10)
+    assert drained == 1, f"expected 1 drained (B), got {drained}"
+
+    # Both C and D must be in the queue after one pass.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT memory_id FROM devbrain.curator_re_eval_queue "
+            "WHERE memory_id = ANY(%s::uuid[])",
+            ([str(c["id"]), str(d["id"])],),
+        )
+        enqueued = {row[0] for row in cur.fetchall()}
+
+    assert c["id"] in enqueued, "C (1-hop transitive dependent) not enqueued in first pass"
+    assert d["id"] in enqueued, "D (2-hop transitive dependent) not enqueued in first pass"
+
+
+def test_worker_multi_hop_cycle_still_converges(
+    conn, project_factory, memory_factory
+):
+    """Multi-hop walker does not cause infinite loops when a dependency cycle exists."""
+    project = project_factory("p_wmhc")
+    a = memory_factory(project["id"], content="a — cycle node 1")
+    b = memory_factory(project["id"], content="b — cycle node 2")
+    c = memory_factory(project["id"], content="c — depends on both")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET strength = 0.9 WHERE id IN (%s,%s,%s)",
+            (a["id"], b["id"], c["id"]),
+        )
+        # A and B form a cycle; C depends on B
+        cur.executemany(
+            "INSERT INTO devbrain.memory_dependencies "
+            "(from_memory_id, to_memory_id, edge_type, created_by) "
+            "VALUES (%s, %s, 'depends_on', 'test')",
+            [
+                (a["id"], b["id"]),   # a depends_on b
+                (b["id"], a["id"]),   # b depends_on a (cycle)
+                (c["id"], b["id"]),   # c depends_on b
+            ],
+        )
+        # Enqueue A for cascade
+        cur.execute(
+            "INSERT INTO devbrain.curator_re_eval_queue "
+            "(memory_id, cascade_source_id, edge_type) "
+            "VALUES (%s, %s, 'supersedes')",
+            (a["id"], b["id"]),
+        )
+    conn.commit()
+
+    # Drain repeatedly — must converge in finite passes.
+    iterations = 0
+    while iterations < 10:
+        drained = drain_one_batch(conn, batch_size=50)
+        if drained == 0:
+            break
+        iterations += 1
+
+    assert iterations < 10, "multi-hop cascade with cycle did not converge"
+
+    # Queue must be empty after convergence.
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM devbrain.curator_re_eval_queue")
+        remaining = cur.fetchone()[0]
+    assert remaining == 0, f"queue not empty after convergence: {remaining} rows remain"


### PR DESCRIPTION
## Summary

- **Commit 1 — `feat(worker)`**: Replace the 1-hop SQL JOIN in `factory/curator/worker.py` `_process_one` with `factory.graph.walker.walk(direction='incoming', max_hops=5, max_nodes=200)`. All transitive dependents are now enumerated in one recursive-CTE pass and bulk-inserted into `curator_re_eval_queue` — no more chained drain cycles for deep dependency chains.

- **Commit 2 — `feat(memory)`**: Add migration `027_memory_dependencies_ledger_trigger.sql` that extends `memory_ledger.operation` to include `edge_added` / `edge_updated` / `edge_removed` and attaches AFTER INSERT/UPDATE/DELETE triggers on `devbrain.memory_dependencies`, writing ledger rows with `memory_id=from_memory_id`, deterministic `payload_hash`, and the same hash-chain mechanics as migration 015.

## Files changed

- `factory/curator/worker.py` — multi-hop walker integration
- `tests/postulates/test_p_worker_multi_hop.py` — new postulate (3-hop chain + cycle convergence)
- `migrations/027_memory_dependencies_ledger_trigger.sql` — edge audit trigger migration
- `factory/tests/test_migration_027.py` — schema + functional tests (8 assertions)
- `tests/postulates/test_p_edge_ledger_audit.py` — new postulate (every edge INSERT → ledger row)

## Test plan

- [ ] All pre-existing postulates pass: P1 supersession cascades, P_archived_mid_cascade, P_cycle
- [ ] All pre-existing curator worker tests pass (`test_curator_worker.py` — 4 tests)
- [ ] New postulate `test_p_worker_multi_hop` passes (2 tests)
- [ ] New migration tests `test_migration_027` pass (8 tests)
- [ ] New postulate `test_p_edge_ledger_audit` passes (2 tests)
- [ ] Total: 88/88 passed locally

## Migration notes

Apply migration 027 before running tests:
```bash
PGPASSWORD=$PW psql -h 127.0.0.1 -p 5433 -U devbrain -d devbrain \
  -f migrations/027_memory_dependencies_ledger_trigger.sql
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)