### PR TITLE
feat(onboarding): plumb ssh_host + ssh_port (VPS jump host for remote devs)

### DIFF
--- a/config/devbrain.yaml.example
+++ b/config/devbrain.yaml.example
@@ -3,6 +3,17 @@
 # Copy this file to config/devbrain.yaml and fill in your values.
 # The real config/devbrain.yaml is gitignored so secrets stay local.
 
+# Onboarding network endpoint — used by the kit's SSH commands so a
+# remote dev can reach the rotation handler without local-network mDNS.
+# Production setups should publish a public host (typically a VPS with
+# a reverse tunnel from Mac Studio) and override below.
+#
+# Defaults (not set here): ssh_host=lhts-mac-studio.local, ssh_port=22 —
+# only works for devs on the same Bonjour-resolvable LAN as Mac Studio.
+onboarding:
+  ssh_host: 72.60.64.155        # Public IP / DNS name (e.g., your VPS)
+  ssh_port: 2222                # Reverse-tunnel port forwarding to Mac Studio's sshd
+
 database:
   host: localhost
   port: 5433

--- a/factory/config.py
+++ b/factory/config.py
@@ -167,6 +167,18 @@ FACTORY_TIER_2_SUBCATEGORIES = dict(
 )
 FACTORY_CRED_DEPENDENTS = list(FACTORY_CONFIG.get("cred_dependents", []))
 
+# Onboarding network endpoint — used by the kit's SSH commands so a
+# remote dev can reach the rotation handler without local-network mDNS.
+# Default falls back to the legacy lhts-mac-studio.local for backward
+# compat with installs that haven't published a tunnel yet. Production
+# installs should override via config/devbrain.yaml:
+#   onboarding:
+#     ssh_host: 72.60.64.155        # VPS jump host (or DNS name)
+#     ssh_port: 2222                # reverse-tunnel port forwarding to Mac Studio
+_ONBOARDING_CONFIG = _config.get("onboarding", {})
+ONBOARDING_SSH_HOST = str(_ONBOARDING_CONFIG.get("ssh_host", "lhts-mac-studio.local"))
+ONBOARDING_SSH_PORT = int(_ONBOARDING_CONFIG.get("ssh_port", 22))
+
 # Fix-loop trigger tier. When True (default as of 2026-04-23), reviewer
 # WARNING findings also route a job through FIX_LOOP; when False the
 # pre-2026-04-23 behavior (BLOCKING-only) is preserved.

--- a/factory/onboarding_kit.py
+++ b/factory/onboarding_kit.py
@@ -335,6 +335,7 @@ persists both, and self-deletes the bootstrap key entry.
 PUBKEY=$(cat ~/.ssh/id_ed25519_devbrain.pub)
 
 ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
+    {ssh_port_flag} \\
     -o StrictHostKeyChecking=accept-new \\
     -o UserKnownHostsFile=~/.ssh/known_hosts \\
     lhtdev@{ssh_host} \\
@@ -364,6 +365,7 @@ token format, persists both, and self-deletes the bootstrap key entry.
 PUBKEY=$(cat ~/.ssh/id_ed25519_devbrain.pub)
 
 ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
+    {ssh_port_flag} \\
     -o StrictHostKeyChecking=accept-new \\
     -o UserKnownHostsFile=~/.ssh/known_hosts \\
     lhtdev@{ssh_host} \\
@@ -394,6 +396,7 @@ bootstrap key entry.
 PUBKEY=$(cat ~/.ssh/id_ed25519_devbrain.pub)
 
 ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
+    {ssh_port_flag} \\
     -o StrictHostKeyChecking=accept-new \\
     -o UserKnownHostsFile=~/.ssh/known_hosts \\
     lhtdev@{ssh_host} \\
@@ -436,7 +439,8 @@ cat <<'EOF'
   "mcpServers": {{
     "devbrain": {{
       "command": "ssh",
-      "args": ["-i", "~/.ssh/id_ed25519_devbrain", "lhtdev@{ssh_host}",
+      "args": ["-i", "~/.ssh/id_ed25519_devbrain", "-p", "{ssh_port}",
+               "lhtdev@{ssh_host}",
                "/Users/lhtdev/devbrain/mcp-server/run.sh"]
     }}
   }}
@@ -451,14 +455,14 @@ After this, restart {cli_display_name}. The DevBrain MCP tools appear in your
 
 <!-- agent:auto requires=user-approval,network risk=low -->
 ```bash
-ssh -i ~/.ssh/id_ed25519_devbrain lhtdev@{ssh_host} whoami
+ssh -i ~/.ssh/id_ed25519_devbrain {ssh_port_flag} lhtdev@{ssh_host} whoami
 # Expected output: lhtdev
 ```
 
 You can now SSH into the Mac Studio at any time:
 
 ```bash
-ssh -i ~/.ssh/id_ed25519_devbrain lhtdev@{ssh_host}
+ssh -i ~/.ssh/id_ed25519_devbrain {ssh_port_flag} lhtdev@{ssh_host}
 # (Add to ~/.ssh/config as `Host mac-studio` for ergonomics.)
 ```
 
@@ -548,6 +552,7 @@ def write_onboarding_kit(
     bootstrap_invite_id_short: str,
     bootstrap_expiry: datetime,
     ssh_host: str = "lhts-mac-studio.local",
+    ssh_port: int = 22,
     cli: CliName = "claude",
 ) -> Path:
     """Render an onboarding kit for one invitation. Returns the path written.
@@ -589,6 +594,8 @@ def write_onboarding_kit(
         first_name=first_name,
         bootstrap_private_key=bootstrap_private_key,
         ssh_host=ssh_host,
+        ssh_port=ssh_port,
+        ssh_port_flag=f"-p {ssh_port}",
     )
 
     sections = [

--- a/factory/setup.py
+++ b/factory/setup.py
@@ -1986,7 +1986,12 @@ def setup_add_dev(cli: str | None = None) -> None:
     from onboarding_kit import write_onboarding_kit
     from profiles import DEV_ID_RE
     from state_machine import FactoryDB
-    from config import DATABASE_URL, DEVBRAIN_HOME as _DEVBRAIN_HOME
+    from config import (
+        DATABASE_URL,
+        DEVBRAIN_HOME as _DEVBRAIN_HOME,
+        ONBOARDING_SSH_HOST,
+        ONBOARDING_SSH_PORT,
+    )
 
     _header("Onboard a new dev")
     _desc(
@@ -2161,6 +2166,8 @@ def setup_add_dev(cli: str | None = None) -> None:
         bootstrap_private_key=bootstrap_private,
         bootstrap_invite_id_short=invite_id_short,
         bootstrap_expiry=bootstrap_expires,
+        ssh_host=ONBOARDING_SSH_HOST,
+        ssh_port=ONBOARDING_SSH_PORT,
         cli=cli,
     )
 


### PR DESCRIPTION
## Summary

The onboarding kit hardcoded `ssh_host='lhts-mac-studio.local'` (Bonjour/mDNS) which only resolves on the LHT local network. Remote devs received kits whose SSH commands timed out — the actual cause of tonight's onboarding failure.

This PR plumbs a configurable SSH endpoint through the kit so kits can target a publicly-reachable host (typically a VPS with a reverse tunnel back to Mac Studio).

## Changes

- `factory/config.py` — new `ONBOARDING_SSH_HOST` + `ONBOARDING_SSH_PORT`, loaded from `config/devbrain.yaml`'s `onboarding:` block. Defaults to legacy `lhts-mac-studio.local:22` for backward compat.
- `factory/setup.py` — `setup_add_dev` passes both into `write_onboarding_kit`.
- `factory/onboarding_kit.py` — new `ssh_port` parameter; templates inject `{ssh_port_flag}` (`-p N`) into every SSH command:
  - Phase 5 rotation call (each CLI variant)
  - Phase 7 MCP config args (now: `["-i", ".../id_ed25519_devbrain", "-p", "<port>", "lhtdev@<host>", ...]`)
  - Phase 8 verify + ergonomic alias
- `config/devbrain.yaml.example` — documents the new `onboarding:` block.

## Companion ops work (already deployed; not in this PR)

- Mac Studio: keypair generated, `autossh` installed, launchd plist `com.devbrain.tunnel-vps` running. Maintains persistent reverse tunnel to LHT VPS via `autossh -M 0 -N -R 0.0.0.0:2222:localhost:22 root@72.60.64.155`.
- VPS: tunnel-only authorized_keys entry (forced command + `permitlisten="*:2222"`); `GatewayPorts clientspecified` in sshd_config.
- Result: `ssh -p 2222 lhtdev@72.60.64.155` from anywhere on the internet lands on Mac Studio.

## Test plan

- [x] All 45 existing onboarding tests still pass (defaults preserve legacy behavior)
- [x] Smoke test: kit rendered with codex CLI + new VPS host emits `ssh -i ... -p 2222 lhtdev@72.60.64.155 ...` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)