### PR TITLE
fix(onboarding): use pipe form in Phase 5, not process substitution

### DIFF
--- a/factory/onboarding_kit.py
+++ b/factory/onboarding_kit.py
@@ -335,12 +335,12 @@ persists both, and self-deletes the bootstrap key entry.
 
 PUBKEY=$(cat ~/.ssh/id_ed25519_devbrain.pub)
 
-ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
-    {ssh_port_flag} \\
-    -o StrictHostKeyChecking=accept-new \\
-    -o UserKnownHostsFile=~/.ssh/known_hosts \\
-    lhtdev@{ssh_host} \\
-    < <(jq -n --arg p "$PUBKEY" --arg t "$OAUTH_TOKEN" '{{pubkey: $p, oauth_token: $t}}')
+jq -n --arg p "$PUBKEY" --arg t "$OAUTH_TOKEN" '{{pubkey: $p, oauth_token: $t}}' \\
+  | ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
+        {ssh_port_flag} \\
+        -o StrictHostKeyChecking=accept-new \\
+        -o UserKnownHostsFile=~/.ssh/known_hosts \\
+        lhtdev@{ssh_host}
 
 # Expected output: {{"status":"ok","dev_id":"{dev_id}","invite_id":"..."}}
 ```
@@ -365,12 +365,12 @@ token format, persists both, and self-deletes the bootstrap key entry.
 
 PUBKEY=$(cat ~/.ssh/id_ed25519_devbrain.pub)
 
-ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
-    {ssh_port_flag} \\
-    -o StrictHostKeyChecking=accept-new \\
-    -o UserKnownHostsFile=~/.ssh/known_hosts \\
-    lhtdev@{ssh_host} \\
-    < <(jq -n --arg p "$PUBKEY" --argjson a "$CODEX_AUTH_JSON" '{{pubkey: $p, codex_auth_json: $a}}')
+jq -n --arg p "$PUBKEY" --argjson a "$CODEX_AUTH_JSON" '{{pubkey: $p, codex_auth_json: $a}}' \\
+  | ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
+        {ssh_port_flag} \\
+        -o StrictHostKeyChecking=accept-new \\
+        -o UserKnownHostsFile=~/.ssh/known_hosts \\
+        lhtdev@{ssh_host}
 
 # Expected output: {{"status":"ok","dev_id":"{dev_id}","invite_id":"..."}}
 ```
@@ -396,12 +396,12 @@ bootstrap key entry.
 
 PUBKEY=$(cat ~/.ssh/id_ed25519_devbrain.pub)
 
-ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
-    {ssh_port_flag} \\
-    -o StrictHostKeyChecking=accept-new \\
-    -o UserKnownHostsFile=~/.ssh/known_hosts \\
-    lhtdev@{ssh_host} \\
-    < <(jq -n --arg p "$PUBKEY" --arg k "$GEMINI_API_KEY" '{{pubkey: $p, gemini_api_key: $k}}')
+jq -n --arg p "$PUBKEY" --arg k "$GEMINI_API_KEY" '{{pubkey: $p, gemini_api_key: $k}}' \\
+  | ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
+        {ssh_port_flag} \\
+        -o StrictHostKeyChecking=accept-new \\
+        -o UserKnownHostsFile=~/.ssh/known_hosts \\
+        lhtdev@{ssh_host}
 
 # Expected output: {{"status":"ok","dev_id":"{dev_id}","invite_id":"..."}}
 ```
@@ -531,7 +531,7 @@ _PHASE0_WINDOWS = """\
 ## Phase 0 — Windows preflight (WSL2 + Ubuntu + apt prereqs)
 
 Phases 1-8 of this kit assume a Linux-shaped shell (bash, ssh, jq,
-process substitution, `~/.ssh/`). On Windows the cleanest path is
+`~/.ssh/`). On Windows the cleanest path is
 **WSL2 + Ubuntu** — the rest of the kit then runs unchanged inside
 the WSL shell.
 


### PR DESCRIPTION
## Summary
- Multi-CLI kit's Phase 5 used `< <(jq -n ... )` process substitution to feed JSON to the rotation handler over SSH; on Windows hosts where the agent invokes the block from cmd via `bash -c "..."` (or any non-true-bash context), the redirection silently produced empty stdin, which the server logged as `reason=empty_body` with no DB writes.
- Replace process substitution with a regular `jq -n ... | ssh ...` pipe across all three CLI variants (Claude / Codex / Gemini). Pipes are portable across cmd, Git Bash, WSL, and native sh/bash.
- Drop the now-stale "process substitution" mention from the Windows-preflight assumption note in the kit module.

## Context
Surfaced when onboarding `mike_courtney` on Windows + Git Bash. Two consecutive Phase 5 attempts produced `empty_body` in `/Users/lhtdev/devbrain/logs/onboard.log` with the rotation script exiting at line 70 (the empty-body guard) before touching any credential code path. Mike's CLI fabricated a plausible bash-trace post-hoc; the actual server logs are the ground truth. Fix has been hot-deployed on Mac Studio and `mike_courtney`'s kit reissued (new invitation `5c15a315`, fresh bootstrap key, old `b59cc8c8` revoked, two old Mike entries dropped from `authorized_keys`).

## Test plan
- [x] `pytest factory/tests/test_onboarding_kit.py` — 35/35 pass (no test changes needed; existing assertions are content-shape, not literal-form)
- [x] Render a sample claude kit: `< <(` absent, `jq -n ... | ssh` present
- [x] Reissued `mike_courtney`'s kit through the patched template — verified end-state in DB + `authorized_keys`
- [ ] Mike runs Phase 5 against the new kit — pending his retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)