### PR TITLE
feat(onboarding): Windows preflight (WSL2 + apt prereqs, verify-before-install)

### DIFF
--- a/factory/onboarding_kit.py
+++ b/factory/onboarding_kit.py
@@ -92,6 +92,7 @@ from typing import Literal
 CliName = Literal["claude", "codex", "gemini"]
 
 VALID_CLIS: tuple[str, ...] = ("claude", "codex", "gemini")
+VALID_PLATFORMS: tuple[str, ...] = ("auto", "mac", "linux", "windows")
 
 # ─── Shared preamble (same for every CLI) ─────────────────────────────────────
 
@@ -520,6 +521,91 @@ _MCP_CONFIG_PATHS: dict[str, str] = {
     "gemini": "~/.gemini/settings.json",
 }
 
+# ─── Phase 0: Windows preflight (only when platform=windows) ──────────────────
+#
+# Verifies WSL2 + Ubuntu + apt prereqs, installs only what's missing. After
+# Phase 0 completes, the dev reopens their AI agent INSIDE the WSL Ubuntu
+# shell. Phases 1-8 then run as standard bash and "just work".
+
+_PHASE0_WINDOWS = """\
+## Phase 0 — Windows preflight (WSL2 + Ubuntu + apt prereqs)
+
+Phases 1-8 of this kit assume a Linux-shaped shell (bash, ssh, jq,
+process substitution, `~/.ssh/`). On Windows the cleanest path is
+**WSL2 + Ubuntu** — the rest of the kit then runs unchanged inside
+the WSL shell.
+
+The agent does verify-before-install: each dependency is checked first;
+only missing pieces are installed.
+
+### Step 0.1 — Verify WSL2
+
+<!-- agent:auto requires=user-approval risk=low -->
+```powershell
+# Run in PowerShell.
+wsl --status 2>&1
+# Expected if installed: "Default Distribution: Ubuntu" or similar.
+# If output is "Windows Subsystem for Linux has no installed
+# distributions" or the command isn't found — install per Step 0.2.
+```
+
+### Step 0.2 — Install WSL2 + Ubuntu (only if Step 0.1 reported missing)
+
+<!-- agent:human reason=requires-admin-elevation -->
+```powershell
+# Run in PowerShell as Administrator. Requires reboot afterward.
+wsl --install -d Ubuntu
+# Reboot when prompted, then:
+#   1. Open "Ubuntu" from the Start menu
+#   2. Set a Linux username + password when prompted
+#   3. Once the Ubuntu shell is open, continue to Step 0.3
+```
+
+> If WSL is already installed but the default distro isn't Ubuntu, you
+> can skip the install and just `wsl -d Ubuntu` from PowerShell. The
+> agent should NOT clobber an existing distro choice.
+
+### Step 0.3 — Verify Ubuntu apt prereqs
+
+<!-- agent:auto requires=user-approval risk=low -->
+```bash
+# Run inside the WSL Ubuntu shell.
+for cmd in jq ssh curl openssl; do
+    if command -v $cmd >/dev/null 2>&1; then
+        echo "✓ $cmd present"
+    else
+        echo "✗ $cmd missing"
+    fi
+done
+```
+
+### Step 0.4 — Install missing apt packages (only the ones flagged ✗ above)
+
+<!-- agent:auto requires=user-approval,sudo risk=low -->
+```bash
+# Adjust the package list to ONLY the missing ones from Step 0.3.
+# jq → jq, ssh → openssh-client, curl → curl, openssl → openssl
+sudo apt update
+sudo apt install -y <space-separated-package-names>
+```
+
+### Step 0.5 — Switch your AI agent to WSL
+
+The remaining phases (1-8) run inside this WSL Ubuntu shell. **Reopen
+your AI agent here** — close the Windows-native session and:
+
+- **Codex / Gemini CLI:** install + run them inside WSL (Phase 2 covers this)
+- **Claude Code:** install Claude Code inside WSL (Phase 2 covers this)
+- **Claude Desktop / Codex Desktop apps:** Windows-native is fine, but
+  the kit's bash commands need to execute via your WSL agent session
+
+Once your agent is running inside WSL Ubuntu, continue to Phase 1.
+
+---
+
+"""
+
+
 _PHASE2_BY_CLI: dict[str, str] = {
     "claude": _PHASE2_CLAUDE,
     "codex": _PHASE2_CODEX,
@@ -554,6 +640,7 @@ def write_onboarding_kit(
     ssh_host: str = "lhts-mac-studio.local",
     ssh_port: int = 22,
     cli: CliName = "claude",
+    platform: str = "auto",
 ) -> Path:
     """Render an onboarding kit for one invitation. Returns the path written.
 
@@ -570,6 +657,10 @@ def write_onboarding_kit(
     """
     if cli not in VALID_CLIS:
         raise ValueError(f"cli must be one of {VALID_CLIS!r}, got {cli!r}")
+    if platform not in VALID_PLATFORMS:
+        raise ValueError(
+            f"platform must be one of {VALID_PLATFORMS!r}, got {platform!r}"
+        )
 
     first_name = full_name.split()[0] if full_name else dev_id
 
@@ -598,8 +689,10 @@ def write_onboarding_kit(
         ssh_port_flag=f"-p {ssh_port}",
     )
 
-    sections = [
-        _PREAMBLE,
+    sections: list[str] = [_PREAMBLE]
+    if platform == "windows":
+        sections.append(_PHASE0_WINDOWS)
+    sections += [
         _PHASE2_BY_CLI[cli],
         _PHASE3_BY_CLI[cli],
         _PHASE4,

--- a/factory/setup.py
+++ b/factory/setup.py
@@ -1954,7 +1954,7 @@ def _run_multi_dev_section() -> None:
     setup_multi_dev(non_interactive=False)
 
 
-def setup_add_dev(cli: str | None = None) -> None:
+def setup_add_dev(cli: str | None = None, platform: str | None = None) -> None:
     """Onboard a new dev: stage row, generate invitation, write kit .md.
 
     The admin runs this on the Mac Studio. They get back a path to a
@@ -2050,6 +2050,41 @@ def setup_add_dev(cli: str | None = None) -> None:
         from onboarding_kit import VALID_CLIS as _VALID_CLIS
         if cli not in _VALID_CLIS:
             _warn(f"--cli '{cli}' is not valid. Must be one of: {', '.join(_VALID_CLIS)}")
+            raise SystemExit(2)
+
+    # ─── Dev's OS / platform selection (controls Windows WSL preflight) ──
+    from onboarding_kit import VALID_PLATFORMS as _VALID_PLATFORMS
+    if platform is None:
+        _platform_labels = {
+            "auto":    "Auto-detect at runtime (default — agent figures it out)",
+            "mac":     "macOS",
+            "linux":   "Linux",
+            "windows": "Windows (kit prepends WSL2 + Ubuntu preflight)",
+        }
+        click.echo()
+        _info("Dev's local platform?")
+        for i, p in enumerate(_VALID_PLATFORMS, 1):
+            click.echo(f"    {i}. {_platform_labels[p]}")
+        click.echo()
+        while True:
+            raw = _prompt("Choice (1-4 or platform name)", default="1").strip().lower()
+            if raw in ("1", "auto"):
+                platform = "auto"
+                break
+            elif raw in ("2", "mac"):
+                platform = "mac"
+                break
+            elif raw in ("3", "linux"):
+                platform = "linux"
+                break
+            elif raw in ("4", "windows"):
+                platform = "windows"
+                break
+            else:
+                _warn(f"'{raw}' is not valid. Enter 1-4 or a platform name.")
+    else:
+        if platform not in _VALID_PLATFORMS:
+            _warn(f"--platform '{platform}' is not valid. Must be one of: {', '.join(_VALID_PLATFORMS)}")
             raise SystemExit(2)
 
     auto_activate = _confirm(
@@ -2169,6 +2204,7 @@ def setup_add_dev(cli: str | None = None) -> None:
         ssh_host=ONBOARDING_SSH_HOST,
         ssh_port=ONBOARDING_SSH_PORT,
         cli=cli,
+        platform=platform,
     )
 
     # ─── Hand back to admin ───────────────────────────────────────────

--- a/factory/tests/test_onboarding_kit.py
+++ b/factory/tests/test_onboarding_kit.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from onboarding_kit import VALID_CLIS, write_onboarding_kit
+from onboarding_kit import VALID_CLIS, VALID_PLATFORMS, write_onboarding_kit
 
 
 COMMON_KWARGS = dict(
@@ -307,3 +307,55 @@ def test_rotate_helper_gemini_format_check():
         "gemini_api_key": "not-a-google-key",
     }
     assert _run_helper(body) == 2
+
+
+# ─── Windows preflight (platform=windows) ─────────────────────────────────────
+
+
+def test_valid_platforms_tuple():
+    assert set(VALID_PLATFORMS) == {"auto", "mac", "linux", "windows"}
+
+
+def test_invalid_platform_raises(tmp_path):
+    with pytest.raises(ValueError, match="platform must be one of"):
+        write_onboarding_kit(
+            path=tmp_path / "kit.md", platform="bsd", **COMMON_KWARGS
+        )
+
+
+def test_windows_platform_includes_phase0(tmp_path):
+    """platform='windows' prepends a Phase 0 preflight section."""
+    kit_path = tmp_path / "alice-onboard-win.md"
+    write_onboarding_kit(path=kit_path, platform="windows", **COMMON_KWARGS)
+    content = kit_path.read_text()
+    assert "Phase 0 — Windows preflight" in content
+    # Verify-before-install pattern: the kit checks WSL status BEFORE
+    # offering to install — never blindly runs the installer.
+    assert "wsl --status" in content
+    assert "if installed:" in content.lower() or "if Step 0.1 reported missing" in content
+    # Apt prereqs are also verified before install (Step 0.3 → 0.4).
+    assert "command -v" in content
+    assert "for cmd in jq ssh curl openssl" in content
+
+
+def test_non_windows_platforms_omit_phase0(tmp_path):
+    """auto / mac / linux must NOT emit the Windows preflight."""
+    for plat in ("auto", "mac", "linux"):
+        kit_path = tmp_path / f"alice-onboard-{plat}.md"
+        write_onboarding_kit(
+            path=kit_path, platform=plat, **COMMON_KWARGS
+        )
+        content = kit_path.read_text()
+        assert "Phase 0 — Windows preflight" not in content, (
+            f"platform={plat!r} should not emit Phase 0"
+        )
+
+
+def test_default_platform_is_auto(tmp_path):
+    """Omitting the platform kwarg defaults to 'auto' — same shape as
+    explicit 'auto'."""
+    kit_default = tmp_path / "default.md"
+    kit_auto = tmp_path / "auto.md"
+    write_onboarding_kit(path=kit_default, **COMMON_KWARGS)
+    write_onboarding_kit(path=kit_auto, platform="auto", **COMMON_KWARGS)
+    assert kit_default.read_text() == kit_auto.read_text()


### PR DESCRIPTION
## Summary

Adds a `platform={auto|mac|linux|windows}` parameter to the onboarding kit generator. When `platform=windows`, the kit prepends a **Phase 0 (Windows preflight)** that walks the dev's AI agent through verify-before-install for each Linux-shell prereq, then switches the agent session to WSL Ubuntu so phases 1-8 run unchanged.

## Verify-before-install pattern (per Patrick's directive)

The agent NEVER blindly installs. Each step:

| Step | Check | Install (only if missing) |
|---|---|---|
| 0.1 | `wsl --status` | — |
| 0.2 | (from 0.1 result) | `wsl --install -d Ubuntu` (PowerShell admin, requires reboot) |
| 0.3 | `command -v jq ssh curl openssl` (inside WSL) | — |
| 0.4 | (from 0.3 result) | `sudo apt install -y <only missing packages>` |
| 0.5 | dev moves AI agent into WSL Ubuntu shell | — |

After Phase 0, phases 1-8 (CLI install, OAuth, key generation, SSH rotation, MCP config, verify) run as the standard bash flow inside WSL. No bash command is duplicated PowerShell-side.

## Wiring

- `factory/onboarding_kit.py` — `VALID_PLATFORMS` tuple + `write_onboarding_kit(platform=...)` kwarg + new `_PHASE0_WINDOWS` template
- `factory/setup.py` — `setup_add_dev(platform=...)` + interactive prompt for dev's local OS
- 5 new tests cover the shape:
  - `VALID_PLATFORMS` set
  - Invalid platform raises
  - `platform='windows'` emits Phase 0
  - `platform in {auto, mac, linux}` omits Phase 0
  - Default (no platform kwarg) matches `platform='auto'`

## Backward compat

`platform='auto'` is the default — no Phase 0 is prepended for installs that haven't opted in. Pre-PR behavior preserved bit-for-bit.

## Test plan

- [x] All 35 onboarding kit tests pass (30 prior + 5 new)
- [x] All 15 onboarding email tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)