### PR TITLE
feat(cognify): cross_project flag for canonical-rule contradiction sweeps

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2830,16 +2830,21 @@ def cmd_rules_lint():
 )
 @click.option("--dry-run", is_flag=True, default=False,
               help="Report what the pass would do without making changes.")
+@click.option("--cross-project", "cross_project", is_flag=True, default=False,
+              help="Edges pass only: include canonical 'devbrain' rules library "
+                   "as candidate-pair source. Detects when project lessons "
+                   "contradict canonical regulatory rules. Other passes ignore.")
 @click.option("--json", "as_json", is_flag=True, default=False,
               help="Emit result as JSON.")
-def cognify_command(pass_name, run_all, project_slug, dry_run, as_json):
+def cognify_command(pass_name, run_all, project_slug, dry_run, cross_project, as_json):
     """Run one or all cognify passes.
 
     Examples:\n
       devbrain cognify --pass=decay\n
       devbrain cognify --pass=extract --project=myproject\n
       devbrain cognify --all --project=myproject\n
-      devbrain cognify --pass=decay --dry-run
+      devbrain cognify --pass=decay --dry-run\n
+      devbrain cognify --pass=edges --project=brightbot --cross-project
     """
     import sys
     from config import DATABASE_URL
@@ -2869,7 +2874,9 @@ def cognify_command(pass_name, run_all, project_slug, dry_run, as_json):
 
     with db._conn() as conn:
         if run_all:
-            results = _run_all(conn, project_id, dry_run=dry_run)
+            results = _run_all(
+                conn, project_id, dry_run=dry_run, cross_project=cross_project
+            )
             if as_json:
                 import json as _json
                 click.echo(_json.dumps(
@@ -2883,7 +2890,10 @@ def cognify_command(pass_name, run_all, project_slug, dry_run, as_json):
                         f"llm={res.llm_calls}  [{status}]"
                     )
         else:
-            result = _run_pass(conn, pass_name, project_id, dry_run=dry_run)
+            result = _run_pass(
+                conn, pass_name, project_id,
+                dry_run=dry_run, cross_project=cross_project,
+            )
             if as_json:
                 import json as _json
                 click.echo(_json.dumps(vars(result), indent=2, default=str))

--- a/factory/cognify/edges.py
+++ b/factory/cognify/edges.py
@@ -62,18 +62,31 @@ class EdgesPass(CognifyPass):
     6-hour cadence. Up to 15 LLM calls per run (contradicts only).
     cites detection is zero-LLM text matching.
     Uses Phase 5 graph_walk for efficient contradiction pair selection.
+
+    cross_project (default False): when True, the contradiction walker
+    surfaces canonical 'devbrain' rules-library memories alongside the
+    project's own memories as candidate pairs. Use to detect when a
+    project's lesson/rule contradicts a regulatory rule in the canonical
+    library. When False, traversal is strict same-project (P3-aligned).
     """
 
     pass_name = "edges"
 
-    def run(self, conn: Any, project_id: Any, *, dry_run: bool = False) -> PassResult:
+    def run(
+        self,
+        conn: Any,
+        project_id: Any,
+        *,
+        dry_run: bool = False,
+        cross_project: bool = False,
+    ) -> PassResult:
         if project_id is None:
             raise ValueError(
                 "cognify_edges requires a project_id (LLM pass; project-scoped)"
             )
 
         cites_new, contradicts_new, llm_calls = _run_edges(
-            conn, project_id, dry_run=dry_run
+            conn, project_id, dry_run=dry_run, cross_project=cross_project
         )
         return PassResult(
             rows_processed=cites_new + contradicts_new,
@@ -87,12 +100,22 @@ class EdgesPass(CognifyPass):
 
 
 def _run_edges(
-    conn: Any, project_id: Any, *, dry_run: bool = False
+    conn: Any,
+    project_id: Any,
+    *,
+    dry_run: bool = False,
+    cross_project: bool = False,
 ) -> tuple[int, int, int]:
-    """Main edges pass logic. Returns (cites_new, contradicts_new, llm_calls)."""
+    """Main edges pass logic. Returns (cites_new, contradicts_new, llm_calls).
+
+    cites detection stays strictly project-local (text-pattern match;
+    no walker involvement). Only contradicts detection honors
+    cross_project when True.
+    """
     cites_new = _detect_cites(conn, project_id, dry_run=dry_run)
     contradicts_new, llm_calls = _detect_contradicts(
-        conn, project_id, dry_run=dry_run, record_conn=conn
+        conn, project_id, dry_run=dry_run, record_conn=conn,
+        cross_project=cross_project,
     )
     return cites_new, contradicts_new, llm_calls
 
@@ -160,6 +183,7 @@ def _detect_contradicts(
     *,
     dry_run: bool = False,
     record_conn: Any = None,
+    cross_project: bool = False,
 ) -> tuple[int, int]:
     """Detect contradicts edges using Phase 5 graph_walk + LLM judgment.
 
@@ -174,6 +198,13 @@ def _detect_contradicts(
     record_conn: connection used to write spend log rows. When None, spend
         is not recorded (e.g. dry_run or test scenarios without the table).
         In production, pass the same conn used for edge writes.
+
+    cross_project: when True, the walker surfaces canonical 'devbrain'
+        rules-library memories (tier='rule' with non-empty
+        compliance_profiles) as candidate pairs alongside the project's
+        own memories. Detects when a project's lesson contradicts a
+        canonical regulatory rule. When False (default), traversal stays
+        strict same-project (P3-aligned).
     """
     all_memories = _load_memories(conn, project_id)
     if len(all_memories) < 2:
@@ -199,7 +230,7 @@ def _detect_contradicts(
             max_hops=CONTRADICTION_MAX_HOPS,
             max_nodes=CONTRADICTION_MAX_NODES,
             direction="both",
-            cross_project=False,
+            cross_project=cross_project,
         )
         for neighbor in result.memories:
             if neighbor.id == m["id"]:

--- a/factory/cognify/orchestrator.py
+++ b/factory/cognify/orchestrator.py
@@ -121,6 +121,7 @@ def run_pass(
     project_id: Any = None,
     *,
     dry_run: bool = False,
+    cross_project: bool = False,
 ) -> PassResult:
     """Run a single named pass and record it in cognify_run_log.
 
@@ -129,6 +130,9 @@ def run_pass(
         pass_name: one of 'decay', 'gc', 'extract', 'edges', 'strengthen'.
         project_id: UUID or None.
         dry_run: if True, compute only; no DB mutations.
+        cross_project: only honored by passes that opt in (currently
+            'edges' for canonical-rule contradiction sweeps). Other
+            passes ignore the flag.
 
     Returns:
         PassResult from the pass.
@@ -151,7 +155,15 @@ def run_pass(
     error_text: str | None = None
 
     try:
-        result = instance.run(conn, project_id, dry_run=dry_run)
+        # Pass-specific kwargs: only forward cross_project to passes that
+        # accept it. The introspection check keeps the signature optional
+        # without forcing every pass to declare it.
+        kwargs = {"dry_run": dry_run}
+        import inspect
+        sig = inspect.signature(instance.run)
+        if "cross_project" in sig.parameters:
+            kwargs["cross_project"] = cross_project
+        result = instance.run(conn, project_id, **kwargs)
     except Exception as exc:
         error_text = traceback.format_exc()[:2000]
         logger.exception("cognify pass %s failed", pass_name)
@@ -171,18 +183,24 @@ def run_all(
     project_id: Any = None,
     *,
     dry_run: bool = False,
+    cross_project: bool = False,
 ) -> dict[str, PassResult]:
     """Run all 5 passes in dependency order.
 
     Returns a dict of {pass_name: PassResult}.
     Continues past individual pass failures (logged but not re-raised) so a
     flaky LLM in 'extract' doesn't block 'strengthen'.
+
+    cross_project is forwarded to passes that accept it (currently 'edges').
     """
     _ensure_registry()
     results: dict[str, PassResult] = {}
     for name in PASS_ORDER:
         try:
-            results[name] = run_pass(conn, name, project_id, dry_run=dry_run)
+            results[name] = run_pass(
+                conn, name, project_id,
+                dry_run=dry_run, cross_project=cross_project,
+            )
         except RuntimeError:
             # Logged inside run_pass; continue to next pass.
             results[name] = PassResult(metadata={"error": "pass failed"})

--- a/factory/tests/test_cognify_edges_contradicts.py
+++ b/factory/tests/test_cognify_edges_contradicts.py
@@ -407,3 +407,72 @@ def test_detect_contradicts_skips_empty_content_pairs(conn, project_factory):
 
     # Empty content → pair skipped → 0 LLM calls.
     assert call_count["n"] == 0
+
+
+# ── cross-project flag ───────────────────────────────────────────────────────
+
+
+@pytest.mark.db
+def test_detect_contradicts_cross_project_forwards_to_walker(conn, project_factory):
+    """cross_project=True must flow through to graph_walker.walk().
+
+    The flag is not a behavior change at this level — _detect_contradicts
+    just hands cross_project to walk(). What matters: forwarding works
+    and the call observably reaches walk() with the right value.
+    """
+    project = project_factory("contra_xp")
+    m_a = _insert_mem(
+        conn, project["id"], "LessonA",
+        "Always do X.", kind="decision", tier="lesson",
+    )
+    m_b = _insert_mem(
+        conn, project["id"], "LessonB",
+        "Never do X.", kind="decision", tier="lesson",
+    )
+    _insert_edge_direct(conn, m_a, m_b, "derived_from")
+
+    captured_cross_project: list[bool] = []
+    real_walk = None
+
+    def capturing_walk(*args, **kwargs):
+        captured_cross_project.append(kwargs.get("cross_project", "missing"))
+        # Return an empty walk result so the test stays fast (no LLM calls).
+        from curator.eval.types import EvalFinding  # noqa: F401  (smoke import)
+        from graph.walker import GraphWalkResult
+        return GraphWalkResult(memories=[], edges=[], truncated=False)
+
+    with patch("cognify.edges.walk", side_effect=capturing_walk):
+        _detect_contradicts(conn, project["id"], cross_project=True)
+
+    assert any(v is True for v in captured_cross_project), (
+        "cross_project=True must propagate to graph_walker.walk()"
+    )
+
+
+@pytest.mark.db
+def test_detect_contradicts_default_cross_project_is_false(conn, project_factory):
+    """Default cross_project=False — preserves P3-aligned same-project behavior."""
+    project = project_factory("contra_xp_default")
+    m_a = _insert_mem(
+        conn, project["id"], "LessonA",
+        "Always do X.", kind="decision", tier="lesson",
+    )
+    m_b = _insert_mem(
+        conn, project["id"], "LessonB",
+        "Never do X.", kind="decision", tier="lesson",
+    )
+    _insert_edge_direct(conn, m_a, m_b, "derived_from")
+
+    captured: list[bool] = []
+
+    def capturing_walk(*args, **kwargs):
+        captured.append(kwargs.get("cross_project", "missing"))
+        from graph.walker import GraphWalkResult
+        return GraphWalkResult(memories=[], edges=[], truncated=False)
+
+    with patch("cognify.edges.walk", side_effect=capturing_walk):
+        _detect_contradicts(conn, project["id"])  # no cross_project kwarg
+
+    assert all(v is False for v in captured), (
+        "default cross_project must be False"
+    )


### PR DESCRIPTION
## Summary

Follow-up split from PR #104. Adds `cross_project: bool = False` parameter through the cognify_edges call chain so contradiction detection can sweep canonical 'devbrain' rules-library memories alongside a project's own.

When True, `_detect_contradicts` forwards `cross_project=True` to `graph_walker.walk()`, surfacing canonical regulatory rules as candidate-pair seeds. Detects when a project's lesson contradicts a HIPAA/SOC2/FERPA rule in the canonical library.

Default False preserves P3-aligned same-project behavior.

## Changes

- `factory/cognify/edges.py` — `CognifyEdges.run()`, `_run_edges()`, `_detect_contradicts()` all accept `cross_project`
- `factory/cognify/orchestrator.py` — `run_pass()` and `run_all()` accept `cross_project`; introspection-based forwarding so passes that don't take the kwarg (decay, gc, extract, strengthen) ignore it without erroring
- `factory/cli.py` — new `--cross-project` flag on `devbrain cognify`
- 2 new tests assert the flag propagates correctly and the default is False

## Usage

```
devbrain cognify --pass=edges --project=brightbot --cross-project
```

Cites detection stays strictly project-local (text pattern match; no walker involvement).

## Test plan

- [x] 2 new tests pass: `test_detect_contradicts_cross_project_forwards_to_walker` + `test_detect_contradicts_default_cross_project_is_false`
- [x] Existing 13 contradicts tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)