### PR TITLE
fix(memory): export/import column drift — preserve 6 columns on roundtrip

### DIFF
--- a/factory/export_memory.py
+++ b/factory/export_memory.py
@@ -260,7 +260,10 @@ def _stream_memory(db, project_ids: list[str] | None):
         "SELECT m.id, p.slug AS project_slug, m.kind, m.title, m.content, "
         "       m.embedding::text AS embedding_text, m.strength, m.hit_count, "
         "       m.last_hit, m.applies_when, m.provenance_id, m.tier, "
-        "       m.archived_at, m.created_at, m.updated_at "
+        "       m.archived_at, m.created_at, m.updated_at, "
+        "       m.compliance_profiles, m.current_streak, "
+        "       m.graduated_at, m.demoted_at, m.effective_hit_count, "
+        "       m.last_cascade_at "
         "FROM devbrain.memory m "
         "JOIN devbrain.projects p ON p.id = m.project_id "
     )
@@ -295,6 +298,12 @@ def _stream_memory(db, project_ids: list[str] | None):
                     "archived_at": row[12],
                     "created_at": row[13],
                     "updated_at": row[14],
+                    "compliance_profiles": row[15],
+                    "current_streak": row[16],
+                    "graduated_at": row[17],
+                    "demoted_at": row[18],
+                    "effective_hit_count": row[19],
+                    "last_cascade_at": row[20],
                 }
         finally:
             cur.close()

--- a/factory/import_memory.py
+++ b/factory/import_memory.py
@@ -262,10 +262,16 @@ def _insert_memory(
         INSERT INTO devbrain.memory
             (project_id, kind, title, content, embedding,
              strength, hit_count, last_hit, applies_when,
-             provenance_id, tier, archived_at, created_at, updated_at)
+             provenance_id, tier, archived_at, created_at, updated_at,
+             compliance_profiles, current_streak,
+             graduated_at, demoted_at, effective_hit_count,
+             last_cascade_at)
         VALUES (%s, %s, %s, %s, %s::vector,
                 %s, %s, %s, %s::jsonb,
-                %s, %s, %s, %s, %s)
+                %s, %s, %s, %s, %s,
+                %s::text[], %s,
+                %s, %s, %s,
+                %s)
         ON CONFLICT (provenance_id, kind) WHERE provenance_id IS NOT NULL
         DO NOTHING
     """
@@ -303,6 +309,12 @@ def _insert_memory(
                 m.get("archived_at"),
                 m.get("created_at"),
                 m.get("updated_at") or m.get("created_at"),
+                m.get("compliance_profiles"),
+                m.get("current_streak", 0),
+                m.get("graduated_at"),
+                m.get("demoted_at"),
+                m.get("effective_hit_count", 0),
+                m.get("last_cascade_at"),
             ),
         )
         if cur.rowcount == 1:

--- a/factory/tests/test_export_import_memory.py
+++ b/factory/tests/test_export_import_memory.py
@@ -428,6 +428,82 @@ def test_embedding_bit_equality_round_trip(db, tmp_path):
     )
 
 
+# ─── 6.5 column drift — Phase 5/6/7 columns survive round-trip ──────────────
+
+
+def test_phase_5_6_7_columns_round_trip(db, tmp_path):
+    """compliance_profiles + 5 other Phase-era columns must survive export →
+    import. Pre-fix bug: export/import column lists omitted these, so
+    rule-tier rows with non-empty compliance_profiles round-tripped as
+    NULL — the source of the 34,650-row pollution incident on 2026-05-05.
+    Migration 026 cleaned the artifacts; this test prevents regression.
+    """
+    pid = _seed_project(db, slug=f"{EXPORT_IMPORT_TEST_PREFIX}drift")
+    prov = str(uuid.uuid4())
+    _seed_memory(
+        db, project_id=pid, kind="decision",
+        title=f"{EXPORT_IMPORT_TEST_PREFIX}drift_rule",
+        content=f"{EXPORT_IMPORT_TEST_PREFIX}rule body",
+        provenance_id=prov,
+    )
+
+    # Stamp the 6 columns with non-default values so a NULL/0 default in
+    # the importer would stand out clearly.
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE devbrain.memory
+            SET tier                = 'rule',
+                compliance_profiles = ARRAY['hipaa','soc2']::text[],
+                current_streak      = 7,
+                graduated_at        = '2026-05-01 12:00:00+00',
+                demoted_at          = '2026-05-02 12:00:00+00',
+                effective_hit_count = 42,
+                last_cascade_at     = '2026-05-03 12:00:00+00'
+            WHERE provenance_id = %s
+            """,
+            (prov,),
+        )
+        conn.commit()
+
+    out = tmp_path / "drift.json"
+    export_memory.write_export_file(db, out)
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM devbrain.memory WHERE provenance_id = %s", (prov,),
+        )
+        conn.commit()
+
+    payload = import_memory.read_import_file(out)
+    import_memory.import_from_dict(db, payload)
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT tier, compliance_profiles, current_streak,
+                   graduated_at, demoted_at, effective_hit_count,
+                   last_cascade_at
+            FROM devbrain.memory WHERE provenance_id = %s
+            """,
+            (prov,),
+        )
+        row = cur.fetchone()
+
+    assert row is not None, "imported row must exist"
+    tier, profiles, streak, grad_at, dem_at, eff_count, cascade_at = row
+    assert tier == "rule"
+    assert list(profiles) == ["hipaa", "soc2"], (
+        "compliance_profiles must round-trip exactly — this is the column "
+        "whose drift produced the 2026-05-05 pollution incident"
+    )
+    assert streak == 7
+    assert grad_at is not None
+    assert dem_at is not None
+    assert eff_count == 42
+    assert cascade_at is not None
+
+
 # ─── 7. gzip output is smaller than plain ───────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes the writer behind the 2026-05-05 pollution incident. Both `factory/export_memory.py` and `factory/import_memory.py` were missing 6 columns from their column lists, so multi-dev migration roundtrips (`devbrain export-memory | devbrain import-memory`) silently stripped these on every cycle:

- `compliance_profiles` (text[]) — **the regulatory tagging that was lost**
- `current_streak` (int)
- `graduated_at` (timestamptz)
- `demoted_at` (timestamptz)
- `effective_hit_count` (int)
- `last_cascade_at` (timestamptz)

Each roundtrip duplicated rule-tier rows AND stripped their profile tagging, producing functionally inert (P6 invisible) rows that polluted the canonical 'devbrain' project. Migration 026 (already in main) archived the 34,650 artifacts; this PR closes the writer so it doesn't happen again.

## Test plan

- [x] New `test_phase_5_6_7_columns_round_trip` seeds a row with all 6 columns stamped to distinctive values, exports, deletes, re-imports, asserts every column survives
- [x] All other export/import tests still pass

## Impact

After this lands, multi-dev migrations are clean. Future `devbrain export-memory | devbrain import-memory` cycles preserve compliance tagging, graduation history, and Phase 5 cascade audit metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)