### PR TITLE
feat(observability): cognify spend tracking + versioned re-extraction

### DIFF
--- a/factory/cognify/edges.py
+++ b/factory/cognify/edges.py
@@ -12,10 +12,12 @@ LLM cost ceiling: max 15 calls per pass for contradicts detection.
 
 Phase 5 dependency: walk() is called directly. Phase 5 is live in main
 (commit 9523987). No fallback needed.
+
+Spend tracking: each LLM call for contradiction detection writes a row to
+devbrain.cognify_spend_log via observability.spend.record_spend.
 """
 from __future__ import annotations
 
-import json
 import logging
 import re
 from typing import Any
@@ -23,11 +25,16 @@ from uuid import UUID
 
 from cognify.orchestrator import CognifyPass, PassResult, register_pass
 from graph.walker import walk
+from observability.pricing import SONNET_4_6, compute_cost_usd
+from observability.spend import record_spend
 
 logger = logging.getLogger(__name__)
 
 # Max LLM calls per pass for contradicts detection.
 MAX_LLM_CALLS_PER_PASS = 15
+
+# Model used for contradiction judgment. Must match a key in observability/pricing.py.
+_EDGES_MODEL = "claude-sonnet-4-6"
 
 # Walk parameters for contradiction candidate selection.
 CONTRADICTION_MAX_HOPS = 3
@@ -75,7 +82,7 @@ def _run_edges(
     """Main edges pass logic. Returns (cites_new, contradicts_new, llm_calls)."""
     cites_new = _detect_cites(conn, project_id, dry_run=dry_run)
     contradicts_new, llm_calls = _detect_contradicts(
-        conn, project_id, dry_run=dry_run
+        conn, project_id, dry_run=dry_run, record_conn=conn
     )
     return cites_new, contradicts_new, llm_calls
 
@@ -138,7 +145,11 @@ def _normalize_title(title: str) -> str:
 
 
 def _detect_contradicts(
-    conn: Any, project_id: Any, *, dry_run: bool = False
+    conn: Any,
+    project_id: Any,
+    *,
+    dry_run: bool = False,
+    record_conn: Any = None,
 ) -> tuple[int, int]:
     """Detect contradicts edges using Phase 5 graph_walk + LLM judgment.
 
@@ -148,6 +159,10 @@ def _detect_contradicts(
     the 'contradicts' edge type (to find existing contradicts neighbors)
     plus 'cites'/'derived_from' (to find semantically related candidates).
     (seed, neighbor) pairs are the LLM judgment candidates.
+
+    record_conn: connection used to write spend log rows. When None, spend
+        is not recorded (e.g. dry_run or test scenarios without the table).
+        In production, pass the same conn used for edge writes.
     """
     memories = _load_memories(conn, project_id)
     if len(memories) < 2:
@@ -193,8 +208,31 @@ def _detect_contradicts(
         if not content_a or not content_b:
             continue
 
-        contradicts_flag = _llm_judge_contradiction(content_a, content_b)
+        contradicts_flag, usage = _llm_judge_contradiction(content_a, content_b)
         llm_calls += 1
+
+        # Record spend for this LLM call (non-zero tokens only — skip mock/no-API runs).
+        if record_conn is not None and any(
+            usage.get(k, 0) for k in ("input_tokens", "output_tokens")
+        ):
+            cost = compute_cost_usd(
+                SONNET_4_6,
+                input_tokens=usage.get("input_tokens", 0),
+                output_tokens=usage.get("output_tokens", 0),
+                cache_read_tokens=usage.get("cache_read_tokens", 0),
+                cache_write_tokens=usage.get("cache_write_tokens", 0),
+            )
+            record_spend(
+                record_conn,
+                project_id=project_id,
+                pass_name="edges",
+                model=_EDGES_MODEL,
+                input_tokens=usage.get("input_tokens", 0),
+                output_tokens=usage.get("output_tokens", 0),
+                cache_read_tokens=usage.get("cache_read_tokens", 0),
+                cache_write_tokens=usage.get("cache_write_tokens", 0),
+                cost_usd=cost,
+            )
 
         if contradicts_flag:
             if dry_run:
@@ -221,20 +259,32 @@ def _detect_contradicts(
     return new_edges, llm_calls
 
 
-def _llm_judge_contradiction(content_a: str, content_b: str) -> bool:
-    """Return True if the LLM judges content_a and content_b to contradict.
+def _llm_judge_contradiction(
+    content_a: str, content_b: str
+) -> tuple[bool, dict]:
+    """Return (contradicts, usage) — whether the LLM judges content_a and
+    content_b to contradict, plus token usage for spend tracking.
+
+    usage dict keys: input_tokens, output_tokens, cache_read_tokens,
+    cache_write_tokens. All are 0 when the LLM was not called.
 
     Degrades gracefully if the SDK is unavailable or the API key is missing.
     """
+    _empty_usage = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
     try:
         import anthropic  # noqa: PLC0415
     except ImportError:
-        return False
+        return False, _empty_usage
 
     import os
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
-        return False
+        return False, _empty_usage
 
     client = anthropic.Anthropic(api_key=api_key)
     prompt = (
@@ -244,15 +294,22 @@ def _llm_judge_contradiction(content_a: str, content_b: str) -> bool:
     )
     try:
         response = client.messages.create(
-            model="claude-sonnet-4-6",
+            model=_EDGES_MODEL,
             max_tokens=8,
             messages=[{"role": "user", "content": prompt}],
         )
+        usage = response.usage
+        token_usage = {
+            "input_tokens": getattr(usage, "input_tokens", 0),
+            "output_tokens": getattr(usage, "output_tokens", 0),
+            "cache_read_tokens": getattr(usage, "cache_read_input_tokens", 0) or 0,
+            "cache_write_tokens": getattr(usage, "cache_creation_input_tokens", 0) or 0,
+        }
         text = response.content[0].text.strip().upper()
-        return text.startswith("YES")
+        return text.startswith("YES"), token_usage
     except Exception as exc:  # noqa: BLE001
         logger.warning("cognify_edges: LLM contradiction check failed: %s", exc)
-        return False
+        return False, _empty_usage
 
 
 # ── Shared helpers ────────────────────────────────────────────────────────────

--- a/factory/cognify/extract.py
+++ b/factory/cognify/extract.py
@@ -19,6 +19,16 @@ but the cognify_run_log rows written by the orchestrator never receive raw
 memory.content — only row counts and metadata are logged.
 
 LLM cost ceiling: max 20 calls per pass invocation (Sonnet 4.6).
+
+Spend tracking: each LLM call writes a row to devbrain.cognify_spend_log
+(migration 029) via observability.spend.record_spend. Costs are estimates
+based on hardcoded Anthropic list prices (see observability/pricing.py).
+
+Versioned extraction: CURRENT_EXTRACTION_VERSION marks the prompt/model
+version for all newly written tier='lesson' rows. Bump this constant when
+the extraction prompt or model changes, then run:
+    devbrain cognify-reextract --since-version=<N>
+to reprocess rows produced by prior versions.
 """
 from __future__ import annotations
 
@@ -29,11 +39,21 @@ from typing import Any
 from uuid import UUID
 
 from cognify.orchestrator import CognifyPass, PassResult, register_pass
+from observability.pricing import SONNET_4_6, compute_cost_usd
+from observability.spend import record_spend
 
 logger = logging.getLogger(__name__)
 
 # Maximum LLM calls per scheduled pass invocation.
 MAX_LLM_CALLS_PER_PASS = 20
+
+# Extraction prompt/model version. Bump this integer when the extraction
+# prompt or model changes, then run `devbrain cognify-reextract --since-version=N`
+# to reprocess existing rows. Starts at 1 per Phase 6 design §6.
+CURRENT_EXTRACTION_VERSION = 1
+
+# Model used for extraction. Must match a key in observability/pricing.py.
+_EXTRACT_MODEL = "claude-sonnet-4-6"
 
 
 @dataclass
@@ -182,6 +202,28 @@ def extract_from_session(
     extracted = _llm_extract(combined, max_llm_calls=max_llm_calls)
     llm_calls = 1  # one call per session for v1
 
+    # Record spend for this LLM call.
+    usage = extracted.get("_usage", {})
+    if any(usage.get(k, 0) for k in ("input_tokens", "output_tokens")):
+        cost = compute_cost_usd(
+            SONNET_4_6,
+            input_tokens=usage.get("input_tokens", 0),
+            output_tokens=usage.get("output_tokens", 0),
+            cache_read_tokens=usage.get("cache_read_tokens", 0),
+            cache_write_tokens=usage.get("cache_write_tokens", 0),
+        )
+        record_spend(
+            conn,
+            project_id=project_id,
+            pass_name="extract",
+            model=_EXTRACT_MODEL,
+            input_tokens=usage.get("input_tokens", 0),
+            output_tokens=usage.get("output_tokens", 0),
+            cache_read_tokens=usage.get("cache_read_tokens", 0),
+            cache_write_tokens=usage.get("cache_write_tokens", 0),
+            cost_usd=cost,
+        )
+
     lessons_created = 0
     decisions_created = 0
     skipped = 0
@@ -317,21 +359,30 @@ def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
     Returns a dict with keys:
       - "lessons": list of {title, content}
       - "decisions": list of {title, content}
+      - "_usage": dict with token usage fields for spend tracking
+          (input_tokens, output_tokens, cache_read_tokens, cache_write_tokens).
+          Always present; all counts are 0 if the LLM was not called.
 
     v1 implementation: uses the Anthropic SDK with prompt caching.
     If the SDK is not available (e.g. CI without API key), returns empty
     lists so the pass degrades gracefully.
     """
+    _empty_usage = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
     try:
         import anthropic  # noqa: PLC0415
     except ImportError:
         logger.warning("cognify_extract: anthropic SDK not available; skipping LLM")
-        return {"lessons": [], "decisions": []}
+        return {"lessons": [], "decisions": [], "_usage": _empty_usage}
 
     api_key = _get_api_key()
     if not api_key:
         logger.warning("cognify_extract: no API key configured; skipping LLM")
-        return {"lessons": [], "decisions": []}
+        return {"lessons": [], "decisions": [], "_usage": _empty_usage}
 
     client = anthropic.Anthropic(api_key=api_key)
 
@@ -347,7 +398,7 @@ def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
 
     try:
         response = client.messages.create(
-            model="claude-sonnet-4-6",
+            model=_EXTRACT_MODEL,
             max_tokens=2048,
             system=[
                 {
@@ -363,15 +414,24 @@ def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
                 }
             ],
         )
+        usage = response.usage
+        token_usage = {
+            "input_tokens": getattr(usage, "input_tokens", 0),
+            "output_tokens": getattr(usage, "output_tokens", 0),
+            "cache_read_tokens": getattr(usage, "cache_read_input_tokens", 0) or 0,
+            "cache_write_tokens": getattr(usage, "cache_creation_input_tokens", 0) or 0,
+        }
         text = response.content[0].text.strip()
         # Strip markdown code fences if present.
         if text.startswith("```"):
             text = "\n".join(text.split("\n")[1:])
             text = text.rsplit("```", 1)[0].strip()
-        return json.loads(text)
+        result = json.loads(text)
+        result["_usage"] = token_usage
+        return result
     except Exception as exc:  # noqa: BLE001
         logger.warning("cognify_extract: LLM call failed: %s", exc)
-        return {"lessons": [], "decisions": []}
+        return {"lessons": [], "decisions": [], "_usage": _empty_usage}
 
 
 def _get_api_key() -> str | None:
@@ -436,10 +496,13 @@ def _upsert_memory(
         return existing[0], False
 
     # Insert new extract row (no provenance_id — avoid unique constraint).
-    cols = ["project_id", "kind", "title", "content", "tier", "strength", "applies_when"]
+    cols = [
+        "project_id", "kind", "title", "content",
+        "tier", "strength", "applies_when", "extraction_version",
+    ]
     vals: list = [
         project_id, db_kind, title, content, "lesson", 1.0,
-        json.dumps(applies_when),
+        json.dumps(applies_when), CURRENT_EXTRACTION_VERSION,
     ]
 
     placeholders = ", ".join(["%s"] * len(cols))

--- a/factory/cognify/reextract_cli.py
+++ b/factory/cognify/reextract_cli.py
@@ -2,14 +2,20 @@
 
 Provides the ``devbrain cognify-reextract`` command:
 
-    devbrain cognify-reextract --session=<id>   # re-extract one session
-    devbrain cognify-reextract --all            # re-extract all sessions in project
-    devbrain cognify-reextract --since=<date>   # sessions ingested after date
+    devbrain cognify-reextract --session=<id>      # re-extract one session
+    devbrain cognify-reextract --all               # re-extract all sessions
+    devbrain cognify-reextract --since=<date>      # sessions ingested after date
+    devbrain cognify-reextract --since-version=N   # sessions with extraction_version < N
 
 Re-extraction archives prior lessons/decisions (sets archived_at; never
 deletes — HIPAA audit trail), then runs extract_from_session with
-reextract=True. New rows carry metadata.reextracted_from = <prior_row_id>
-for traceability.
+reextract=True. New rows carry applies_when.reextracted_from = <prior_row_id>
+for traceability (per Phase 6 design §6). New rows also receive
+extraction_version = CURRENT_EXTRACTION_VERSION from extract.py.
+
+--since-version=N: selects all sessions that have at least one tier='lesson'
+row with extraction_version < N. Useful when bumping CURRENT_EXTRACTION_VERSION
+to reprocess rows produced by an older extraction prompt or model.
 
 This module only contains the CLI logic and ``run_reextract``; the actual
 re-extraction is delegated to cognify.extract.extract_from_session.
@@ -30,11 +36,13 @@ def run_reextract(
     session_id: str | None = None,
     all_sessions: bool = False,
     since: str | None = None,
+    since_version: int | None = None,
     dry_run: bool = False,
 ) -> dict:
     """Re-extract lessons/decisions for the specified sessions.
 
-    Exactly one of session_id / all_sessions / since must be set.
+    Exactly one of session_id / all_sessions / since / since_version must
+    be set.
 
     Args:
         conn: psycopg2 connection.
@@ -42,6 +50,10 @@ def run_reextract(
         session_id: provenance_id of the specific session to re-extract.
         all_sessions: if True, re-extract all sessions for the project.
         since: ISO date string; re-extract sessions ingested after this date.
+        since_version: integer N; re-extract sessions that have at least one
+            tier='lesson' row with extraction_version < N. Old rows gain
+            archived_at = NOW() and applies_when.reextracted_from = <prior_id>.
+            New rows are written with CURRENT_EXTRACTION_VERSION.
         dry_run: compute what would happen without mutating.
 
     Returns:
@@ -49,9 +61,13 @@ def run_reextract(
     """
     from cognify.extract import extract_from_session, _sessions_since
 
-    if sum([bool(session_id), all_sessions, bool(since)]) != 1:
+    flags_set = sum(
+        [bool(session_id), all_sessions, bool(since), since_version is not None]
+    )
+    if flags_set != 1:
         raise ValueError(
-            "Exactly one of --session, --all, or --since must be specified."
+            "Exactly one of --session, --all, --since, or --since-version "
+            "must be specified."
         )
 
     # Resolve target sessions.
@@ -59,20 +75,22 @@ def run_reextract(
         sessions = [session_id]
     elif all_sessions:
         sessions = _sessions_since(conn, project_id, since=None)
-    else:
+    elif since is not None:
         # Parse since date.
         try:
             since_dt = datetime.fromisoformat(since).replace(tzinfo=timezone.utc)
         except ValueError as exc:
             raise ValueError(f"Invalid --since date: {since!r}") from exc
         sessions = _sessions_since(conn, project_id, since=since_dt)
+    else:
+        # since_version: find sessions that have lesson rows with old version.
+        sessions = _sessions_below_version(conn, project_id, since_version)
 
     if not sessions:
         return {
             "sessions_targeted": 0,
             "lessons_created": 0,
             "decisions_created": 0,
-            "archived": 0,
         }
 
     if dry_run:
@@ -84,7 +102,6 @@ def run_reextract(
 
     total_lessons = 0
     total_decisions = 0
-    total_archived = 0
 
     for sid in sessions:
         result = extract_from_session(
@@ -95,11 +112,37 @@ def run_reextract(
         )
         total_lessons += result.lessons_created
         total_decisions += result.decisions_created
-        # archived count is not returned by extract_from_session directly;
-        # it's recorded internally via _archive_prior_extracts.
+        # archived count is recorded internally via _archive_prior_extracts.
 
     return {
         "sessions_targeted": len(sessions),
         "lessons_created": total_lessons,
         "decisions_created": total_decisions,
     }
+
+
+def _sessions_below_version(
+    conn: Any, project_id: Any, version: int
+) -> list[str]:
+    """Return session IDs (as strings) that have tier='lesson' rows with
+    extraction_version < version.
+
+    A session is identified by applies_when->>'source_session'. Rows without
+    a source_session are excluded (they predate the applies_when schema).
+
+    Returns a deduplicated, ordered list suitable for passing to
+    extract_from_session.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT DISTINCT applies_when->>'source_session' AS session_id "
+            "FROM devbrain.memory "
+            "WHERE project_id = %s "
+            "  AND tier = 'lesson' "
+            "  AND archived_at IS NULL "
+            "  AND applies_when->>'source_session' IS NOT NULL "
+            "  AND extraction_version < %s "
+            "ORDER BY session_id",
+            (project_id, version),
+        )
+        return [row[0] for row in cur.fetchall()]

--- a/factory/curator/eval/runner.py
+++ b/factory/curator/eval/runner.py
@@ -22,6 +22,13 @@ finding). The schema reuses the existing artifact columns:
 If an agent fails (subprocess exit non-zero, JSON parse error, timeout),
 the EvalResult carries an empty findings list + the error string. The
 OTHER agents still run — failure isolation is per-agent, not per-batch.
+
+Spend tracking: each LLM agent call writes a row to
+devbrain.cognify_spend_log (migration 029) via
+observability.spend.record_spend. Token usage is parsed from the
+claude subprocess JSON output (fields: input_tokens, output_tokens,
+cache_creation_input_tokens, cache_read_input_tokens). Spend logging
+failures are non-fatal — a warning is emitted and the eval chain continues.
 """
 from __future__ import annotations
 
@@ -35,8 +42,13 @@ from typing import Any
 from uuid import UUID
 
 from curator.eval.types import EvalFinding, EvalResult
+from observability.pricing import SONNET_4_6, compute_cost_usd
+from observability.spend import record_spend
 
 logger = logging.getLogger(__name__)
+
+# Model used by the eval agent chain. Must match a key in observability/pricing.py.
+_EVAL_MODEL = "claude-sonnet-4-6"
 
 # Path to prompts dir — resolved relative to this module.
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
@@ -57,6 +69,8 @@ def run_evals(
     brief: dict,
     plan: str,
     diff: str,
+    *,
+    project_id: Any = None,
 ) -> list[EvalResult]:
     """Run LLM eval chain (security → test → perf), sharing a warm cache.
 
@@ -65,13 +79,22 @@ def run_evals(
 
     Failure isolation: if one agent raises, its EvalResult carries
     findings=[] + error=<exc>; the other agents still run.
+
+    Args:
+        conn: psycopg2 connection (also used for spend logging).
+        job_id: factory job UUID.
+        brief: job brief dict.
+        plan: implementation plan text.
+        diff: git diff string.
+        project_id: UUID of the project, used for spend log P3 scoping.
+            If None, spend rows are written without a project_id.
     """
     cached_context = _build_cached_context(brief, plan, diff)
     results: list[EvalResult] = []
 
     for agent_name, prompt_file in _LLM_AGENT_ORDER:
         try:
-            result = _invoke_agent(
+            result, usage = _invoke_agent(
                 job_id=job_id,
                 agent_name=agent_name,
                 prompt_path=_PROMPTS_DIR / prompt_file,
@@ -88,6 +111,29 @@ def run_evals(
                 started_at=datetime.now(timezone.utc),
                 error=str(exc)[:500],
             )
+            usage = {}
+
+        # Record spend for this eval agent call.
+        if any(usage.get(k, 0) for k in ("input_tokens", "output_tokens")):
+            cost = compute_cost_usd(
+                SONNET_4_6,
+                input_tokens=usage.get("input_tokens", 0),
+                output_tokens=usage.get("output_tokens", 0),
+                cache_read_tokens=usage.get("cache_read_tokens", 0),
+                cache_write_tokens=usage.get("cache_write_tokens", 0),
+            )
+            record_spend(
+                conn,
+                project_id=project_id,
+                pass_name=agent_name,
+                model=_EVAL_MODEL,
+                input_tokens=usage.get("input_tokens", 0),
+                output_tokens=usage.get("output_tokens", 0),
+                cache_read_tokens=usage.get("cache_read_tokens", 0),
+                cache_write_tokens=usage.get("cache_write_tokens", 0),
+                cost_usd=cost,
+            )
+
         results.append(result)
 
     _persist_findings(conn, job_id, results)
@@ -114,11 +160,16 @@ def _invoke_agent(
     agent_name: str,
     prompt_path: Path,
     cached_context: str,
-) -> EvalResult:
+) -> tuple["EvalResult", dict]:
     """Invoke claude with the eval prompt + cached context.
 
     First call instantiates cache; second call reuses it (claude's prompt
     cache TTL is 5 min, well within typical job phase duration).
+
+    Returns:
+        (EvalResult, usage_dict) where usage_dict has keys:
+          input_tokens, output_tokens, cache_read_tokens, cache_write_tokens.
+        All usage counts are 0 if the subprocess output did not include usage.
     """
     started_at = datetime.now(timezone.utc)
     start = time.perf_counter()
@@ -147,8 +198,20 @@ def _invoke_agent(
     response = json.loads(proc.stdout)
     findings = _parse_findings(agent_name, response)
 
+    # Extract token usage from the claude JSON output. The claude CLI
+    # --output-format json response includes a top-level "usage" object with
+    # input_tokens, output_tokens, cache_creation_input_tokens,
+    # cache_read_input_tokens fields.
+    raw_usage = response.get("usage") or {}
+    usage = {
+        "input_tokens": raw_usage.get("input_tokens", 0) or 0,
+        "output_tokens": raw_usage.get("output_tokens", 0) or 0,
+        "cache_read_tokens": raw_usage.get("cache_read_input_tokens", 0) or 0,
+        "cache_write_tokens": raw_usage.get("cache_creation_input_tokens", 0) or 0,
+    }
+
     elapsed_ms = int((time.perf_counter() - start) * 1000)
-    return EvalResult(
+    result = EvalResult(
         version="1.0",
         job_id=job_id,
         agent_name=agent_name,
@@ -156,6 +219,7 @@ def _invoke_agent(
         elapsed_ms=elapsed_ms,
         started_at=started_at,
     )
+    return result, usage
 
 
 def _parse_findings(agent_name: str, response: dict) -> list[EvalFinding]:

--- a/factory/observability/__init__.py
+++ b/factory/observability/__init__.py
@@ -1,0 +1,20 @@
+"""factory.observability — spend tracking and cost observability helpers.
+
+Provides per-call LLM cost capture written to devbrain.cognify_spend_log
+(migration 029). No raw PHI is stored — only token counts, model name,
+pass name, project_id, and timestamps.
+
+Usage::
+
+    from observability.pricing import SONNET_4_6, compute_cost_usd
+    from observability.spend import record_spend
+
+    cost = compute_cost_usd(
+        SONNET_4_6,
+        input_tokens=...,
+        output_tokens=...,
+        cache_read_tokens=...,
+        cache_write_tokens=...,
+    )
+    record_spend(conn, project_id=..., pass_name=..., model=..., ..., cost_usd=cost)
+"""

--- a/factory/observability/pricing.py
+++ b/factory/observability/pricing.py
@@ -1,0 +1,98 @@
+"""LLM pricing constants for spend estimation.
+
+IMPORTANT — these are per-call cost ESTIMATES based on Anthropic's published
+list prices, NOT actuals from the Anthropic billing API. Actual costs may
+differ due to:
+  - Volume discounts or negotiated rates
+  - Price changes after this file was last updated
+  - API-level rounding differences
+
+Last updated: 2026-05-06
+Source: https://www.anthropic.com/pricing (claude-sonnet-4-6 row)
+
+To update pricing: bump the relevant ModelPricing fields and update the
+date above. Do NOT integrate with the billing API — that would require
+credentials and network access in the ingest path.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    """Per-million-token pricing for a single model.
+
+    All costs are in USD per 1,000,000 tokens (i.e. $/Mtok).
+
+    Fields:
+        model: Anthropic model identifier string.
+        input_per_mtok: Cost per million input (non-cached) tokens.
+        output_per_mtok: Cost per million output tokens.
+        cache_read_per_mtok: Cost per million prompt-cache-read tokens.
+        cache_write_per_mtok: Cost per million prompt-cache-write tokens.
+    """
+
+    model: str
+    input_per_mtok: float
+    output_per_mtok: float
+    cache_read_per_mtok: float
+    cache_write_per_mtok: float
+
+
+# ── Published Anthropic list prices (USD / 1M tokens) ─────────────────────────
+#
+# claude-sonnet-4-6 (as of 2026-05-06):
+#   Input:        $3.00 / Mtok
+#   Output:       $15.00 / Mtok
+#   Cache read:   $0.30 / Mtok
+#   Cache write:  $3.75 / Mtok
+SONNET_4_6 = ModelPricing(
+    model="claude-sonnet-4-6",
+    input_per_mtok=3.00,
+    output_per_mtok=15.00,
+    cache_read_per_mtok=0.30,
+    cache_write_per_mtok=3.75,
+)
+
+# Registry: model string → pricing. Extend as new models are added.
+_PRICING_REGISTRY: dict[str, ModelPricing] = {
+    SONNET_4_6.model: SONNET_4_6,
+}
+
+
+def get_pricing(model: str) -> ModelPricing | None:
+    """Return the ModelPricing for *model*, or None if not registered.
+
+    Callers that need a non-None fallback should use SONNET_4_6 directly
+    or add the missing model to _PRICING_REGISTRY.
+    """
+    return _PRICING_REGISTRY.get(model)
+
+
+def compute_cost_usd(
+    pricing: ModelPricing,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+) -> float:
+    """Compute the estimated USD cost for a single LLM call.
+
+    Returns a float (not Decimal) suitable for insertion into a
+    NUMERIC(10, 6) column via psycopg2's default float adapter.
+
+    Formula:
+        cost = (input_tokens / 1_000_000)  * input_per_mtok
+             + (output_tokens / 1_000_000) * output_per_mtok
+             + (cache_read_tokens / 1_000_000)  * cache_read_per_mtok
+             + (cache_write_tokens / 1_000_000) * cache_write_per_mtok
+    """
+    mtok = 1_000_000.0
+    return (
+        (input_tokens / mtok) * pricing.input_per_mtok
+        + (output_tokens / mtok) * pricing.output_per_mtok
+        + (cache_read_tokens / mtok) * pricing.cache_read_per_mtok
+        + (cache_write_tokens / mtok) * pricing.cache_write_per_mtok
+    )

--- a/factory/observability/spend.py
+++ b/factory/observability/spend.py
@@ -1,0 +1,87 @@
+"""spend.py — write rows to devbrain.cognify_spend_log.
+
+A thin wrapper around the INSERT so callers (extract, edges, eval runner)
+don't embed raw SQL. All columns map 1-to-1 with the migration 029 schema.
+
+PHI constraint: this module NEVER receives or logs raw session content —
+only token counts, model name, pass name, project_id, and timestamps.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+def record_spend(
+    conn: Any,
+    *,
+    project_id: UUID | str | None,
+    pass_name: str,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    cost_usd: float,
+) -> int | None:
+    """Insert one row into devbrain.cognify_spend_log.
+
+    Args:
+        conn: psycopg2 connection. The caller owns the transaction; this
+            function commits the INSERT independently so a downstream
+            failure doesn't roll back the spend record.
+        project_id: UUID of the project. May be None for cross-project passes
+            (but spend_log rows are most useful when project_id is set).
+        pass_name: Name of the cognify pass or eval agent (e.g. 'extract',
+            'edges', 'eval_security').
+        model: Anthropic model identifier string (e.g. 'claude-sonnet-4-6').
+        input_tokens: Non-cached input tokens from the response usage block.
+        output_tokens: Output tokens from the response usage block.
+        cache_read_tokens: Prompt-cache-read tokens (0 if not applicable).
+        cache_write_tokens: Prompt-cache-write tokens (0 if not applicable).
+        cost_usd: Estimated cost in USD (from observability.pricing.compute_cost_usd).
+
+    Returns:
+        The inserted row id (BIGINT) or None if the INSERT failed.
+        Failures are logged at WARNING but not re-raised — spend logging
+        must never abort a cognify pass.
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO devbrain.cognify_spend_log "
+                "(project_id, pass_name, model, "
+                " input_tokens, output_tokens, "
+                " cache_read_tokens, cache_write_tokens, "
+                " cost_usd) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) "
+                "RETURNING id",
+                (
+                    project_id,
+                    pass_name,
+                    model,
+                    input_tokens,
+                    output_tokens,
+                    cache_read_tokens,
+                    cache_write_tokens,
+                    cost_usd,
+                ),
+            )
+            row_id = cur.fetchone()[0]
+        conn.commit()
+        return row_id
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "record_spend: failed to write spend log row (pass=%s, model=%s): %s",
+            pass_name,
+            model,
+            exc,
+        )
+        try:
+            conn.rollback()
+        except Exception:  # noqa: BLE001
+            pass
+        return None

--- a/factory/tests/conftest.py
+++ b/factory/tests/conftest.py
@@ -175,6 +175,15 @@ def project_factory(conn):
                 )
             except Exception:
                 conn.rollback()
+            # cognify_spend_log (migration 029) FKs project_id; clean up
+            # before deleting the project.
+            try:
+                cur.execute(
+                    "DELETE FROM devbrain.cognify_spend_log WHERE project_id = %s",
+                    (pid,),
+                )
+            except Exception:
+                conn.rollback()
             cur.execute(
                 "DELETE FROM devbrain.memory WHERE project_id = %s", (pid,)
             )

--- a/factory/tests/test_cognify_edges.py
+++ b/factory/tests/test_cognify_edges.py
@@ -149,7 +149,9 @@ def test_edges_pass_dry_run_no_edges(conn, project_factory):
 
 
 def test_llm_judge_contradiction_returns_false_without_api_key(monkeypatch):
-    """_llm_judge_contradiction returns False when ANTHROPIC_API_KEY is not set."""
+    """_llm_judge_contradiction returns (False, empty_usage) when API key is not set."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    result = _llm_judge_contradiction("Memory A says X.", "Memory B says not X.")
-    assert result is False
+    contradicts, usage = _llm_judge_contradiction("Memory A says X.", "Memory B says not X.")
+    assert contradicts is False
+    assert usage["input_tokens"] == 0
+    assert usage["output_tokens"] == 0

--- a/factory/tests/test_spend_tracking.py
+++ b/factory/tests/test_spend_tracking.py
@@ -1,0 +1,368 @@
+"""Tests for LLM spend tracking (migration 029 + observability package).
+
+Covers:
+  - pricing.compute_cost_usd: correct USD cost from token counts
+  - pricing.get_pricing: registry lookup
+  - spend.record_spend: inserts a row into cognify_spend_log
+  - spend.record_spend: failure is non-fatal (no exception raised)
+  - Daily view: cognify_spend_daily aggregates by (project_id, day, model)
+  - extract.py integration: spend row written when mock LLM returns usage
+  - edges.py integration: spend row written when mock LLM returns usage
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from observability.pricing import (
+    SONNET_4_6,
+    ModelPricing,
+    compute_cost_usd,
+    get_pricing,
+)
+from observability.spend import record_spend
+
+
+# ── Pricing unit tests (no DB) ────────────────────────────────────────────────
+
+
+def test_compute_cost_usd_input_only():
+    """1M input tokens at $3/Mtok = $3.00."""
+    cost = compute_cost_usd(SONNET_4_6, input_tokens=1_000_000, output_tokens=0)
+    assert abs(cost - 3.00) < 1e-9
+
+
+def test_compute_cost_usd_output_only():
+    """1M output tokens at $15/Mtok = $15.00."""
+    cost = compute_cost_usd(SONNET_4_6, input_tokens=0, output_tokens=1_000_000)
+    assert abs(cost - 15.00) < 1e-9
+
+
+def test_compute_cost_usd_cache_read():
+    """1M cache_read tokens at $0.30/Mtok = $0.30."""
+    cost = compute_cost_usd(
+        SONNET_4_6, input_tokens=0, output_tokens=0, cache_read_tokens=1_000_000
+    )
+    assert abs(cost - 0.30) < 1e-9
+
+
+def test_compute_cost_usd_cache_write():
+    """1M cache_write tokens at $3.75/Mtok = $3.75."""
+    cost = compute_cost_usd(
+        SONNET_4_6, input_tokens=0, output_tokens=0, cache_write_tokens=1_000_000
+    )
+    assert abs(cost - 3.75) < 1e-9
+
+
+def test_compute_cost_usd_mixed():
+    """Combined token counts produce the correct sum."""
+    cost = compute_cost_usd(
+        SONNET_4_6,
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_tokens=200,
+        cache_write_tokens=300,
+    )
+    expected = (
+        (100 / 1_000_000) * 3.00
+        + (50 / 1_000_000) * 15.00
+        + (200 / 1_000_000) * 0.30
+        + (300 / 1_000_000) * 3.75
+    )
+    assert abs(cost - expected) < 1e-12
+
+
+def test_compute_cost_usd_zero():
+    """Zero tokens → zero cost."""
+    cost = compute_cost_usd(SONNET_4_6, input_tokens=0, output_tokens=0)
+    assert cost == 0.0
+
+
+def test_get_pricing_known_model():
+    """get_pricing returns SONNET_4_6 for 'claude-sonnet-4-6'."""
+    p = get_pricing("claude-sonnet-4-6")
+    assert p is SONNET_4_6
+    assert isinstance(p, ModelPricing)
+
+
+def test_get_pricing_unknown_model():
+    """get_pricing returns None for unregistered models."""
+    p = get_pricing("claude-nonexistent-999")
+    assert p is None
+
+
+# ── DB integration tests ──────────────────────────────────────────────────────
+
+
+def _count_spend_rows(conn, project_id) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.cognify_spend_log "
+            "WHERE project_id = %s",
+            (project_id,),
+        )
+        return cur.fetchone()[0]
+
+
+def _fetch_spend_rows(conn, project_id) -> list[dict]:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT pass_name, model, input_tokens, output_tokens, "
+            "       cache_read_tokens, cache_write_tokens, cost_usd "
+            "FROM devbrain.cognify_spend_log "
+            "WHERE project_id = %s "
+            "ORDER BY id",
+            (project_id,),
+        )
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+@pytest.mark.db
+def test_record_spend_inserts_row(conn, project_factory):
+    """record_spend inserts a cognify_spend_log row with correct values."""
+    project = project_factory("spend_basic")
+
+    cost = compute_cost_usd(
+        SONNET_4_6,
+        input_tokens=1000,
+        output_tokens=200,
+        cache_read_tokens=500,
+        cache_write_tokens=0,
+    )
+    row_id = record_spend(
+        conn,
+        project_id=project["id"],
+        pass_name="extract",
+        model="claude-sonnet-4-6",
+        input_tokens=1000,
+        output_tokens=200,
+        cache_read_tokens=500,
+        cache_write_tokens=0,
+        cost_usd=cost,
+    )
+
+    assert row_id is not None
+    rows = _fetch_spend_rows(conn, project["id"])
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["pass_name"] == "extract"
+    assert r["model"] == "claude-sonnet-4-6"
+    assert r["input_tokens"] == 1000
+    assert r["output_tokens"] == 200
+    assert r["cache_read_tokens"] == 500
+    assert r["cache_write_tokens"] == 0
+    assert abs(float(r["cost_usd"]) - cost) < 1e-6
+
+
+@pytest.mark.db
+def test_record_spend_multiple_rows(conn, project_factory):
+    """Multiple record_spend calls produce independent rows."""
+    project = project_factory("spend_multi")
+
+    for i in range(3):
+        record_spend(
+            conn,
+            project_id=project["id"],
+            pass_name="edges",
+            model="claude-sonnet-4-6",
+            input_tokens=100 * (i + 1),
+            output_tokens=10,
+            cost_usd=0.001,
+        )
+
+    assert _count_spend_rows(conn, project["id"]) == 3
+
+
+@pytest.mark.db
+def test_record_spend_nonfatal_on_bad_conn(project_factory):
+    """record_spend returns None and doesn't raise on a broken connection."""
+    bad_conn = MagicMock()
+    bad_conn.cursor.side_effect = Exception("connection closed")
+
+    result = record_spend(
+        bad_conn,
+        project_id=uuid.uuid4(),
+        pass_name="extract",
+        model="claude-sonnet-4-6",
+        input_tokens=100,
+        output_tokens=50,
+        cost_usd=0.001,
+    )
+    assert result is None
+
+
+@pytest.mark.db
+def test_cognify_spend_daily_view(conn, project_factory):
+    """cognify_spend_daily aggregates rows by (project_id, day, model)."""
+    project = project_factory("spend_daily")
+
+    # Insert 2 rows with the same project/model (they should aggregate).
+    record_spend(
+        conn,
+        project_id=project["id"],
+        pass_name="extract",
+        model="claude-sonnet-4-6",
+        input_tokens=1000,
+        output_tokens=100,
+        cost_usd=0.0035,
+    )
+    record_spend(
+        conn,
+        project_id=project["id"],
+        pass_name="extract",
+        model="claude-sonnet-4-6",
+        input_tokens=2000,
+        output_tokens=200,
+        cost_usd=0.0090,
+    )
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT input_tokens, output_tokens, cost_usd, call_count "
+            "FROM devbrain.cognify_spend_daily "
+            "WHERE project_id = %s AND model = %s",
+            (project["id"], "claude-sonnet-4-6"),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) == 1
+    input_tok, output_tok, cost, call_count = rows[0]
+    assert input_tok == 3000
+    assert output_tok == 300
+    assert call_count == 2
+    assert abs(float(cost) - 0.0125) < 1e-6
+
+
+@pytest.mark.db
+def test_extract_pass_records_spend(conn, project_factory):
+    """extract_from_session writes a spend row when the mock LLM returns usage."""
+    from cognify.extract import extract_from_session
+
+    project = project_factory("spend_extract")
+    session_id = str(uuid.uuid4())
+
+    # Insert a raw chunk
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, provenance_id) "
+            "VALUES (%s, 'pattern', 'chunk', 'some content', %s::uuid) RETURNING id",
+            (project["id"], session_id),
+        )
+    conn.commit()
+
+    # Mock _llm_extract to return usage data
+    mock_response = {
+        "lessons": [{"title": "Test Lesson", "content": "Content about something"}],
+        "decisions": [],
+        "_usage": {
+            "input_tokens": 500,
+            "output_tokens": 100,
+            "cache_read_tokens": 200,
+            "cache_write_tokens": 0,
+        },
+    }
+    with patch("cognify.extract._llm_extract", return_value=mock_response):
+        result = extract_from_session(conn, session_id, project["id"])
+
+    assert result.llm_calls == 1
+    assert result.lessons_created == 1
+
+    # Spend row should have been written
+    rows = _fetch_spend_rows(conn, project["id"])
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["pass_name"] == "extract"
+    assert r["input_tokens"] == 500
+    assert r["output_tokens"] == 100
+    assert r["cache_read_tokens"] == 200
+
+
+@pytest.mark.db
+def test_extract_pass_no_spend_when_no_tokens(conn, project_factory):
+    """extract_from_session does not write a spend row when token counts are 0
+    (e.g. no API key in CI — LLM returns empty usage)."""
+    from cognify.extract import extract_from_session
+
+    project = project_factory("spend_extract_no_tok")
+    session_id = str(uuid.uuid4())
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, provenance_id) "
+            "VALUES (%s, 'pattern', 'chunk2', 'content', %s::uuid) RETURNING id",
+            (project["id"], session_id),
+        )
+    conn.commit()
+
+    mock_response = {
+        "lessons": [],
+        "decisions": [],
+        "_usage": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        },
+    }
+    with patch("cognify.extract._llm_extract", return_value=mock_response):
+        extract_from_session(conn, session_id, project["id"])
+
+    assert _count_spend_rows(conn, project["id"]) == 0
+
+
+@pytest.mark.db
+def test_edges_pass_records_spend(conn, project_factory, memory_factory):
+    """_detect_contradicts writes a spend row when the mock LLM returns usage."""
+    project = project_factory("spend_edges")
+    # Insert two memory rows that will form a candidate pair via the walker.
+    memory_factory(project["id"], kind="decision", title="Edge node A", content="A says X")
+    memory_factory(project["id"], kind="decision", title="Edge node B", content="B says not X")
+
+    # The walker won't find edges without real graph topology; we test at
+    # the _detect_contradicts level by mocking _llm_judge_contradiction
+    # directly to simulate a real LLM hit.
+    usage_stub = {
+        "input_tokens": 300,
+        "output_tokens": 5,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+
+    with patch("cognify.edges._llm_judge_contradiction", return_value=(False, usage_stub)):
+        # We need candidate pairs to trigger the loop. Patch walk to return
+        # the two memory nodes as neighbors of each other.
+        from types import SimpleNamespace
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM devbrain.memory WHERE project_id = %s AND archived_at IS NULL",
+                (project["id"],),
+            )
+            mem_ids = [r[0] for r in cur.fetchall()]
+
+        if len(mem_ids) < 2:
+            pytest.skip("need at least 2 memory rows for edge spend test")
+
+        # Manually invoke _detect_contradicts with mocked walk that returns pairs.
+        from unittest.mock import patch as _patch
+        from cognify import edges as edges_mod
+
+        # Build a fake walk result returning the second node as neighbor of first.
+        fake_neighbor = SimpleNamespace(id=mem_ids[1])
+        fake_walk_result = SimpleNamespace(memories=[fake_neighbor])
+
+        with _patch.object(edges_mod, "walk", return_value=fake_walk_result):
+            edges_mod._detect_contradicts(
+                conn, project["id"], record_conn=conn
+            )
+
+    # Spend row should exist for the judged pair
+    rows = _fetch_spend_rows(conn, project["id"])
+    assert len(rows) >= 1
+    assert rows[0]["pass_name"] == "edges"
+    assert rows[0]["input_tokens"] == 300

--- a/factory/tests/test_versioned_reextract.py
+++ b/factory/tests/test_versioned_reextract.py
@@ -1,0 +1,320 @@
+"""Tests for versioned re-extraction (migration 030 + reextract_cli --since-version).
+
+Covers:
+  - extraction_version is set to CURRENT_EXTRACTION_VERSION on new extract rows
+  - extraction_version column exists on devbrain.memory (schema check)
+  - reextract_cli --since-version selects sessions with old extraction_version
+  - reextract_cli --since-version: old rows get archived_at set, new rows
+    written with CURRENT_EXTRACTION_VERSION
+  - reextract_cli --since-version dry_run: returns session count without mutating
+  - _sessions_below_version: returns correct sessions
+  - Mutual exclusion: since_version is exclusive with other flags
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from cognify.extract import (
+    CURRENT_EXTRACTION_VERSION,
+    _upsert_memory,
+    extract_from_session,
+)
+from cognify.reextract_cli import _sessions_below_version, run_reextract
+
+
+# ── Schema check (no LLM, no mock needed) ────────────────────────────────────
+
+
+@pytest.mark.db
+def test_extraction_version_column_exists(conn):
+    """devbrain.memory has an extraction_version column (migration 030)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name, data_type, column_default "
+            "FROM information_schema.columns "
+            "WHERE table_schema = 'devbrain' "
+            "  AND table_name = 'memory' "
+            "  AND column_name = 'extraction_version'",
+        )
+        row = cur.fetchone()
+    assert row is not None, "extraction_version column missing from devbrain.memory"
+    col_name, data_type, default = row
+    assert data_type in ("integer", "bigint"), f"unexpected type: {data_type}"
+    assert "1" in str(default), f"expected default 1, got: {default}"
+
+
+# ── CURRENT_EXTRACTION_VERSION sentinel ──────────────────────────────────────
+
+
+def test_current_extraction_version_is_int():
+    """CURRENT_EXTRACTION_VERSION must be a positive integer."""
+    assert isinstance(CURRENT_EXTRACTION_VERSION, int)
+    assert CURRENT_EXTRACTION_VERSION >= 1
+
+
+# ── _upsert_memory sets extraction_version ────────────────────────────────────
+
+
+@pytest.mark.db
+def test_upsert_memory_sets_extraction_version(conn, project_factory):
+    """New rows written by _upsert_memory carry CURRENT_EXTRACTION_VERSION."""
+    project = project_factory("ver_upsert")
+    session_id = str(uuid.uuid4())
+
+    mid, was_new = _upsert_memory(
+        conn,
+        project_id=project["id"],
+        kind="lesson",
+        title="Versioned Lesson",
+        content="Some content",
+        session_id=session_id,
+    )
+
+    assert was_new is True
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT extraction_version FROM devbrain.memory WHERE id = %s",
+            (mid,),
+        )
+        version = cur.fetchone()[0]
+    assert version == CURRENT_EXTRACTION_VERSION
+
+
+# ── extract_from_session integration ──────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_extract_sets_extraction_version_on_new_rows(conn, project_factory):
+    """extract_from_session writes new lesson rows with CURRENT_EXTRACTION_VERSION."""
+    project = project_factory("ver_extract")
+    session_id = str(uuid.uuid4())
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, provenance_id) "
+            "VALUES (%s, 'pattern', 'raw chunk', 'content', %s::uuid)",
+            (project["id"], session_id),
+        )
+    conn.commit()
+
+    mock_response = {
+        "lessons": [{"title": "Versioned Lesson", "content": "A great insight"}],
+        "decisions": [],
+        "_usage": {"input_tokens": 0, "output_tokens": 0,
+                   "cache_read_tokens": 0, "cache_write_tokens": 0},
+    }
+    with patch("cognify.extract._llm_extract", return_value=mock_response):
+        result = extract_from_session(conn, session_id, project["id"])
+
+    assert result.lessons_created == 1
+
+    # Verify the inserted row has the correct version.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT extraction_version FROM devbrain.memory "
+            "WHERE project_id = %s "
+            "  AND tier = 'lesson' "
+            "  AND archived_at IS NULL "
+            "  AND (applies_when->>'source_session') = %s",
+            (project["id"], session_id),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == CURRENT_EXTRACTION_VERSION
+
+
+# ── _sessions_below_version ───────────────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_sessions_below_version_returns_stale_sessions(conn, project_factory):
+    """_sessions_below_version returns sessions whose lesson rows have
+    extraction_version < the given threshold."""
+    project = project_factory("ver_below")
+    session_old = str(uuid.uuid4())
+    session_current = str(uuid.uuid4())
+
+    # Insert an "old" lesson row (version 0) for session_old.
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, tier, strength, applies_when, extraction_version) "
+            "VALUES (%s, 'pattern', 'Old Lesson', 'content', 'lesson', 1.0, %s::jsonb, 0)",
+            (project["id"], f'{{"source_session": "{session_old}"}}'),
+        )
+    conn.commit()
+
+    # Insert a "current" lesson row (version = CURRENT_EXTRACTION_VERSION) for session_current.
+    _upsert_memory(
+        conn,
+        project_id=project["id"],
+        kind="lesson",
+        title="Current Lesson",
+        content="up-to-date",
+        session_id=session_current,
+    )
+
+    # Query with threshold = CURRENT_EXTRACTION_VERSION.
+    sessions = _sessions_below_version(conn, project["id"], CURRENT_EXTRACTION_VERSION)
+    # Only the old session should be returned.
+    assert session_old in sessions
+    assert session_current not in sessions
+
+
+@pytest.mark.db
+def test_sessions_below_version_excludes_archived(conn, project_factory):
+    """_sessions_below_version skips archived lesson rows."""
+    project = project_factory("ver_archived")
+    session_id = str(uuid.uuid4())
+
+    # Insert a stale row but immediately archive it.
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, tier, strength, applies_when, "
+            " extraction_version, archived_at) "
+            "VALUES (%s, 'pattern', 'Archived', 'body', 'lesson', 1.0, %s::jsonb, "
+            "        0, NOW())",
+            (project["id"], f'{{"source_session": "{session_id}"}}'),
+        )
+    conn.commit()
+
+    sessions = _sessions_below_version(conn, project["id"], CURRENT_EXTRACTION_VERSION)
+    assert session_id not in sessions
+
+
+# ── run_reextract --since-version ─────────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_reextract_since_version_archives_old_and_writes_new(conn, project_factory):
+    """run_reextract --since-version archives stale rows and writes new ones
+    with the current extraction_version."""
+    project = project_factory("ver_reextract")
+    session_id = str(uuid.uuid4())
+
+    # Seed a raw chunk for the LLM to "process".
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, provenance_id) "
+            "VALUES (%s, 'pattern', 'raw', 'raw content', %s::uuid)",
+            (project["id"], session_id),
+        )
+    conn.commit()
+
+    # Insert a stale lesson row (version 0) for this session.
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, tier, strength, applies_when, extraction_version) "
+            "VALUES (%s, 'pattern', 'Stale Lesson', 'old content', 'lesson', 1.0, "
+            "        %s::jsonb, 0)",
+            (project["id"], f'{{"source_session": "{session_id}"}}'),
+        )
+    conn.commit()
+
+    # Mock the LLM to return a new lesson.
+    mock_response = {
+        "lessons": [{"title": "Fresh Lesson", "content": "Updated insight"}],
+        "decisions": [],
+        "_usage": {"input_tokens": 0, "output_tokens": 0,
+                   "cache_read_tokens": 0, "cache_write_tokens": 0},
+    }
+    with patch("cognify.extract._llm_extract", return_value=mock_response):
+        result = run_reextract(
+            conn,
+            project["id"],
+            since_version=CURRENT_EXTRACTION_VERSION,
+        )
+
+    assert result["sessions_targeted"] == 1
+    assert result["lessons_created"] == 1
+
+    # Old row should be archived.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT archived_at FROM devbrain.memory WHERE title = 'Stale Lesson' "
+            "AND project_id = %s",
+            (project["id"],),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row[0] is not None, "stale row should have been archived"
+
+    # New row should exist with CURRENT_EXTRACTION_VERSION.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT extraction_version FROM devbrain.memory "
+            "WHERE project_id = %s AND title = 'Fresh Lesson' AND archived_at IS NULL",
+            (project["id"],),
+        )
+        new_row = cur.fetchone()
+    assert new_row is not None
+    assert new_row[0] == CURRENT_EXTRACTION_VERSION
+
+
+@pytest.mark.db
+def test_reextract_since_version_dry_run(conn, project_factory):
+    """run_reextract --since-version dry_run returns session count without mutating."""
+    project = project_factory("ver_dry")
+    session_id = str(uuid.uuid4())
+
+    # Insert a stale lesson row (version 0).
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.memory "
+            "(project_id, kind, title, content, tier, strength, applies_when, extraction_version) "
+            "VALUES (%s, 'pattern', 'Dry Stale', 'content', 'lesson', 1.0, %s::jsonb, 0)",
+            (project["id"], f'{{"source_session": "{session_id}"}}'),
+        )
+    conn.commit()
+
+    result = run_reextract(
+        conn,
+        project["id"],
+        since_version=CURRENT_EXTRACTION_VERSION,
+        dry_run=True,
+    )
+
+    assert result.get("dry_run") is True
+    assert result.get("sessions_targeted") == 1
+
+    # Verify the stale row was NOT archived.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT archived_at FROM devbrain.memory "
+            "WHERE project_id = %s AND title = 'Dry Stale'",
+            (project["id"],),
+        )
+        archived_at = cur.fetchone()[0]
+    assert archived_at is None
+
+
+@pytest.mark.db
+def test_reextract_since_version_mutual_exclusion(conn, project_factory):
+    """since_version is mutually exclusive with other reextract flags."""
+    project = project_factory("ver_mutex")
+    with pytest.raises(ValueError, match="Exactly one"):
+        run_reextract(
+            conn,
+            project["id"],
+            since_version=2,
+            all_sessions=True,
+        )
+
+
+@pytest.mark.db
+def test_reextract_since_version_no_stale_sessions(conn, project_factory):
+    """run_reextract --since-version returns zero when no stale sessions exist."""
+    project = project_factory("ver_empty")
+    result = run_reextract(
+        conn,
+        project["id"],
+        since_version=CURRENT_EXTRACTION_VERSION,
+    )
+    assert result["sessions_targeted"] == 0

--- a/migrations/029_cognify_spend_log.sql
+++ b/migrations/029_cognify_spend_log.sql
@@ -1,0 +1,51 @@
+-- Migration 029: cognify_spend_log + cognify_spend_daily view
+-- ============================================================================
+-- Tracks per-call LLM cost estimates for all cognify passes and eval agents.
+-- Project-scoped (P3): all rows carry project_id; cross-project aggregation
+-- is intentionally NOT supported in the daily view.
+--
+-- PHI constraint: NO raw session content stored here — only token counts,
+-- model name, pass name, project_id, and timestamps.
+--
+-- Costs are ESTIMATES based on hardcoded Anthropic list prices (see
+-- factory/observability/pricing.py). Not integrated with the billing API.
+--
+-- Phase 6 design: docs/plans/2026-05-05-phase-6-cognify-memify-design.md §6
+
+CREATE TABLE IF NOT EXISTS devbrain.cognify_spend_log (
+    id                  BIGSERIAL PRIMARY KEY,
+    project_id          UUID REFERENCES devbrain.projects(id),
+    pass_name           TEXT NOT NULL,          -- 'extract', 'edges', 'eval_security', …
+    model               TEXT NOT NULL,          -- 'claude-sonnet-4-6', …
+    input_tokens        INTEGER NOT NULL,
+    output_tokens       INTEGER NOT NULL,
+    cache_read_tokens   INTEGER DEFAULT 0,
+    cache_write_tokens  INTEGER DEFAULT 0,
+    cost_usd            NUMERIC(10, 6) NOT NULL,
+    occurred_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cognify_spend_log_project_day
+    ON devbrain.cognify_spend_log (project_id, occurred_at DESC);
+
+-- ── Daily aggregation view ────────────────────────────────────────────────────
+-- Sums spend by (project_id, calendar day, model).
+-- project_id is preserved — never aggregated away (P3 isolation).
+CREATE OR REPLACE VIEW devbrain.cognify_spend_daily AS
+SELECT
+    project_id,
+    date_trunc('day', occurred_at)::date  AS day,
+    model,
+    sum(input_tokens)                     AS input_tokens,
+    sum(output_tokens)                    AS output_tokens,
+    sum(cache_read_tokens)                AS cache_read_tokens,
+    sum(cache_write_tokens)               AS cache_write_tokens,
+    sum(cost_usd)                         AS cost_usd,
+    count(*)                              AS call_count
+FROM devbrain.cognify_spend_log
+GROUP BY project_id, date_trunc('day', occurred_at)::date, model
+ORDER BY day DESC, project_id, model;
+
+INSERT INTO devbrain.schema_migrations (filename)
+VALUES ('029_cognify_spend_log.sql')
+ON CONFLICT (filename) DO NOTHING;

--- a/migrations/030_extraction_version.sql
+++ b/migrations/030_extraction_version.sql
@@ -1,0 +1,28 @@
+-- Migration 030: extraction_version column on devbrain.memory
+-- ============================================================================
+-- Supports versioned re-extraction in Phase 6 (cognify_extract). When the
+-- extraction prompt or model is bumped, CURRENT_EXTRACTION_VERSION in
+-- factory/cognify/extract.py is incremented. The reextract_cli --since-version
+-- flag then selects rows with extraction_version < N for re-processing.
+--
+-- Default 1: all existing extracted rows (tier='lesson') get version=1 implicitly
+-- (DEFAULT 1 on ADD COLUMN backfills existing rows).
+--
+-- Non-extracted rows (tier='memory', tier='rule') also receive 1 as the
+-- default, but the column is only meaningful for tier='lesson' rows.
+--
+-- Phase 6 design: docs/plans/2026-05-05-phase-6-cognify-memify-design.md §6
+
+ALTER TABLE devbrain.memory
+    ADD COLUMN IF NOT EXISTS extraction_version INTEGER DEFAULT 1;
+
+COMMENT ON COLUMN devbrain.memory.extraction_version IS
+    'Version of the extraction prompt/model that produced this row. '
+    'Bumped in factory/cognify/extract.py CURRENT_EXTRACTION_VERSION when '
+    'the extraction logic changes. Used by reextract_cli --since-version. '
+    'Only meaningful for tier=''lesson'' rows; non-extracted rows carry the '
+    'default value (1).';
+
+INSERT INTO devbrain.schema_migrations (filename)
+VALUES ('030_extraction_version.sql')
+ON CONFLICT (filename) DO NOTHING;


### PR DESCRIPTION
## Summary

- **Migration 029**: `devbrain.cognify_spend_log` table for per-call LLM cost capture, plus `cognify_spend_daily` view that sums by `(project_id, day, model)` (P3 scoped — never aggregates across projects). No raw PHI: only token counts, model name, pass name, timestamps.
- **`factory/observability/` package**: `pricing.py` with hardcoded Sonnet 4.6 list rates and `compute_cost_usd()`; `spend.py` with non-fatal `record_spend()` INSERT helper. Costs are documented as estimates (no billing API integration).
- **Spend wired into**: `cognify/extract.py` (per-session extraction call), `cognify/edges.py` (per-contradiction-judgment call), `curator/eval/runner.py` (per-eval-agent call with optional `project_id` kwarg).
- **Migration 030**: `extraction_version INTEGER DEFAULT 1` column on `devbrain.memory`. New tier=lesson rows carry `CURRENT_EXTRACTION_VERSION` (starts at 1).
- **`reextract_cli.py --since-version=N`**: selects sessions with `extraction_version < N`, archives stale rows (`archived_at` + `applies_when.reextracted_from` for traceability), re-extracts with current version. HIPAA audit trail preserved (archive only, never delete).

## Test plan

- [x] 25/25 new tests pass: `test_spend_tracking.py` (8 unit + 7 DB) and `test_versioned_reextract.py` (10 DB + unit)
- [x] Pricing math: `compute_cost_usd` unit tests for each token type and mixed
- [x] `record_spend`: DB row insertion, multi-row, non-fatal on broken connection, daily view aggregation
- [x] `extract.py` integration: spend row written/not-written based on mock token counts
- [x] `edges.py` integration: spend row written per contradiction judgment
- [x] `extraction_version` schema check (migration 030), `CURRENT_EXTRACTION_VERSION` type guard
- [x] `--since-version`: stale-session selection, archived-row exclusion, dry-run, live archive+rewrite, mutual exclusion, empty project
- [x] Pre-existing `test_cognify_edges.py` updated for `_llm_judge_contradiction` new `(bool, usage_dict)` return type
- [x] Ruff lint clean across all touched files
- [x] Migrations idempotent (applied to local dev DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)