### PR TITLE
feat(onboarding): server-side auth + minimal kit + PowerShell-native

### DIFF
--- a/factory/ai_clis/gemini.py
+++ b/factory/ai_clis/gemini.py
@@ -4,24 +4,21 @@ Gemini, like Claude, has no documented config-dir env var. We swap HOME
 for the spawned subprocess to redirect `~/.gemini/` to the per-dev
 profile. The swap is constrained to the single subprocess invocation.
 
-Auth strategies:
-1. **API key (preferred for headless / SSH sessions).** If the dev has
-   set `dev.gemini_api_key` (carried on the Dev model or supplied via
-   env at registration), the adapter sets `GEMINI_API_KEY` on the
-   spawned env and skips OAuth entirely. No `~/.gemini/` interaction
-   needed.
-2. **OAuth via Google login.** Default flow when no API key is
-   configured. Runs `gemini` (which prompts auth method choice) under
-   the swapped HOME. OAuth callback specifics were not exhaustively
-   probed; if the flow proves to use a localhost port, the dev should
-   set an API key instead (preferred) or coordinate a tunnel manually.
+Auth: an API key from https://aistudio.google.com/app/apikey. The key
+is stashed at `<profile>/.devbrain/env` as `GEMINI_API_KEY=...` (mode
+600). cli_executor sources this file before each gemini spawn.
+
+`devbrain login --cli gemini` prompts the dev interactively (the SSH
+session has a TTY) for the key. OAuth-via-browser is not supported
+under SSH (the localhost callback path doesn't reach the dev's
+machine) — API key is the only headless-friendly option.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import subprocess
+import sys
 from pathlib import Path
 
 from ai_clis.auth_helpers import git_author_env
@@ -29,15 +26,71 @@ from ai_clis.base import AICliAdapter, LoginResult, SpawnArgs
 
 logger = logging.getLogger(__name__)
 
+_GEMINI_ENV_REL = Path(".devbrain") / "env"
+_GEMINI_API_KEY_PREFIX = "AIza"
+
 
 def _dev_api_key(dev) -> str | None:
-    """Return the dev's gemini API key if set, else None."""
+    """Return the dev's gemini API key if set on the dev record, else None."""
     return getattr(dev, "gemini_api_key", None) or None
+
+
+def _read_gemini_key_from_env_file(profile_dir: Path) -> str | None:
+    """Read GEMINI_API_KEY=... from <profile>/.devbrain/env if present."""
+    env_file = profile_dir / _GEMINI_ENV_REL
+    if not env_file.exists():
+        return None
+    for line in env_file.read_text().splitlines():
+        if line.startswith("GEMINI_API_KEY="):
+            return line.split("=", 1)[1].strip()
+    return None
+
+
+def _stash_gemini_key(profile_dir: Path, api_key: str) -> None:
+    """Write GEMINI_API_KEY=<key> to <profile>/.devbrain/env (mode 600).
+
+    Preserves any other KEY=VALUE lines already in the file; replaces
+    any existing GEMINI_API_KEY line.
+    """
+    env_dir = profile_dir / ".devbrain"
+    env_dir.mkdir(parents=True, exist_ok=True)
+    env_file = env_dir / "env"
+    existing = env_file.read_text() if env_file.exists() else ""
+    lines = [
+        ln for ln in existing.splitlines()
+        if not ln.startswith("GEMINI_API_KEY=")
+    ]
+    lines.append(f"GEMINI_API_KEY={api_key.strip()}")
+    env_file.write_text("\n".join(lines) + "\n")
+    env_file.chmod(0o600)
+
+
+def _prompt_for_api_key(prompt_in=None, prompt_out=None) -> str:
+    """Prompt the dev interactively for their Gemini API key.
+
+    Reads from the controlling tty so `devbrain login` over SSH works:
+    the dev's local agent gets the prompt streamed through the SSH
+    pipe, the dev pastes the key, the adapter receives it on stdin.
+
+    prompt_in / prompt_out are injectable for tests; default to stdin / stderr.
+    """
+    if prompt_in is None:
+        prompt_in = sys.stdin
+    if prompt_out is None:
+        prompt_out = sys.stderr
+    prompt_out.write(
+        "\nGemini API key required.\n"
+        "Get one from https://aistudio.google.com/app/apikey "
+        "(create one if you don't already have it), then paste it below.\n"
+        "API key (starts with AIza): "
+    )
+    prompt_out.flush()
+    return prompt_in.readline().strip()
 
 
 class GeminiAdapter(AICliAdapter):
     name = "gemini"
-    oauth_callback_ports = []  # OAuth specifics unverified; API key path bypasses entirely
+    oauth_callback_ports = []  # API key flow has no callback
 
     def spawn_args(self, dev, profile_dir: Path) -> SpawnArgs:
         gitconfig = str(profile_dir / ".gitconfig")
@@ -46,7 +99,7 @@ class GeminiAdapter(AICliAdapter):
             "GIT_CONFIG_GLOBAL": gitconfig,
             **git_author_env(dev),
         }
-        api_key = _dev_api_key(dev)
+        api_key = _dev_api_key(dev) or _read_gemini_key_from_env_file(profile_dir)
         if api_key:
             env["GEMINI_API_KEY"] = api_key
         return SpawnArgs(env=env, argv_prefix=["gemini"])
@@ -55,50 +108,37 @@ class GeminiAdapter(AICliAdapter):
         profile_dir.mkdir(parents=True, exist_ok=True)
         (profile_dir / ".gemini").mkdir(exist_ok=True)
 
-        api_key = _dev_api_key(dev)
-        if api_key:
+        # Already-set key on the dev record: nothing to prompt for.
+        if _dev_api_key(dev):
             return LoginResult(
                 success=True,
-                hint="Using GEMINI_API_KEY from dev record; OAuth flow skipped.",
+                hint="Using GEMINI_API_KEY from dev record; no prompt needed.",
             )
 
-        env = {**os.environ, "HOME": str(profile_dir)}
-        try:
-            result = subprocess.run(
-                ["gemini"],
-                env=env,
-                check=False,
-            )
-        except FileNotFoundError:
+        api_key = _prompt_for_api_key()
+        if not api_key:
             return LoginResult(
                 success=False,
-                error="gemini CLI not found on PATH",
-                hint="Install Gemini CLI: https://github.com/google-gemini/gemini-cli",
+                error="no API key provided",
+                hint="Re-run `devbrain login --dev <id> --cli gemini` and paste your key when prompted.",
             )
-
-        if result.returncode != 0:
+        if not api_key.startswith(_GEMINI_API_KEY_PREFIX):
             return LoginResult(
                 success=False,
-                error=f"gemini exited with code {result.returncode}",
-                hint="If OAuth flow needs a localhost callback, set GEMINI_API_KEY instead via the dev record.",
+                error=f"key doesn't look like a Gemini API key (expected prefix {_GEMINI_API_KEY_PREFIX!r})",
+                hint="Get a fresh key at https://aistudio.google.com/app/apikey and try again.",
             )
 
-        if not self.is_logged_in(dev, profile_dir):
-            return LoginResult(
-                success=False,
-                error="gemini exited but ~/.gemini/google_accounts.json not found",
-                hint=f"Check {profile_dir}/.gemini/google_accounts.json or set GEMINI_API_KEY.",
-            )
-
+        _stash_gemini_key(profile_dir, api_key)
         return LoginResult(success=True)
 
     def is_logged_in(self, dev, profile_dir: Path) -> bool:
         if _dev_api_key(dev):
             return True
-        return (profile_dir / ".gemini" / "google_accounts.json").exists()
+        return _read_gemini_key_from_env_file(profile_dir) is not None
 
     def required_dotfiles(self) -> list[str]:
-        return [".gemini/", ".gitconfig"]
+        return [str(_GEMINI_ENV_REL), ".gemini/", ".gitconfig"]
 
 
 default_register = True

--- a/factory/onboard_reconciler.py
+++ b/factory/onboard_reconciler.py
@@ -140,18 +140,24 @@ def _try_activate(
             )
             return False
 
-        # ─── 3. Provision profile dir + 4. stash CLI credential ──────
+        # ─── 3. Provision profile dir + (optionally) 4. stash CLI credential ──
+        # Under the server-side-auth flow, oauth_token is NULL at activation
+        # time — the dev's `devbrain login` writes the credential directly
+        # into the profile dir afterward. Under the legacy in-transit-token
+        # flow (kept here for backward compat), oauth_token may already be
+        # set, in which case we stash it now.
         profile_dir = _resolve_profile_dir(dev_id)
         profile_dir.mkdir(parents=True, exist_ok=True)
-        try:
-            _stash_credential(profile_dir, oauth_token, cli=cli)
-        except OSError as e:
-            logger.error(
-                "invitation %s could not stash credential (cli=%s): %s — rolling back authorized_keys",
-                str(id_)[:8], cli, e,
-            )
-            _remove_marker_from_authorized_keys(ak_path, marker)
-            return False
+        if oauth_token:
+            try:
+                _stash_credential(profile_dir, oauth_token, cli=cli)
+            except OSError as e:
+                logger.error(
+                    "invitation %s could not stash credential (cli=%s): %s — rolling back authorized_keys",
+                    str(id_)[:8], cli, e,
+                )
+                _remove_marker_from_authorized_keys(ak_path, marker)
+                return False
         # Provision .gitconfig if absent (best-effort; the dev's full
         # name + email live on the dev row).
         _ensure_gitconfig(profile_dir, db, dev_id)
@@ -187,14 +193,21 @@ def _try_activate(
 
     # ─── 7. Notify admin ──────────────────────────────────────────
     cli_label = cli if cli else "claude"
-    _notify_admin(
-        db, dev_id, status="activated",
-        detail=(
+    if oauth_token:
+        detail = (
             f"Dev '{dev_id}' is now live (cli={cli_label}). Pubkey added to "
             f"authorized_keys, credential stashed at per-profile path. "
             f"Factory is ready to spawn {cli_label} on their behalf."
-        ),
-    )
+        )
+    else:
+        detail = (
+            f"Dev '{dev_id}' SSH access is live (cli={cli_label}). Pubkey "
+            f"added to authorized_keys; profile dir provisioned. The dev "
+            f"still needs to run `devbrain login --cli {cli_label}` "
+            f"server-side to issue their auth token before factory work "
+            f"can spawn on their behalf."
+        )
+    _notify_admin(db, dev_id, status="activated", detail=detail)
 
     logger.info("Activated invitation for dev=%s", dev_id)
     return True

--- a/factory/onboard_rotate.sh
+++ b/factory/onboard_rotate.sh
@@ -8,43 +8,30 @@
 #
 # Lifecycle: a new dev's invitation kit ships a temp ed25519 private
 # key + invite token. Their AI agent SSHes in using the temp key,
-# sending CLI-specific JSON on stdin (see below). We:
+# sending pubkey-only JSON on stdin. We:
 #
 #   1. Read the JSON.
 #   2. Validate pubkey shape (defense-in-depth — Python helper does
 #      the canonical check).
-#   3. Look up the invitation to determine which CLI was used (cli
-#      column, migration 031).
-#   4. Validate the CLI credential against its upstream API:
-#        claude: POST to api.anthropic.com — 200/400 = valid, 401 = reject
-#        codex:  same Anthropic API (codex auth.json contains an
-#                Anthropic-format OAuth token under "accessToken")
-#        gemini: GET to generativelanguage.googleapis.com with the API key
-#   5. Persist via the same DB path the webhook uses so the reconciler
-#      picks it up identically.
-#   6. Self-delete this temp key's authorized_keys entry by marker.
-#   7. Audit-log the rotation.
-#   8. Return JSON to the agent: {"status":"ok"}.
+#   3. Look up the invitation's cli column (set at issuance time;
+#      informational here — not used to validate any credential).
+#   4. Persist the pubkey to the invitation row.
+#   5. Self-delete this temp key's authorized_keys entry by marker.
+#   6. Audit-log the rotation.
+#   7. Return JSON to the agent: {"status":"ok"}.
 #
-# ─── Stdin JSON shapes by CLI ─────────────────────────────────────────────────
+# Subscription auth (oauth-token / codex auth.json / gemini api-key)
+# is NOT collected here. After the reconciler appends the pubkey to
+# authorized_keys, the dev SSHes in with their permanent key and runs
+# `devbrain login` server-side. That command runs the appropriate
+# per-CLI auth flow inside the dev's profile dir; the credential
+# stays on the Mac Studio and never transits the dev's machine.
 #
-#   claude:  {"pubkey":"...", "oauth_token":"sk-ant-oat01-..."}
-#   codex:   {"pubkey":"...", "codex_auth_json":{...}}
-#             (the full ~/.codex/auth.json object; accessToken pulled server-side)
-#   gemini:  {"pubkey":"...", "gemini_api_key":"AIza..."}
-#
-# ─── Two-factor security ──────────────────────────────────────────────────────
-#
-# The temp SSH key gets the agent INTO this script. The CLI credential
-# (which the dev generated on their own machine/account) is the SECOND
-# factor. An attacker who intercepts the email gets the temp SSH key +
-# invite token, but can't forge a valid CLI credential — the respective
-# platform only issues those to authenticated accounts.
+# Stdin JSON shape:  {"pubkey":"ssh-ed25519 AAAA... comment"}
 #
 # Failure modes (all return non-zero exit + JSON error to the agent):
 #   - Malformed JSON
 #   - Pubkey shape rejected
-#   - CLI credential rejected by upstream API
 #   - DB write failure
 #   - File permission failure on authorized_keys edit
 
@@ -117,118 +104,15 @@ with db._conn() as conn, conn.cursor() as cur:
 " 2>/dev/null || echo "claude"
 )"
 
-# ─── Extract + validate CLI credential ────────────────────────────────────────
+# ─── Validate CLI is recognized ────────────────────────────────────────────────
+#
+# The CLI was set at invitation issuance time. We don't collect any
+# subscription credential at this stage — the dev runs `devbrain login`
+# server-side after their pubkey lands in authorized_keys.
 
 case "$CLI_NAME" in
-
-  claude)
-    OAUTH_TOKEN="$(read_field oauth_token)" || {
-      printf '{"status":"error","error":"missing_or_invalid_oauth_token"}\n' >&3
-      echo "$(date -u +%FT%TZ) rotate-fail dev=${DEV_ID} reason=missing_oauth_token from=${SSH_CLIENT:-unknown}" >> "$LOG_FILE"
-      exit 1
-    }
-
-    # Validate OAuth token against Anthropic API (200 or 400 = valid auth;
-    # 401/403 = bad token).
-    VALIDATION_HTTP=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
-      -H "Authorization: Bearer ${OAUTH_TOKEN}" \
-      -H "anthropic-version: 2023-06-01" \
-      -H "Content-Type: application/json" \
-      -X POST https://api.anthropic.com/v1/messages \
-      -d '{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"x"}]}' || echo 000)
-
-    case "$VALIDATION_HTTP" in
-      200|400) ;;
-      401|403)
-        printf '{"status":"error","error":"oauth_token_rejected_by_anthropic","http":%s}\n' "$VALIDATION_HTTP" >&3
-        echo "$(date -u +%FT%TZ) rotate-fail dev=${DEV_ID} reason=oauth_${VALIDATION_HTTP} from=${SSH_CLIENT:-unknown}" >> "$LOG_FILE"
-        exit 1
-        ;;
-      *)
-        printf '{"status":"error","error":"oauth_validation_unreachable","http":%s}\n' "$VALIDATION_HTTP" >&3
-        echo "$(date -u +%FT%TZ) rotate-fail dev=${DEV_ID} reason=oauth_${VALIDATION_HTTP} from=${SSH_CLIENT:-unknown}" >> "$LOG_FILE"
-        exit 1
-        ;;
-    esac
+  claude|codex|gemini)
     ;;
-
-  codex)
-    CODEX_AUTH_JSON="$(read_field codex_auth_json)" || {
-      printf '{"status":"error","error":"missing_or_invalid_codex_auth_json"}\n' >&3
-      echo "$(date -u +%FT%TZ) rotate-fail dev=${DEV_ID} reason=missing_codex_auth_json from=${SSH_CLIENT:-unknown}" >> "$LOG_FILE"
-      exit 1
-    }
-
-    # Extract the accessToken from auth.json — codex stores an Anthropic
-    # OAuth-format token there. Validate against api.anthropic.com same as
-    # the claude path. If the auth.json uses a different token key in
-    # future codex versions, this will surface as a 401 (safe failure).
-    CODEX_ACCESS_TOKEN="$(python3 -c "
-import json, sys
-try:
-    d = json.loads(sys.stdin.read())
-    # Support both 'accessToken' and 'access_token' key names
-    tok = d.get('accessToken') or d.get('access_token') or ''
-    print(tok)
-except Exception:
-    print('')
-" <<< "$CODEX_AUTH_JSON")"
-
-    if [ -z "$CODEX_ACCESS_TOKEN" ]; then
-      printf '{"status":"error","error":"codex_auth_json_missing_access_token"}\n' >&3
-      echo "$(date -u +%FT%TZ) rotate-fail dev=${DEV_ID} reason=codex_no_access_token from=${SSH_CLIENT:-unknown}" >> "$LOG_FILE"
-      exit 1
-    fi
-
-    VALIDATION_HTTP=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
-      -H "Authorization: Bearer ${CODEX_ACCESS_TOKEN}" \
-      -H "anthropic-version: 2023-06-01" \
-      -H "Content-Type: application/json" \
-      -X POST https://api.anthropic.com/v1/messages \
-      -d '{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"x"}]}' || echo 000)
-
-    case "$VALIDATION_HTTP" in
-      200|400) ;;
-      401|403)
-        printf '{"status":"error","error":"codex_auth_json_invalid","http":%s}\n' "$VALIDATION_HTTP" >&3
-        echo "$(date -u +%FT%TZ) rotate-fail dev=${DEV_ID} reason=codex_auth_${VALIDATION_HTTP} from=${SSH_CLIENT:-unknown}" >> "$LOG_FILE"
-        exit 1
-        ;;
-      *)
-        printf '{"status":"error","error":"codex_validation_unreachable","http":%s}\n' "$VALIDATION_HTTP" >&3
-        echo "$(date -u +%FT%TZ) rotate-fail dev=${DEV_ID} reason=codex_auth_${VALIDATION_HTTP} from=${SSH_CLIENT:-unknown}" >> "$LOG_FILE"
-        exit 1
-        ;;
-    esac
-    ;;
-
-  gemini)
-    GEMINI_API_KEY="$(read_field gemini_api_key)" || {
-      printf '{"status":"error","error":"missing_or_invalid_gemini_api_key"}\n' >&3
-      echo "$(date -u +%FT%TZ) rotate-fail dev=${DEV_ID} reason=missing_gemini_api_key from=${SSH_CLIENT:-unknown}" >> "$LOG_FILE"
-      exit 1
-    }
-
-    # Validate the Gemini API key by hitting the models list endpoint.
-    # 200 = valid key; 400/403 = bad key.
-    VALIDATION_HTTP=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
-      "https://generativelanguage.googleapis.com/v1beta/models?key=${GEMINI_API_KEY}" || echo 000)
-
-    case "$VALIDATION_HTTP" in
-      200) ;;
-      400|401|403)
-        printf '{"status":"error","error":"gemini_api_key_rejected","http":%s}\n' "$VALIDATION_HTTP" >&3
-        echo "$(date -u +%FT%TZ) rotate-fail dev=${DEV_ID} reason=gemini_key_${VALIDATION_HTTP} from=${SSH_CLIENT:-unknown}" >> "$LOG_FILE"
-        exit 1
-        ;;
-      *)
-        printf '{"status":"error","error":"gemini_validation_unreachable","http":%s}\n' "$VALIDATION_HTTP" >&3
-        echo "$(date -u +%FT%TZ) rotate-fail dev=${DEV_ID} reason=gemini_key_${VALIDATION_HTTP} from=${SSH_CLIENT:-unknown}" >> "$LOG_FILE"
-        exit 1
-        ;;
-    esac
-    ;;
-
   *)
     printf '{"status":"error","error":"unknown_cli","cli":"%s"}\n' "$CLI_NAME" >&3
     echo "$(date -u +%FT%TZ) rotate-fail dev=${DEV_ID} reason=unknown_cli=${CLI_NAME} from=${SSH_CLIENT:-unknown}" >> "$LOG_FILE"
@@ -236,34 +120,12 @@ except Exception:
     ;;
 esac
 
-# ─── Persist to invitations DB via Python helper ───────────────────────────
+# ─── Persist pubkey to invitations DB via Python helper ──────────────────────
 
-# Helper handles: pubkey shape validation, credential persistence per CLI,
-# and the proper state-machine guards. We pass invite_id_short as argv
-# (non-secret) and all credentials as JSON on stdin (avoids them appearing
-# in `ps`).
 HELPER_INPUT="$(python3 -c "
 import json, sys
-cli = '${CLI_NAME}'
-pubkey = sys.argv[1]
-data = {'pubkey': pubkey, 'cli': cli}
-if cli == 'claude':
-    data['oauth_token'] = sys.argv[2]
-elif cli == 'codex':
-    data['codex_auth_json'] = json.loads(sys.argv[2])
-elif cli == 'gemini':
-    data['gemini_api_key'] = sys.argv[2]
-print(json.dumps(data))
-" \
-  "$PUBKEY" \
-  "$(
-    case "$CLI_NAME" in
-      claude) echo "$OAUTH_TOKEN" ;;
-      codex)  echo "$CODEX_AUTH_JSON" ;;
-      gemini) echo "$GEMINI_API_KEY" ;;
-    esac
-  )"
-)"
+print(json.dumps({'pubkey': sys.argv[1], 'cli': '${CLI_NAME}'}))
+" "$PUBKEY")"
 
 ROTATE_RESULT="$(
   cd "${DEVBRAIN_HOME}/factory"

--- a/factory/onboard_rotate_helper.py
+++ b/factory/onboard_rotate_helper.py
@@ -1,28 +1,16 @@
-"""Helper invoked by onboard_rotate.sh — persist rotation to DB.
+"""Helper invoked by onboard_rotate.sh — persist pubkey rotation to DB.
 
 Receives JSON on stdin:
-  claude: {"pubkey": "...", "cli": "claude", "oauth_token": "sk-ant-..."}
-  codex:  {"pubkey": "...", "cli": "codex",  "codex_auth_json": {...}}
-  gemini: {"pubkey": "...", "cli": "gemini", "gemini_api_key": "AIza..."}
+  {"pubkey": "ssh-ed25519 AAAA...", "cli": "claude"|"codex"|"gemini"}
 
 Receives invite_id_short via argv.
 
-Looks up the invitation row by id prefix, updates the appropriate
-credential column and pubkey, then flips status from pending → ready
-so the reconciler picks it up.
-
-The reconciler (onboard_reconciler.py) reads the cli column and routes
-the credential to the right per-profile stash path:
-  claude: <profile>/.claude/oauth-token
-  codex:  <profile>/.codex/auth.json
-  gemini: <profile>/.devbrain/env (GEMINI_API_KEY=...)
-
-Why not reuse `submit_pubkey` / `submit_oauth_token` from
-invitations.py: those functions key on `token_hash` because the
-webhook only has the raw token. Here we already have invite_id_short
-(authorized_keys baked it into the command="..." directive), so a
-direct UPDATE is more precise and avoids needing to round-trip the
-raw token through the rotate.sh script.
+Looks up the invitation row by id prefix, sets pubkey + pubkey_received_at,
+flips status pending → ready so the reconciler picks it up. The CLI's
+auth credential (oauth-token / codex auth.json / gemini api-key) is
+NOT collected here — the dev runs `devbrain login` server-side after
+the reconciler has appended their pubkey to authorized_keys, and the
+adapter writes the credential directly into the dev's profile dir.
 """
 
 from __future__ import annotations
@@ -33,13 +21,15 @@ import os
 import sys
 
 
+_VALID_CLIS = ("claude", "codex", "gemini")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--invite-id-short", required=True,
                         help="First 8 chars of the invitation UUID")
     args = parser.parse_args()
 
-    # Read JSON from stdin
     try:
         body = json.load(sys.stdin)
     except json.JSONDecodeError as e:
@@ -53,77 +43,26 @@ def main() -> int:
         print("missing_pubkey", file=sys.stderr)
         return 2
 
-    if cli not in ("claude", "codex", "gemini"):
+    if cli not in _VALID_CLIS:
         print(f"unknown_cli: {cli}", file=sys.stderr)
         return 2
 
-    # Validate pubkey shape using the reconciler's same logic
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
     from onboard_reconciler import _is_safe_pubkey_line
     if not _is_safe_pubkey_line(pubkey):
         print("pubkey_unsafe", file=sys.stderr)
         return 2
 
-    # ─── Extract + validate CLI credential ────────────────────────────────
-
-    if cli == "claude":
-        oauth_token = body.get("oauth_token", "").strip()
-        if not oauth_token:
-            print("missing_oauth_token", file=sys.stderr)
-            return 2
-        # Belt-and-suspenders format check (Anthropic API validation
-        # already happened in rotate.sh).
-        if not (oauth_token.startswith("sk-ant-oat01-") or oauth_token.startswith("sk-ant-")):
-            print("oauth_token_format_invalid", file=sys.stderr)
-            return 2
-        # Stored in oauth_token column; reconciler reads it and stashes at
-        # <profile>/.claude/oauth-token
-        credential_col = "oauth_token"
-        credential_val = oauth_token
-
-    elif cli == "codex":
-        codex_auth = body.get("codex_auth_json")
-        if not codex_auth:
-            print("missing_codex_auth_json", file=sys.stderr)
-            return 2
-        if isinstance(codex_auth, dict):
-            credential_val = json.dumps(codex_auth)
-        else:
-            credential_val = str(codex_auth)
-        # Stored in oauth_token column (overloaded for now — all CLIs get
-        # one credential slot; the cli column tells the reconciler what
-        # it contains). Reconciler writes it to <profile>/.codex/auth.json
-        credential_col = "oauth_token"
-
-    elif cli == "gemini":
-        gemini_key = body.get("gemini_api_key", "").strip()
-        if not gemini_key:
-            print("missing_gemini_api_key", file=sys.stderr)
-            return 2
-        if not gemini_key.startswith("AIza"):
-            print("gemini_api_key_format_invalid", file=sys.stderr)
-            return 2
-        # Stored in oauth_token column; reconciler writes to
-        # <profile>/.devbrain/env as GEMINI_API_KEY=...
-        credential_col = "oauth_token"
-        credential_val = gemini_key
-
     from state_machine import FactoryDB
     from config import DATABASE_URL
     db = FactoryDB(DATABASE_URL)
 
-    # Direct DB update keyed by invite-id prefix. We require the row
-    # to be in pending OR ready state (idempotent retry: if rotate.sh
-    # ran once, succeeded the DB write, but failed the authorized_keys
-    # cleanup, a retry should still work).
     with db._conn() as conn, conn.cursor() as cur:
         cur.execute(
-            f"""
+            """
             UPDATE devbrain.invitations
             SET pubkey = %s,
                 pubkey_received_at = COALESCE(pubkey_received_at, NOW()),
-                {credential_col} = %s,
-                oauth_token_received_at = COALESCE(oauth_token_received_at, NOW()),
                 status = CASE
                     WHEN status IN ('pending','ready') THEN 'ready'
                     ELSE status
@@ -133,7 +72,7 @@ def main() -> int:
               AND expires_at > NOW()
             RETURNING id, dev_id, status
             """,
-            (pubkey, credential_val, f"{args.invite_id_short}%"),
+            (pubkey, f"{args.invite_id_short}%"),
         )
         row = cur.fetchone()
         conn.commit()

--- a/factory/onboarding_email.py
+++ b/factory/onboarding_email.py
@@ -5,20 +5,16 @@ factory/notifications/channels/ so the credentials only have to be
 configured in one place (config/devbrain.yaml under
 notifications.channels.smtp or notifications.channels.gmail_dwd).
 
-Email body: a short welcome paragraph + 5-step summary + a pointer to
-the attached kit file. The full kit content is delivered as a .md
-attachment (not inlined). The attachment is ~3-15 KB — well within any
-provider's limits — and is trivially saved to disk for the dev to feed
-to their AI agent.
+Email body branches on `agent_app`:
+- specified (claude-desktop / codex-desktop / etc.): tailored "drop
+  the .md into [agent app]" instructions.
+- auto / unknown: lists supported agent apps with install pointers,
+  letting the dev pick.
 
-Why attachment (not inline):
-  - AI agent UIs (Claude Code, Codex, Gemini CLI) all accept file paths
-    on the command line; dragging/pasting a saved .md is the natural
-    onboarding path.
-  - Keeps the visible email body short and scan-friendly for the human.
-  - Avoids the body growing with future kit expansions (multi-CLI kits
-    can get long; the email subject+body stay constant).
-  - Re-send is trivial: the attachment is the same kit file on disk.
+The full kit content is always delivered as a .md attachment (not
+inlined). The attachment is ~10-15 KB — well within any provider's
+limits — and is trivially saved to disk for the dev to feed to their
+AI agent.
 """
 
 from __future__ import annotations
@@ -28,9 +24,71 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-# Email body template. Short by design — full content is in the attachment.
-# Patrick reviews + tweaks via the optional template-override path documented
-# below before the first real send.
+_CLI_DISPLAY_NAMES: dict[str, str] = {
+    "claude": "Claude Code",
+    "codex":  "Codex",
+    "gemini": "Gemini CLI",
+}
+
+_AGENT_APP_DISPLAY_NAMES: dict[str, str] = {
+    "auto":            "your AI agent",
+    "claude-desktop":  "Claude Desktop",
+    "codex-desktop":   "Codex Desktop",
+    "gemini-desktop":  "Gemini Desktop",
+    "claude-cli":      "Claude Code (CLI)",
+    "codex-cli":       "Codex (CLI)",
+    "gemini-cli":      "Gemini (CLI)",
+}
+
+# Per-agent-app: how to drop the kit into the agent
+_AGENT_APP_DROP_INSTRUCTIONS: dict[str, str] = {
+    "claude-desktop": (
+        "Open Claude Desktop, attach the {kit_filename} file to your "
+        "next message (paperclip icon), and tell Claude: \"Please run "
+        "this onboarding kit.\""
+    ),
+    "codex-desktop": (
+        "Open Codex Desktop, attach the {kit_filename} file to your "
+        "next message, and tell Codex: \"Please run this onboarding "
+        "kit.\""
+    ),
+    "gemini-desktop": (
+        "Open Gemini Desktop, attach the {kit_filename} file to your "
+        "next message, and tell Gemini: \"Please run this onboarding "
+        "kit.\""
+    ),
+    "claude-cli": (
+        "Open a terminal, run `claude`, and paste the contents of "
+        "{kit_filename} (or pass it as a path argument: "
+        "`claude < {kit_filename}`)."
+    ),
+    "codex-cli": (
+        "Open a terminal, run `codex`, and paste the contents of "
+        "{kit_filename}."
+    ),
+    "gemini-cli": (
+        "Open a terminal, run `gemini`, and paste the contents of "
+        "{kit_filename}."
+    ),
+}
+
+# Agent-app-agnostic preface for "auto" mode
+_AUTO_AGENT_APP_PREFACE = """\
+**If you don't have an AI agent app yet,** install one of the
+following (any of them can run this kit):
+
+- **Claude Desktop** — https://claude.com/download
+- **Codex Desktop** — https://chatgpt.com/download (includes Codex)
+- **Gemini Desktop** — https://gemini.google.com/app
+
+Once installed, drop the attached {kit_filename} into the app and
+tell the agent: \"Please run this onboarding kit.\"
+
+If you'd rather use a CLI: `claude`, `codex`, or `gemini` will all
+work the same way — just paste the kit's contents at the prompt.
+"""
+
+
 _EMAIL_TEMPLATE = """Welcome to BrightBot, {first_name}!
 
 You've been invited to join the BrightBot dev factory — Lighthouse
@@ -40,33 +98,23 @@ attributed to YOUR git identity.
 
 # How to onboard (~5 minutes)
 
-1. Save the attached file ({kit_filename}) to your laptop.
+{drop_instruction}
 
-2. Drop it into your AI agent ({cli_display_name}, or any agent you prefer).
-   The agent walks through every step, asking for your approval as it goes.
-   (Or run the steps manually — every command is shown in the kit.)
+The kit asks for your approval at each step. It generates an SSH
+keypair on your machine, delivers the public half to the Mac Studio,
+then SSHes you into your profile on the Mac Studio so you can sign
+into your {cli_display_name} subscription server-side. Your auth
+token is generated on the Mac Studio and **never leaves it** — only
+your SSH public key transits this email's chain.
 
-3. The agent generates an SSH keypair, installs {cli_display_name} locally,
-   and prompts you to authorize your credentials.
-
-4. DevBrain auto-activates your account. You'll get a confirmation.
-
-5. SSH into the Mac Studio (`ssh mac-studio`) and run
-   `factory dashboard` — you're in.
-
-The invite token in the kit is single-use and expires in 7 days. Treat
-the kit like a credential — don't broadcast it.
+The bootstrap key in the attached kit is single-use, locked to a
+single rotation script, and auto-expires in 3 days. Treat the kit
+like a credential — don't broadcast it.
 
 If anything breaks, reply to this email or ping {admin_contact}.
 
 — DevBrain (on behalf of {admin_name})
 """
-
-_CLI_DISPLAY_NAMES: dict[str, str] = {
-    "claude": "Claude Code",
-    "codex":  "Codex",
-    "gemini": "Gemini CLI",
-}
 
 
 def _pick_email_channel():
@@ -75,11 +123,6 @@ def _pick_email_channel():
     Preference order:
       1. gmail_dwd  (Google Workspace service account; no password)
       2. smtp       (plain SMTP / Gmail App Password / etc.)
-
-    Only one is expected to be enabled at a time — the setup wizard
-    disables the other when one is configured. But if both are
-    enabled, gmail_dwd wins because it's password-rotation-free and
-    audit-friendly.
     """
     import sys
     from pathlib import Path as _Path
@@ -116,6 +159,18 @@ def _pick_email_channel():
     return None
 
 
+def _build_drop_instruction(agent_app: str, kit_filename: str) -> str:
+    """Return the agent-app-specific 'drop the kit into your agent' block."""
+    if agent_app == "auto":
+        return _AUTO_AGENT_APP_PREFACE.format(kit_filename=kit_filename)
+    template = _AGENT_APP_DROP_INSTRUCTIONS.get(agent_app)
+    if template is None:
+        # Defensive fallback — shouldn't happen if the validator runs first
+        return _AUTO_AGENT_APP_PREFACE.format(kit_filename=kit_filename)
+    rendered = template.format(kit_filename=kit_filename)
+    return f"**To get started:** {rendered}"
+
+
 def send_onboarding_email(
     *,
     to_email: str,
@@ -125,20 +180,18 @@ def send_onboarding_email(
     admin_name: str = "your admin",
     admin_contact: str = "the admin who sent this email",
     cli: str = "claude",
+    agent_app: str = "auto",
 ) -> bool:
     """Send the onboarding kit to the dev as a .md email attachment.
 
-    The email body is a short welcome + 5-step summary. The full kit
-    content is delivered as an attachment named `<dev_id>-onboarding-kit.md`.
-
-    Picks the configured email channel (gmail_dwd preferred, smtp fallback).
-    Returns True on successful delivery, False otherwise. Failures are
-    logged and the kit file is left in place — the admin can re-send via
-    `devbrain send-invite --dev <id>` after fixing config.
-
     Args:
-        cli: AI CLI the dev was invited for. Used to personalise the email
-             body (e.g. "your Codex subscription"). Defaults to 'claude'.
+        cli: AI subscription the dev was invited for. Personalises
+             body wording.
+        agent_app: Which AI agent app the dev will use to run the
+                   kit. When 'auto', the email lists install
+                   pointers for each supported app and lets the dev
+                   pick. Otherwise, the email gives tailored
+                   drop-in instructions for that specific app.
     """
     channel = _pick_email_channel()
     if channel is None:
@@ -152,11 +205,12 @@ def send_onboarding_email(
     first_name = full_name.split()[0] if full_name else dev_id
     cli_display_name = _CLI_DISPLAY_NAMES.get(cli, cli)
     kit_filename = f"{dev_id}-onboarding-kit.md"
+    drop_instruction = _build_drop_instruction(agent_app, kit_filename)
 
     body = _EMAIL_TEMPLATE.format(
         first_name=first_name,
         cli_display_name=cli_display_name,
-        kit_filename=kit_filename,
+        drop_instruction=drop_instruction,
         admin_name=admin_name,
         admin_contact=admin_contact,
     )
@@ -164,10 +218,6 @@ def send_onboarding_email(
     title = f"Welcome to BrightBot — your DevBrain onboarding kit ({cli_display_name})"
 
     # Rename the kit file to the canonical attachment name if it differs.
-    # This avoids surprising filenames (e.g. "alice-onboard.md") when the
-    # attachment lands in the dev's inbox. We use a symlink-free rename
-    # approach: write a copy with the canonical name, send that, leave the
-    # original in place (the admin's reference copy).
     if kit_path.name != kit_filename:
         attachment_path = kit_path.parent / kit_filename
         attachment_path.write_bytes(kit_path.read_bytes())
@@ -185,8 +235,8 @@ def send_onboarding_email(
         logger.error("Email send failed via %s: %s", channel.name, result.error)
         return False
     logger.info(
-        "Onboarding email sent to %s for dev=%s (cli=%s) via %s; "
+        "Onboarding email sent to %s for dev=%s (cli=%s, agent_app=%s) via %s; "
         "kit attached as %s",
-        to_email, dev_id, cli, channel.name, kit_filename,
+        to_email, dev_id, cli, agent_app, channel.name, kit_filename,
     )
     return True

--- a/factory/onboarding_kit.py
+++ b/factory/onboarding_kit.py
@@ -1,65 +1,50 @@
-"""Onboarding kit Markdown generator.
+"""Onboarding kit Markdown generator (server-side-auth flow).
 
 Produces a `.md` file the admin sends to a new dev. The file is:
 
   1. Human-readable as plain documentation. The dev can follow it
      manually if they don't have an AI agent or don't want to use one.
 
-  2. Agent-executable. AI agents (Claude Code, Codex, etc.) parse the
-     structured headers + code blocks + `<!-- agent:* -->` directive
-     comments to walk through the steps autonomously, asking the dev
-     for approval at each network or credential boundary.
+  2. Agent-executable. AI agents (Claude Desktop, Codex Desktop, the
+     CLI variants) parse the structured headers + code blocks +
+     `<!-- agent:* -->` directive comments to walk through the steps
+     autonomously, asking the dev for approval at each network or
+     credential boundary.
 
 The kit's content is mostly static; what changes per-invitation is
-the YAML frontmatter (dev_id, invite token, expiry, cli) and the
-embedded TEMP SSH PRIVATE KEY that gives the dev's agent a one-shot
-rotation session into the Mac Studio.
+the YAML frontmatter (dev_id, invite token, expiry, cli, agent-app,
+SSH host fingerprint) and the embedded TEMP SSH PRIVATE KEY that
+gives the dev's agent a one-shot rotation session into the Mac Studio.
 
-Bootstrap flow:
-  1. Admin runs `devbrain setup add-dev`. DevBrain generates an
-     ephemeral ed25519 keypair, stages the public half in
-     ~lhtdev/.ssh/authorized_keys with strict options
-     (`restrict,command="onboard_rotate.sh ...",expiry-time="..."`),
-     and embeds the PRIVATE half into this kit.
-  2. Admin emails the kit to the dev.
-  3. Dev's agent reads the temp private key from the kit, writes it
-     to ~/.ssh/devbrain-bootstrap-<dev_id> (mode 600).
-  4. Agent SSHes into the Mac Studio with the temp key, sending CLI-
-     specific JSON on stdin (see Phase 5 for each CLI's payload shape).
-  5. The temp key's authorized_keys entry pins the SSH command to
-     onboard_rotate.sh (no shell, no other capabilities possible).
-     onboard_rotate.sh validates the credentials against the appropriate
-     upstream API, persists the key+credential to the invitations DB,
-     and self-deletes the temp authorized_keys entry.
-  6. Reconciler picks up the now-ready invitation, finishes
-     activation: appends the dev's PERMANENT pubkey to
-     authorized_keys, stashes the CLI credential at the per-profile
-     path for that CLI, populates per-profile gitconfig, fires admin
-     notification.
-  7. Agent deletes the temp private key file from the dev's laptop.
+Architecture (server-side-auth flow, post 2026-05-07 redesign — see
+docs/plans/2026-05-07-onboarding-server-side-auth-design.md):
 
-CLI-specific auth shapes:
+  Phase 0  Trust banner — issuer, intent, host fingerprint, ask user
+           to confirm before proceeding.
+  Phase 1  Environment check + dep install. Bash for macOS/Linux,
+           PowerShell for Windows (built-in OpenSSH; no WSL/Git Bash).
+  Phase 2  Generate permanent SSH keypair locally.
+  Phase 3  Stage bootstrap (one-shot, expiring) SSH key locally.
+  Phase 4  Rotate permanent pubkey to Mac Studio. Payload is pubkey-
+           only — no subscription credential transits the dev's box.
+  Phase 5  SSH into the dev's profile on Mac Studio and run
+           `devbrain login`. The wrapper invokes the appropriate
+           per-CLI auth flow server-side; the auth token is generated
+           and stashed inside the profile dir on the Mac Studio. It
+           NEVER returns to the dev's machine.
+  Phase 6  MCP wire-up + SSH verify.
 
-  claude:
-    Install:  brew install --cask claude
-    Login:    claude /login  (browser OAuth)
-    Token:    claude setup-token  → sk-ant-oat01-...
-    Rotation: JSON {"pubkey": "...", "oauth_token": "sk-ant-oat01-..."}
-    Storage:  <profile>/.claude/oauth-token
+Three issuance axes — admin specifies what's known at `devbrain
+add-dev` time:
 
-  codex:
-    Install:  npm install -g @openai/codex  (binary: `codex`)
-    Login:    codex login --device-auth  (device-code flow; no localhost port)
-    Token:    ~/.codex/auth.json (written automatically by `codex login`)
-    Rotation: JSON {"pubkey": "...", "codex_auth_json": "<contents of auth.json>"}
-    Storage:  <profile>/.codex/auth.json
+  --cli         claude | codex | gemini
+  --platform    mac | linux | windows | auto
+  --agent-app   claude-desktop | codex-desktop | gemini-desktop |
+                claude-cli | codex-cli | gemini-cli | auto
 
-  gemini:
-    Install:  npm install -g @google/gemini-cli  (binary: `gemini`)
-    Login:    API key from aistudio.google.com (headless-friendly; no OAuth dance)
-    Token:    GEMINI_API_KEY value
-    Rotation: JSON {"pubkey": "...", "gemini_api_key": "AIza..."}
-    Storage:  <profile>/.devbrain/env  (KEY=VALUE sourced by spawn)
+Each axis defaults to `auto`. When auto, the kit branches on that
+dimension and the agent navigates at runtime. When specified, the
+kit is tailored.
 
 Agent directive vocabulary (placed inside HTML comments so they don't
 render in the visible Markdown):
@@ -93,8 +78,36 @@ CliName = Literal["claude", "codex", "gemini"]
 
 VALID_CLIS: tuple[str, ...] = ("claude", "codex", "gemini")
 VALID_PLATFORMS: tuple[str, ...] = ("auto", "mac", "linux", "windows")
+VALID_AGENT_APPS: tuple[str, ...] = (
+    "auto",
+    "claude-desktop", "codex-desktop", "gemini-desktop",
+    "claude-cli", "codex-cli", "gemini-cli",
+)
 
-# ─── Shared preamble (same for every CLI) ─────────────────────────────────────
+_CLI_DISPLAY_NAMES: dict[str, str] = {
+    "claude": "Claude Code",
+    "codex": "Codex",
+    "gemini": "Gemini CLI",
+}
+
+_AGENT_APP_DISPLAY_NAMES: dict[str, str] = {
+    "auto": "your AI agent",
+    "claude-desktop": "Claude Desktop",
+    "codex-desktop": "Codex Desktop",
+    "gemini-desktop": "Gemini Desktop",
+    "claude-cli": "Claude Code (CLI)",
+    "codex-cli": "Codex (CLI)",
+    "gemini-cli": "Gemini (CLI)",
+}
+
+# Where each AI agent app reads MCP server config from
+_MCP_CONFIG_PATHS: dict[str, str] = {
+    "claude": "~/.claude.json",
+    "codex": "~/.codex/config.json",
+    "gemini": "~/.gemini/settings.json",
+}
+
+# ─── Frontmatter / preamble ───────────────────────────────────────────────────
 
 _PREAMBLE = """\
 ---
@@ -104,71 +117,180 @@ dev_id: {dev_id}
 full_name: "{full_name}"
 email: {email}
 cli: {cli}
+agent_app: {agent_app}
+platform: {platform}
 expires: {expires_iso}
 bootstrap_expires: {bootstrap_expiry_iso}
 mac_studio_ssh_user: lhtdev
-mac_studio_ssh_host: lhts-mac-studio.local
+mac_studio_ssh_host: {ssh_host}
+mac_studio_ssh_port: {ssh_port}
+mac_studio_host_fingerprint: "{ssh_host_fingerprint}"
 ---
 
-# Welcome to BrightBot, {first_name} 👋
+# DevBrain onboarding — {full_name}
 
-You've been invited to join the BrightBot dev factory — Lighthouse
-Therapy's multi-AI-agent automation pipeline that drafts, implements,
-reviews, and QAs feature work using YOUR {cli_display_name} subscription,
-attributed to YOUR git identity.
+Welcome aboard. This kit walks your AI agent through connecting your
+machine to Lighthouse Therapy's DevBrain dev factory, then triggers
+your AI subscription auth on the Mac Studio (server-side — your auth
+token never transits this machine).
 
-This file is your onboarding kit. You can either:
+Your AI subscription: **{cli_display_name}**.
+Your dev id: **{dev_id}**.
+Kit expires: {expires_human}.
 
-  • **Drop it into your AI agent of choice** (Claude Code, Codex, Gemini CLI, etc.)
-    — the agent walks through every step, asking for your approval as
-    it goes. ~5 minutes of attention.
+"""
 
-  • **Or run the steps yourself manually** — every command is shown.
-    Same outcome, just typed by you instead of the agent.
+# ─── Phase 0: Trust banner ────────────────────────────────────────────────────
 
-> **Privacy note:** The temp SSH key embedded below is single-use.
-> It can ONLY run a rotation script (cannot get a shell, cannot read
-> files, cannot do anything else). It auto-expires {bootstrap_expiry_human}.
-> After you complete onboarding, the key auto-deletes from the
-> Mac Studio.
+_PHASE0_TRUST = """\
+## Phase 0 — Verification (read this first)
 
-> **Two-factor security:** Even if this email leaks, the temp key
-> alone isn't enough. The rotation script also requires a valid credential
-> (which you generate from your own {cli_display_name} account in
-> Phase 4 below). Without that credential, the temp key is useless.
+This onboarding kit was issued by:
 
----
+| Field | Value |
+|---|---|
+| **Issuer** | Lighthouse Therapy / DevBrain |
+| **Sender domain** | lighthouse-therapy.com (delivered via Google Workspace DWD) |
+| **Issued at** | {expires_iso} (kit expiry) |
+| **Invitation ID** | `{invite_id_short}` (full UUID in YAML frontmatter above) |
+| **Target server** | `{ssh_host}` on port `{ssh_port}` |
+| **SSH host key fingerprint** | `{ssh_host_fingerprint}` |
 
-<!-- agent:plan -->
-<!--
-  AGENT INSTRUCTIONS — read these first, then execute the steps below.
+### What this kit will do
 
-  This document onboards the user named in the frontmatter to DevBrain
-  using {cli_display_name}. Walk through the numbered phases in order.
-  At each phase boundary, show the user a one-sentence summary of what
-  you're about to do and ask for explicit approval before proceeding
-  (yes/no). Never run the next phase without approval for THAT phase.
+1. Generate an SSH keypair on this machine (your permanent dev key,
+   stays local).
+2. Stage a one-shot bootstrap SSH key (embedded at the bottom of this
+   file) that is locked to a single server-side rotation script and
+   auto-expires {bootstrap_expiry_human}.
+3. Use the bootstrap key to deliver your permanent public key to the
+   Mac Studio.
+4. SSH into your profile on the Mac Studio and run `devbrain login`,
+   which generates your AI subscription's auth token *on the server*.
+   The token never leaves the Mac Studio.
+5. Wire up your local AI agent's MCP config so it can call DevBrain
+   factory tools over SSH.
 
-  Steps marked `<!-- agent:auto -->` you may execute on the user's
-  behalf after approval. Steps marked `<!-- agent:human -->` require
-  the user to perform an action in their browser or terminal; you must
-  NOT attempt to automate them — display the command, wait for them to
-  run it, and only then continue.
+No long-lived credentials transit this machine. No persistent network
+listeners are opened locally. The bootstrap key is rendered useless
+after first use.
 
-  Sensitive values (the bootstrap private key and the CLI credential)
-  marked `secret=...` must never be echoed in your responses, written
-  to log files, or persisted outside the single rotation invocation.
-  After Phase 5 completes, DELETE the bootstrap private key file from
-  the user's filesystem.
--->
+### Agent: ask the user to confirm before proceeding
 
-## Phase 1 — Generate your permanent SSH keypair
+<!-- agent:human reason=intent-confirmation risk=medium -->
 
-This key stays on YOUR laptop and is what the Mac Studio will trust
-going forward. The temp key embedded in this kit is for one-shot
-delivery only.
+Before running any commands, ask the user to confirm:
+
+- They are expecting this onboarding kit from their employer (Lighthouse
+  Therapy).
+- The Invitation ID above (`{invite_id_short}`) matches what the admin
+  who sent this kit said it would be.
+- The Mac Studio SSH host fingerprint above matches what the admin
+  shared out-of-band (this can also be verified on first SSH connect
+  by comparing to the prompt your SSH client shows).
+
+If the user can't confirm any of the above, **STOP** and have the user
+contact the admin who issued the kit at `patrick@lighthouse-therapy.com`.
+
+"""
+
+# ─── Phase 1: Environment check + dep install ────────────────────────────────
+
+_PHASE1_HEADER = """\
+## Phase 1 — Environment check + dependency install
+
+This kit assumes a working SSH client (`ssh`, `ssh-keygen`) on your
+machine. Most macOS and Linux installations have these built in;
+Windows 10+ ships them as an optional feature.
+
+The agent should detect your platform and run the matching block below.
+
+"""
+
+_PHASE1_BASH = """\
+### macOS / Linux (bash / zsh)
 
 <!-- agent:auto requires=user-approval risk=low -->
+```bash
+# Verify ssh + ssh-keygen are present.
+for cmd in ssh ssh-keygen; do
+  if command -v "$cmd" >/dev/null 2>&1; then
+    echo "✓ $cmd present"
+  else
+    echo "✗ $cmd MISSING"
+  fi
+done
+```
+
+If either is missing on Linux, install via your distro's package manager:
+
+<!-- agent:auto requires=user-approval,sudo risk=low -->
+```bash
+# Debian/Ubuntu
+sudo apt update && sudo apt install -y openssh-client
+
+# Fedora/RHEL
+sudo dnf install -y openssh-clients
+
+# Alpine
+sudo apk add openssh-client
+```
+
+(macOS ships `ssh` and `ssh-keygen` by default; nothing to install.)
+
+"""
+
+_PHASE1_POWERSHELL = """\
+### Windows (PowerShell)
+
+Windows 10+ ships the OpenSSH client (`ssh.exe`, `ssh-keygen.exe`) as
+an optional feature. Verify it's enabled, and if not, enable it.
+
+<!-- agent:auto requires=user-approval risk=low -->
+```powershell
+# Verify the OpenSSH client is installed and enabled.
+Get-WindowsCapability -Online -Name 'OpenSSH.Client*' |
+  Select-Object Name, State
+# State should be 'Installed'.
+```
+
+If `State` shows `NotPresent`, install it (this requires admin
+elevation but is fast — no reboot needed):
+
+<!-- agent:human reason=requires-admin-elevation risk=low -->
+```powershell
+# Run in an elevated PowerShell (Run as Administrator).
+Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
+```
+
+After install (or if already present), verify:
+
+<!-- agent:auto requires=user-approval risk=low -->
+```powershell
+ssh -V         # prints OpenSSH version
+ssh-keygen -?  # prints usage
+```
+
+The remaining phases run from a regular (non-elevated) PowerShell
+session.
+
+"""
+
+# ─── Phase 2: Generate permanent SSH keypair ─────────────────────────────────
+
+_PHASE2_HEADER = """\
+## Phase 2 — Generate your permanent SSH keypair
+
+This key stays on YOUR machine and is what the Mac Studio will trust
+going forward. The bootstrap key embedded later in this file is for
+one-shot delivery only.
+
+"""
+
+_PHASE2_BASH = """\
+### macOS / Linux
+
+<!-- agent:auto requires=file-write,user-approval risk=low -->
 ```bash
 ssh-keygen -t ed25519 \\
   -f ~/.ssh/id_ed25519_devbrain \\
@@ -177,263 +299,240 @@ ssh-keygen -t ed25519 \\
 ```
 
 If the file already exists, the agent should ask before overwriting.
+
 """
 
-# ─── Phase 2: Install (CLI-specific) ──────────────────────────────────────────
+_PHASE2_POWERSHELL = """\
+### Windows (PowerShell)
 
-_PHASE2_CLAUDE = """\
-## Phase 2 — Install Claude Code
+<!-- agent:auto requires=file-write,user-approval risk=low -->
+```powershell
+# Ensure ~/.ssh exists with correct ACL
+$sshDir = Join-Path $env:USERPROFILE ".ssh"
+New-Item -ItemType Directory -Path $sshDir -Force | Out-Null
 
-If Claude Code is already installed and authenticated on this laptop,
-skip to Phase 3.
-
-<!-- agent:auto requires=user-approval risk=medium -->
-```bash
-brew install --cask claude
+ssh-keygen -t ed25519 `
+  -f "$sshDir\\id_ed25519_devbrain" `
+  -C "{email}" `
+  -N '""'
 ```
 
-Sign in with your Anthropic account (Pro / Max / Team / Enterprise):
+If the file already exists, the agent should ask before overwriting.
 
-<!-- agent:human reason=oauth-browser-required -->
-```bash
-claude /login
-```
-
-This opens a browser for OAuth. Complete the sign-in.
 """
 
-_PHASE2_CODEX = """\
-## Phase 2 — Install Codex
+# ─── Phase 3: Stage bootstrap SSH key ────────────────────────────────────────
 
-If Codex is already installed and authenticated on this laptop,
-skip to Phase 3.
+_PHASE3_HEADER = """\
+## Phase 3 — Stage the bootstrap SSH key locally
 
-<!-- agent:auto requires=user-approval risk=medium -->
-```bash
-npm install -g @openai/codex
-```
+The bootstrap key (embedded at the bottom of this file under
+`bootstrap_private_key:`) is single-use, locked server-side to the
+rotation script, and auto-expires {bootstrap_expiry_human}.
 
-Authenticate via device-code flow (works over SSH — no localhost port needed):
-
-<!-- agent:human reason=device-code-required -->
-```bash
-codex login --device-auth
-```
-
-Codex will print a URL and a one-time code. Open the URL in your browser
-(on any device), enter the code, and confirm. Once the CLI reports success,
-the auth token is written to `~/.codex/auth.json` automatically.
 """
 
-_PHASE2_GEMINI = """\
-## Phase 2 — Install Gemini CLI
-
-If Gemini CLI is already installed and you have an API key, skip to Phase 3.
-
-<!-- agent:auto requires=user-approval risk=medium -->
-```bash
-npm install -g @google/gemini-cli
-```
-
-Get a Gemini API key from Google AI Studio (free tier available):
-
-<!-- agent:human reason=browser-required -->
-Open https://aistudio.google.com/app/apikey in your browser, sign in with
-your Google account, click "Create API key", and copy the resulting key
-(it starts with `AIza...`).
-
-You do **not** need to run `gemini auth login` — DevBrain uses the API key
-directly (headless-friendly, no localhost callback port needed).
-"""
-
-# ─── Phase 3: Generate / capture credential (CLI-specific) ────────────────────
-
-_PHASE3_CLAUDE = """\
-## Phase 3 — Generate a long-lived OAuth token
-
-DevBrain uses this to call Claude on your behalf inside the factory.
-The token is valid for ~1 year, billed against YOUR subscription.
-
-<!-- agent:human reason=oauth-browser-required -->
-```bash
-claude setup-token
-```
-
-Copy the `sk-ant-oat01-...` string. **Do not share it anywhere except
-the rotation step below.** The agent will hold it in memory only and
-discard after Phase 5.
-"""
-
-_PHASE3_CODEX = """\
-## Phase 3 — Capture your Codex auth token
-
-After `codex login --device-auth` completed in Phase 2, the auth token was
-written automatically to `~/.codex/auth.json`.
-
-<!-- agent:auto requires=file-read,user-approval secret=codex_auth_json risk=low -->
-```bash
-# Agent: read the CONTENTS of ~/.codex/auth.json into session memory.
-# Label it `codex_auth_json`. Do NOT print, log, or echo the contents.
-# This file is the credential DevBrain needs — treat it like a password.
-
-cat ~/.codex/auth.json
-```
-
-Keep the JSON content in session memory — you'll send it in Phase 5.
-"""
-
-_PHASE3_GEMINI = """\
-## Phase 3 — Store your Gemini API key
-
-Hold the `AIza...` API key you copied from AI Studio in session memory.
-**Do not paste it into any chat, file, or log.** The agent will use it
-only in Phase 5's rotation call.
-
-<!-- agent:human reason=user-must-paste secret=gemini_api_key risk=medium -->
-Paste your Gemini API key when your agent asks for it. It will be held
-in memory only and discarded after Phase 5 completes.
-"""
-
-# ─── Phase 4: Stage bootstrap key (identical for all CLIs) ────────────────────
-
-_PHASE4 = """\
-## Phase 4 — Stage the bootstrap SSH key locally
-
-The bootstrap key below is single-use, locked to a rotation script,
-and auto-expires {bootstrap_expiry_human}.
+_PHASE3_BASH = """\
+### macOS / Linux
 
 <!-- agent:auto requires=file-write,user-approval target=~/.ssh/devbrain-bootstrap-{dev_id} secret=bootstrap_private_key risk=medium -->
 ```bash
-# Agent: write the contents of `bootstrap_private_key` (below) to
-# ~/.ssh/devbrain-bootstrap-{dev_id}, set mode 0600. Do NOT cat to
-# stdout, do NOT add to ssh-agent, do NOT commit anywhere.
-
-# After Phase 5 completes successfully, the agent will delete this
-# file. The bootstrap key has no value beyond this single rotation.
+# Agent: write the contents of `bootstrap_private_key` (at the bottom
+# of this file) to ~/.ssh/devbrain-bootstrap-{dev_id} and set mode 0600.
+# Do NOT cat to stdout, do NOT add to ssh-agent, do NOT commit.
 
 cat > ~/.ssh/devbrain-bootstrap-{dev_id} <<'BOOTSTRAP_KEY_END'
 {bootstrap_private_key}BOOTSTRAP_KEY_END
 
 chmod 600 ~/.ssh/devbrain-bootstrap-{dev_id}
 ```
+
 """
 
-# ─── Phase 5: Rotate (CLI-specific JSON payload) ──────────────────────────────
+_PHASE3_POWERSHELL = """\
+### Windows (PowerShell)
 
-_PHASE5_CLAUDE = """\
-## Phase 5 — SSH-rotate to your permanent key
+<!-- agent:auto requires=file-write,user-approval target=~/.ssh/devbrain-bootstrap-{dev_id} secret=bootstrap_private_key risk=medium -->
+```powershell
+# Agent: write the contents of `bootstrap_private_key` (at the bottom
+# of this file) to a per-user file under ~/.ssh and tighten the ACL so
+# only the current user can read it. ssh.exe refuses keys with looser
+# permissions on Windows.
 
-This single SSH connection delivers your permanent pubkey + OAuth
-token to the Mac Studio's rotation handler. The handler validates
-the OAuth token by hitting api.anthropic.com (two-factor check),
-persists both, and self-deletes the bootstrap key entry.
+$keyPath = Join-Path $env:USERPROFILE ".ssh\\devbrain-bootstrap-{dev_id}"
 
-<!-- agent:auto requires=user-approval,network,user-paste secret=oauth_token scope=lhts-mac-studio.local risk=medium -->
+# Replace the placeholder block here with the bootstrap_private_key
+# content (between BEGIN OPENSSH PRIVATE KEY and END OPENSSH PRIVATE KEY,
+# inclusive of those markers).
+@'
+{bootstrap_private_key}'@ | Set-Content -Path $keyPath -NoNewline -Encoding ASCII
+
+# Lock down the ACL: remove inheritance, grant only the current user
+icacls $keyPath /inheritance:r | Out-Null
+icacls $keyPath /grant:r ("{{0}}:(R)" -f $env:USERNAME) | Out-Null
+```
+
+"""
+
+# ─── Phase 4: Rotate permanent pubkey to server ──────────────────────────────
+
+_PHASE4_HEADER = """\
+## Phase 4 — Deliver your permanent public key to the Mac Studio
+
+This single SSH connection delivers your permanent SSH **public key**
+(only — no auth token) to the rotation handler. The handler persists
+your pubkey, marks the invitation ready for activation, and self-deletes
+the bootstrap key entry from `authorized_keys`.
+
+Your AI subscription auth happens server-side in Phase 5 — nothing
+about it transits this connection.
+
+"""
+
+_PHASE4_BASH = """\
+### macOS / Linux
+
+<!-- agent:auto requires=user-approval,network scope={ssh_host} risk=medium -->
 ```bash
-# Agent: read $OAUTH_TOKEN from session memory (collected in Phase 3).
-# DO NOT log, persist, or echo it.
-
 PUBKEY=$(cat ~/.ssh/id_ed25519_devbrain.pub)
 
-jq -n --arg p "$PUBKEY" --arg t "$OAUTH_TOKEN" '{{pubkey: $p, oauth_token: $t}}' \\
+printf '{{"pubkey":"%s"}}' "$PUBKEY" \\
   | ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
-        {ssh_port_flag} \\
+        -p {ssh_port} \\
         -o StrictHostKeyChecking=accept-new \\
         -o UserKnownHostsFile=~/.ssh/known_hosts \\
         lhtdev@{ssh_host}
 
-# Expected output: {{"status":"ok","dev_id":"{dev_id}","invite_id":"..."}}
+# Expected response:
+#   {{"status":"ok","dev_id":"{dev_id}","invite_id":"..."}}
 ```
 
-If the response is anything other than `status: ok`, stop and surface
-the error to the user. Common errors:
-  - `oauth_token_rejected_by_anthropic` — the token wasn't valid; re-run `claude setup-token` and retry.
-  - `no_matching_invitation_for_prefix=` — the invitation has expired or been revoked. Contact the admin who sent the kit.
 """
 
-_PHASE5_CODEX = """\
-## Phase 5 — SSH-rotate to your permanent key
+_PHASE4_POWERSHELL = """\
+### Windows (PowerShell)
 
-This single SSH connection delivers your permanent pubkey + Codex auth
-token to the Mac Studio's rotation handler. The handler validates the
-token format, persists both, and self-deletes the bootstrap key entry.
+<!-- agent:auto requires=user-approval,network scope={ssh_host} risk=medium -->
+```powershell
+$pubkey = (Get-Content -Raw "$env:USERPROFILE\\.ssh\\id_ed25519_devbrain.pub").Trim()
+$payload = @{{ pubkey = $pubkey }} | ConvertTo-Json -Compress
 
-<!-- agent:auto requires=user-approval,network,user-paste secret=codex_auth_json scope=lhts-mac-studio.local risk=medium -->
-```bash
-# Agent: read $CODEX_AUTH_JSON from session memory (collected in Phase 3).
-# DO NOT log, persist, or echo it.
+$payload | ssh `
+  -i "$env:USERPROFILE\\.ssh\\devbrain-bootstrap-{dev_id}" `
+  -p {ssh_port} `
+  -o StrictHostKeyChecking=accept-new `
+  -o UserKnownHostsFile="$env:USERPROFILE\\.ssh\\known_hosts" `
+  "lhtdev@{ssh_host}"
 
-PUBKEY=$(cat ~/.ssh/id_ed25519_devbrain.pub)
-
-jq -n --arg p "$PUBKEY" --argjson a "$CODEX_AUTH_JSON" '{{pubkey: $p, codex_auth_json: $a}}' \\
-  | ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
-        {ssh_port_flag} \\
-        -o StrictHostKeyChecking=accept-new \\
-        -o UserKnownHostsFile=~/.ssh/known_hosts \\
-        lhtdev@{ssh_host}
-
-# Expected output: {{"status":"ok","dev_id":"{dev_id}","invite_id":"..."}}
+# Expected response:
+#   {{"status":"ok","dev_id":"{dev_id}","invite_id":"..."}}
 ```
 
-If the response is anything other than `status: ok`, stop and surface
-the error to the user. Common errors:
-  - `codex_auth_json_invalid` — the auth.json content wasn't accepted; re-run `codex login --device-auth` and retry.
-  - `no_matching_invitation_for_prefix=` — the invitation has expired or been revoked. Contact the admin who sent the kit.
 """
 
-_PHASE5_GEMINI = """\
-## Phase 5 — SSH-rotate to your permanent key
+_PHASE4_FOOTER = """\
+If the response is anything other than `status: ok`, **STOP** and
+surface the error to the user. Common errors:
 
-This single SSH connection delivers your permanent pubkey + Gemini API
-key to the Mac Studio's rotation handler. The handler validates the
-API key by hitting the Gemini API, persists both, and self-deletes the
-bootstrap key entry.
+- `pubkey_unsafe` — your SSH pubkey didn't match the expected shape;
+  re-run Phase 2 to regenerate it.
+- `no_matching_invitation_for_prefix=` — the invitation has expired or
+  been revoked. Contact the admin who sent the kit.
 
-<!-- agent:auto requires=user-approval,network,user-paste secret=gemini_api_key scope=lhts-mac-studio.local risk=medium -->
-```bash
-# Agent: read $GEMINI_API_KEY from session memory (collected in Phase 3).
-# DO NOT log, persist, or echo it.
-
-PUBKEY=$(cat ~/.ssh/id_ed25519_devbrain.pub)
-
-jq -n --arg p "$PUBKEY" --arg k "$GEMINI_API_KEY" '{{pubkey: $p, gemini_api_key: $k}}' \\
-  | ssh -i ~/.ssh/devbrain-bootstrap-{dev_id} \\
-        {ssh_port_flag} \\
-        -o StrictHostKeyChecking=accept-new \\
-        -o UserKnownHostsFile=~/.ssh/known_hosts \\
-        lhtdev@{ssh_host}
-
-# Expected output: {{"status":"ok","dev_id":"{dev_id}","invite_id":"..."}}
-```
-
-If the response is anything other than `status: ok`, stop and surface
-the error to the user. Common errors:
-  - `gemini_api_key_rejected` — the API key wasn't valid; get a fresh key from aistudio.google.com and retry.
-  - `no_matching_invitation_for_prefix=` — the invitation has expired or been revoked. Contact the admin who sent the kit.
 """
 
-# ─── Phase 6-8: Cleanup + MCP config + verify (identical for all CLIs) ────────
+# ─── Phase 5: Server-side `devbrain login` ───────────────────────────────────
 
-_PHASES_6_8 = """\
-## Phase 6 — Cleanup
+_PHASE5_BY_CLI: dict[str, str] = {
+    "claude": """\
+## Phase 5 — Issue your Claude OAuth token (server-side)
 
-<!-- agent:auto requires=file-write target=~/.ssh/devbrain-bootstrap-{dev_id} risk=low -->
+You SSH into your profile on the Mac Studio and run `devbrain login`.
+That command runs `claude setup-token` server-side; you'll see an
+OAuth URL printed. Open the URL **in your local browser**, sign in
+with your Anthropic account (Pro / Max / Team / Enterprise), copy the
+verification code from the post-signin page, and paste it back into
+this SSH session. The resulting token is stashed at
+`<profile>/.claude/oauth-token` on the Mac Studio. It never returns
+to this machine.
+
+<!-- agent:auto requires=user-approval,network,user-paste secret=oauth_verification_code scope={ssh_host} risk=medium -->
+""",
+    "codex": """\
+## Phase 5 — Authenticate Codex via device-code (server-side)
+
+You SSH into your profile on the Mac Studio and run `devbrain login`.
+That command runs `codex login --device-auth` server-side; you'll see
+a verification URL and one-time code printed. Open the URL **in your
+local browser**, enter the code, and confirm. The resulting auth.json
+is written at `<profile>/.codex/auth.json` on the Mac Studio. It
+never returns to this machine.
+
+<!-- agent:auto requires=user-approval,network,user-paste scope={ssh_host} risk=medium -->
+""",
+    "gemini": """\
+## Phase 5 — Provide your Gemini API key (server-side)
+
+You SSH into your profile on the Mac Studio and run `devbrain login`.
+That command will prompt you to paste your Gemini API key. Get one
+from https://aistudio.google.com/app/apikey (free tier is fine), open
+the URL **in your local browser**, copy the key (starts with `AIza`),
+and paste it into the SSH prompt. The key is stashed at
+`<profile>/.devbrain/env` on the Mac Studio. It never returns to
+this machine.
+
+<!-- agent:auto requires=user-approval,network,user-paste secret=gemini_api_key scope={ssh_host} risk=medium -->
+""",
+}
+
+_PHASE5_COMMAND = """\
 ```bash
-shred -u ~/.ssh/devbrain-bootstrap-{dev_id} 2>/dev/null || rm -f ~/.ssh/devbrain-bootstrap-{dev_id}
+ssh -i ~/.ssh/id_ed25519_devbrain \\
+    -p {ssh_port} \\
+    -o StrictHostKeyChecking=accept-new \\
+    -t lhtdev@{ssh_host} \\
+    devbrain login --dev {dev_id} --cli {cli}
 ```
 
-(macOS doesn't ship `shred` by default — `rm -f` is the fallback. The
-key was useless after rotation anyway.)
+Windows PowerShell equivalent:
 
-## Phase 7 — Configure your local {cli_display_name} MCP
+```powershell
+ssh -i "$env:USERPROFILE\\.ssh\\id_ed25519_devbrain" `
+    -p {ssh_port} `
+    -o StrictHostKeyChecking=accept-new `
+    -t "lhtdev@{ssh_host}" `
+    devbrain login --dev {dev_id} --cli {cli}
+```
 
-Lets your laptop's {cli_display_name} call DevBrain factory tools (factory_plan,
-factory_status, deep_search) over SSH using your permanent key.
+The `-t` flag is required: `devbrain login` is interactive (you'll be
+asked to paste a code, or an API key, depending on your CLI). The
+agent should keep your SSH session open and help you copy/paste
+between your local browser and the SSH prompt.
+
+After this command exits with `success: true`, your dev profile on
+the Mac Studio has the credential it needs to spawn {cli_display_name}
+on your behalf. The token never came back through this connection.
+
+"""
+
+# ─── Phase 6: MCP wire-up + verify (per-CLI; same on bash/PowerShell) ────────
+
+_PHASE6_HEADER = """\
+## Phase 6 — Wire up your local agent's MCP config + verify SSH
+
+This step lets your **local** AI agent ({agent_app_display}) call DevBrain
+factory tools (factory_plan, factory_status, deep_search) over SSH
+using your permanent key.
+
+"""
+
+_PHASE6_BASH = """\
+### macOS / Linux
 
 <!-- agent:auto requires=user-approval,file-write target={mcp_config_path} risk=low -->
 ```bash
-# Agent: read {mcp_config_path}, MERGE the mcpServers block (don't clobber
-# existing entries), write back.
+# Agent: read {mcp_config_path}, MERGE the mcpServers block (don't
+# clobber other entries), write back.
 
 cat <<'EOF'
 {{
@@ -449,180 +548,145 @@ cat <<'EOF'
 EOF
 ```
 
-After this, restart {cli_display_name}. The DevBrain MCP tools appear in your
-{cli_display_name} session.
+After this, restart {agent_app_display}. The DevBrain MCP tools should
+appear in your session.
 
-## Phase 8 — Verify
+### Verify SSH
 
-<!-- agent:auto requires=user-approval,network risk=low -->
+<!-- agent:auto requires=user-approval,network scope={ssh_host} risk=low -->
 ```bash
-ssh -i ~/.ssh/id_ed25519_devbrain {ssh_port_flag} lhtdev@{ssh_host} whoami
+ssh -i ~/.ssh/id_ed25519_devbrain -p {ssh_port} lhtdev@{ssh_host} whoami
 # Expected output: lhtdev
 ```
 
-You can now SSH into the Mac Studio at any time:
+You can also add the host to `~/.ssh/config` for ergonomics:
 
-```bash
-ssh -i ~/.ssh/id_ed25519_devbrain {ssh_port_flag} lhtdev@{ssh_host}
-# (Add to ~/.ssh/config as `Host mac-studio` for ergonomics.)
+```
+Host mac-studio
+  HostName {ssh_host}
+  Port {ssh_port}
+  User lhtdev
+  IdentityFile ~/.ssh/id_ed25519_devbrain
 ```
 
-Once on the Mac Studio, view the factory dashboard:
+"""
 
-```bash
-factory dashboard
+_PHASE6_POWERSHELL = """\
+### Windows (PowerShell)
+
+<!-- agent:auto requires=user-approval,file-write target={mcp_config_path} risk=low -->
+```powershell
+# Agent: read {mcp_config_path} (Windows path expansion), merge the
+# mcpServers block, write back. ConvertFrom-Json + ConvertTo-Json
+# handle the merge cleanly.
+
+$cfgPath = "{mcp_config_path}".Replace("~", $env:USERPROFILE) -replace "/", "\\"
+$cfg = if (Test-Path $cfgPath) {{
+  Get-Content -Raw $cfgPath | ConvertFrom-Json -AsHashtable
+}} else {{ @{{}} }}
+
+if (-not $cfg.mcpServers) {{ $cfg.mcpServers = @{{}} }}
+$cfg.mcpServers.devbrain = @{{
+  command = "ssh"
+  args = @("-i", "$env:USERPROFILE\\.ssh\\id_ed25519_devbrain",
+           "-p", "{ssh_port}",
+           "lhtdev@{ssh_host}",
+           "/Users/lhtdev/devbrain/mcp-server/run.sh")
+}}
+
+$cfg | ConvertTo-Json -Depth 10 | Set-Content -Path $cfgPath -Encoding UTF8
 ```
 
-Or submit a job:
+After this, restart {agent_app_display}. The DevBrain MCP tools should
+appear in your session.
 
+### Verify SSH
+
+<!-- agent:auto requires=user-approval,network scope={ssh_host} risk=low -->
+```powershell
+ssh -i "$env:USERPROFILE\\.ssh\\id_ed25519_devbrain" -p {ssh_port} `
+    "lhtdev@{ssh_host}" whoami
+# Expected output: lhtdev
+```
+
+"""
+
+_PHASE7_CLEANUP = """\
+## Phase 7 — Cleanup (you're done!)
+
+The bootstrap key is now useless (the server self-deleted its
+`authorized_keys` entry on Phase 4 success and the key file's expiry
+has rolled past). Remove it from this machine:
+
+### macOS / Linux
+
+<!-- agent:auto requires=file-write target=~/.ssh/devbrain-bootstrap-{dev_id} risk=low -->
 ```bash
-factory submit "Add a no-op test that asserts True" --project devbrain --cli {cli}
+shred -u ~/.ssh/devbrain-bootstrap-{dev_id} 2>/dev/null \\
+  || rm -f ~/.ssh/devbrain-bootstrap-{dev_id}
+```
+
+### Windows
+
+<!-- agent:auto requires=file-write target=~/.ssh/devbrain-bootstrap-{dev_id} risk=low -->
+```powershell
+Remove-Item -Force "$env:USERPROFILE\\.ssh\\devbrain-bootstrap-{dev_id}"
 ```
 
 ---
 
 ## You're done!
 
-DevBrain has notified the admin that you've completed onboarding. Ping
-them if you don't get a confirmation message within a few minutes.
+DevBrain has notified the admin that you're activated. Try submitting
+a test job from your local agent:
 
-If anything broke, the kit and your invite token are reusable until
-{expires_human}, BUT the bootstrap SSH key expires earlier
-({bootstrap_expiry_human}). After bootstrap expiry, the admin can
-issue a fresh kit.
+```
+factory submit "Add a no-op test that asserts True" --project devbrain --cli {cli}
+```
 
-Welcome aboard.
+Or run `factory dashboard` after SSHing into the Mac Studio to see the
+factory's job queue.
+
+If anything broke, the kit is reusable until {expires_human}, BUT the
+bootstrap SSH key expires earlier ({bootstrap_expiry_human}). After
+bootstrap expiry, the admin can issue a fresh kit.
+
 """
 
-# ─── Bootstrap private key block (appended at end of kit) ─────────────────────
+# ─── Bootstrap private key block ──────────────────────────────────────────────
 
 _BOOTSTRAP_KEY_BLOCK = """\
 
-<!-- The bootstrap private key below is referenced by Phase 4 above.
-     agent:secret — never echo, log, or transmit outside Phase 4-5. -->
+<!-- The bootstrap private key below is referenced by Phase 3 above.
+     agent:secret — never echo, log, or transmit outside Phase 3-4. -->
 
 ```
 bootstrap_private_key:
 {bootstrap_private_key}```
 """
 
-# ─── CLI display names + MCP config paths ─────────────────────────────────────
 
-_CLI_DISPLAY_NAMES: dict[str, str] = {
-    "claude": "Claude Code",
-    "codex": "Codex",
-    "gemini": "Gemini CLI",
-}
+# ─── Section assembly helpers ─────────────────────────────────────────────────
 
-# The config file each CLI merges mcpServers into
-_MCP_CONFIG_PATHS: dict[str, str] = {
-    "claude": "~/.claude.json",
-    "codex": "~/.codex/config.json",
-    "gemini": "~/.gemini/settings.json",
-}
-
-# ─── Phase 0: Windows preflight (only when platform=windows) ──────────────────
-#
-# Verifies WSL2 + Ubuntu + apt prereqs, installs only what's missing. After
-# Phase 0 completes, the dev reopens their AI agent INSIDE the WSL Ubuntu
-# shell. Phases 1-8 then run as standard bash and "just work".
-
-_PHASE0_WINDOWS = """\
-## Phase 0 — Windows preflight (WSL2 + Ubuntu + apt prereqs)
-
-Phases 1-8 of this kit assume a Linux-shaped shell (bash, ssh, jq,
-`~/.ssh/`). On Windows the cleanest path is
-**WSL2 + Ubuntu** — the rest of the kit then runs unchanged inside
-the WSL shell.
-
-The agent does verify-before-install: each dependency is checked first;
-only missing pieces are installed.
-
-### Step 0.1 — Verify WSL2
-
-<!-- agent:auto requires=user-approval risk=low -->
-```powershell
-# Run in PowerShell.
-wsl --status 2>&1
-# Expected if installed: "Default Distribution: Ubuntu" or similar.
-# If output is "Windows Subsystem for Linux has no installed
-# distributions" or the command isn't found — install per Step 0.2.
-```
-
-### Step 0.2 — Install WSL2 + Ubuntu (only if Step 0.1 reported missing)
-
-<!-- agent:human reason=requires-admin-elevation -->
-```powershell
-# Run in PowerShell as Administrator. Requires reboot afterward.
-wsl --install -d Ubuntu
-# Reboot when prompted, then:
-#   1. Open "Ubuntu" from the Start menu
-#   2. Set a Linux username + password when prompted
-#   3. Once the Ubuntu shell is open, continue to Step 0.3
-```
-
-> If WSL is already installed but the default distro isn't Ubuntu, you
-> can skip the install and just `wsl -d Ubuntu` from PowerShell. The
-> agent should NOT clobber an existing distro choice.
-
-### Step 0.3 — Verify Ubuntu apt prereqs
-
-<!-- agent:auto requires=user-approval risk=low -->
-```bash
-# Run inside the WSL Ubuntu shell.
-for cmd in jq ssh curl openssl; do
-    if command -v $cmd >/dev/null 2>&1; then
-        echo "✓ $cmd present"
-    else
-        echo "✗ $cmd missing"
-    fi
-done
-```
-
-### Step 0.4 — Install missing apt packages (only the ones flagged ✗ above)
-
-<!-- agent:auto requires=user-approval,sudo risk=low -->
-```bash
-# Adjust the package list to ONLY the missing ones from Step 0.3.
-# jq → jq, ssh → openssh-client, curl → curl, openssl → openssl
-sudo apt update
-sudo apt install -y <space-separated-package-names>
-```
-
-### Step 0.5 — Switch your AI agent to WSL
-
-The remaining phases (1-8) run inside this WSL Ubuntu shell. **Reopen
-your AI agent here** — close the Windows-native session and:
-
-- **Codex / Gemini CLI:** install + run them inside WSL (Phase 2 covers this)
-- **Claude Code:** install Claude Code inside WSL (Phase 2 covers this)
-- **Claude Desktop / Codex Desktop apps:** Windows-native is fine, but
-  the kit's bash commands need to execute via your WSL agent session
-
-Once your agent is running inside WSL Ubuntu, continue to Phase 1.
-
----
-
-"""
+def _select_shell_variants(platform: str) -> tuple[bool, bool]:
+    """Return (include_bash, include_powershell) given a platform."""
+    if platform == "windows":
+        return (False, True)
+    if platform in ("mac", "linux"):
+        return (True, False)
+    # auto — include both
+    return (True, True)
 
 
-_PHASE2_BY_CLI: dict[str, str] = {
-    "claude": _PHASE2_CLAUDE,
-    "codex": _PHASE2_CODEX,
-    "gemini": _PHASE2_GEMINI,
-}
-
-_PHASE3_BY_CLI: dict[str, str] = {
-    "claude": _PHASE3_CLAUDE,
-    "codex": _PHASE3_CODEX,
-    "gemini": _PHASE3_GEMINI,
-}
-
-_PHASE5_BY_CLI: dict[str, str] = {
-    "claude": _PHASE5_CLAUDE,
-    "codex": _PHASE5_CODEX,
-    "gemini": _PHASE5_GEMINI,
-}
+def _phase_block(header: str, bash: str, powershell: str, platform: str) -> str:
+    """Assemble a phase by stitching header + selected shell variants."""
+    include_bash, include_ps = _select_shell_variants(platform)
+    parts = [header]
+    if include_bash:
+        parts.append(bash)
+    if include_ps:
+        parts.append(powershell)
+    return "".join(parts)
 
 
 def write_onboarding_kit(
@@ -639,21 +703,30 @@ def write_onboarding_kit(
     bootstrap_expiry: datetime,
     ssh_host: str = "lhts-mac-studio.local",
     ssh_port: int = 22,
+    ssh_host_fingerprint: str = "",
     cli: CliName = "claude",
     platform: str = "auto",
+    agent_app: str = "auto",
 ) -> Path:
     """Render an onboarding kit for one invitation. Returns the path written.
 
-    The file is mode 600 — it embeds a single-use bootstrap SSH private
-    key (locked to the rotation handler, auto-expires) plus the
-    invitation token. Treat as a credential. Email transit, Slack DM,
-    or hand-off are appropriate; broadcast channels are not.
-
     Args:
-        cli: Which AI CLI to generate the kit for. Defaults to 'claude'
-             for backward compatibility. Valid values: 'claude', 'codex',
-             'gemini'. Determines the Install (Phase 2), Login/Token-capture
-             (Phase 3), and SSH rotation payload (Phase 5) sections.
+        cli: AI subscription the dev's factory work runs against
+             ('claude' / 'codex' / 'gemini'). Drives Phase 5's
+             server-side auth flow.
+        platform: Dev's local OS ('mac', 'linux', 'windows', 'auto').
+                  Drives which shell variants (bash / PowerShell)
+                  appear in the kit. 'auto' includes both.
+        agent_app: Which AI agent app the dev will use to consume this
+                   kit ('claude-desktop', 'codex-desktop',
+                   'gemini-desktop', 'claude-cli', 'codex-cli',
+                   'gemini-cli', 'auto'). Affects framing language;
+                   functional behavior is identical across choices.
+        ssh_host_fingerprint: SHA256 fingerprint of the Mac Studio's
+                              SSH host pubkey, included in Phase 0
+                              for the dev to verify on first connect.
+                              Empty string means "not embedded" — the
+                              dev verifies via SSH client prompt only.
     """
     if cli not in VALID_CLIS:
         raise ValueError(f"cli must be one of {VALID_CLIS!r}, got {cli!r}")
@@ -661,11 +734,11 @@ def write_onboarding_kit(
         raise ValueError(
             f"platform must be one of {VALID_PLATFORMS!r}, got {platform!r}"
         )
+    if agent_app not in VALID_AGENT_APPS:
+        raise ValueError(
+            f"agent_app must be one of {VALID_AGENT_APPS!r}, got {agent_app!r}"
+        )
 
-    first_name = full_name.split()[0] if full_name else dev_id
-
-    # Ensure trailing newline on the private key so the heredoc
-    # cat-block produces a clean PEM-formatted file.
     if not bootstrap_private_key.endswith("\n"):
         bootstrap_private_key = bootstrap_private_key + "\n"
 
@@ -677,27 +750,32 @@ def write_onboarding_kit(
         email=email,
         cli=cli,
         cli_display_name=_CLI_DISPLAY_NAMES[cli],
+        agent_app=agent_app,
+        agent_app_display=_AGENT_APP_DISPLAY_NAMES[agent_app],
+        platform=platform,
         mcp_config_path=_MCP_CONFIG_PATHS[cli],
         expires_iso=expires_at.isoformat(),
         expires_human=expires_at.strftime("%Y-%m-%d %H:%M %Z").strip(),
         bootstrap_expiry_iso=bootstrap_expiry.isoformat(),
         bootstrap_expiry_human=bootstrap_expiry.strftime("%Y-%m-%d %H:%M %Z").strip(),
-        first_name=first_name,
         bootstrap_private_key=bootstrap_private_key,
         ssh_host=ssh_host,
         ssh_port=ssh_port,
-        ssh_port_flag=f"-p {ssh_port}",
+        ssh_host_fingerprint=ssh_host_fingerprint or "(verify on first SSH connect)",
     )
 
-    sections: list[str] = [_PREAMBLE]
-    if platform == "windows":
-        sections.append(_PHASE0_WINDOWS)
-    sections += [
-        _PHASE2_BY_CLI[cli],
-        _PHASE3_BY_CLI[cli],
-        _PHASE4,
+    sections: list[str] = [
+        _PREAMBLE,
+        _PHASE0_TRUST,
+        _phase_block(_PHASE1_HEADER, _PHASE1_BASH, _PHASE1_POWERSHELL, platform),
+        _phase_block(_PHASE2_HEADER, _PHASE2_BASH, _PHASE2_POWERSHELL, platform),
+        _phase_block(_PHASE3_HEADER, _PHASE3_BASH, _PHASE3_POWERSHELL, platform),
+        _phase_block(_PHASE4_HEADER, _PHASE4_BASH, _PHASE4_POWERSHELL, platform),
+        _PHASE4_FOOTER,
         _PHASE5_BY_CLI[cli],
-        _PHASES_6_8,
+        _PHASE5_COMMAND,
+        _phase_block(_PHASE6_HEADER, _PHASE6_BASH, _PHASE6_POWERSHELL, platform),
+        _PHASE7_CLEANUP,
         _BOOTSTRAP_KEY_BLOCK,
     ]
     content = "".join(s.format(**fmt_args) for s in sections)

--- a/factory/setup.py
+++ b/factory/setup.py
@@ -1954,7 +1954,11 @@ def _run_multi_dev_section() -> None:
     setup_multi_dev(non_interactive=False)
 
 
-def setup_add_dev(cli: str | None = None, platform: str | None = None) -> None:
+def setup_add_dev(
+    cli: str | None = None,
+    platform: str | None = None,
+    agent_app: str | None = None,
+) -> None:
     """Onboard a new dev: stage row, generate invitation, write kit .md.
 
     The admin runs this on the Mac Studio. They get back a path to a
@@ -2087,6 +2091,49 @@ def setup_add_dev(cli: str | None = None, platform: str | None = None) -> None:
             _warn(f"--platform '{platform}' is not valid. Must be one of: {', '.join(_VALID_PLATFORMS)}")
             raise SystemExit(2)
 
+    # ─── Dev's AI agent app (controls kit framing + email body) ──────────
+    from onboarding_kit import VALID_AGENT_APPS as _VALID_AGENT_APPS
+    if agent_app is None:
+        _agent_app_labels = {
+            "auto":            "Auto / unknown (kit ships generic; email lists install options)",
+            "claude-desktop":  "Claude Desktop",
+            "codex-desktop":   "Codex Desktop",
+            "gemini-desktop":  "Gemini Desktop",
+            "claude-cli":      "Claude Code (CLI)",
+            "codex-cli":       "Codex (CLI)",
+            "gemini-cli":      "Gemini (CLI)",
+        }
+        click.echo()
+        _info("Which AI agent app will the dev use to read this kit?")
+        for i, a in enumerate(_VALID_AGENT_APPS, 1):
+            click.echo(f"    {i}. {_agent_app_labels[a]}")
+        click.echo()
+        while True:
+            raw = _prompt(
+                f"Choice (1-{len(_VALID_AGENT_APPS)} or agent-app name)",
+                default="1",
+            ).strip().lower()
+            if raw in ("1", "auto"):
+                agent_app = "auto"; break
+            elif raw in ("2", "claude-desktop"):
+                agent_app = "claude-desktop"; break
+            elif raw in ("3", "codex-desktop"):
+                agent_app = "codex-desktop"; break
+            elif raw in ("4", "gemini-desktop"):
+                agent_app = "gemini-desktop"; break
+            elif raw in ("5", "claude-cli"):
+                agent_app = "claude-cli"; break
+            elif raw in ("6", "codex-cli"):
+                agent_app = "codex-cli"; break
+            elif raw in ("7", "gemini-cli"):
+                agent_app = "gemini-cli"; break
+            else:
+                _warn(f"'{raw}' is not valid. Pick by number or name.")
+    else:
+        if agent_app not in _VALID_AGENT_APPS:
+            _warn(f"--agent-app '{agent_app}' is not valid. Must be one of: {', '.join(_VALID_AGENT_APPS)}")
+            raise SystemExit(2)
+
     auto_activate = _confirm(
         "Auto-activate this dev when their pubkey + OAuth token arrive? "
         "(no = require manual `devbrain setup activate --dev <id>`)",
@@ -2105,6 +2152,8 @@ def setup_add_dev(cli: str | None = None, platform: str | None = None) -> None:
     click.echo(f"   full_name:     {full_name}")
     click.echo(f"   email:         {email}")
     click.echo(f"   cli:           {cli}")
+    click.echo(f"   platform:      {platform}")
+    click.echo(f"   agent_app:     {agent_app}")
     if slack_handle:
         click.echo(f"   slack:         {slack_handle}")
     click.echo(f"   auto_activate: {auto_activate}")
@@ -2184,6 +2233,26 @@ def setup_add_dev(cli: str | None = None, platform: str | None = None) -> None:
     ak_path.write_text(payload)
     ak_path.chmod(0o600)
 
+    # ─── Discover the Mac Studio's SSH host fingerprint ────────────────
+    # Embedded in the kit's Phase 0 trust banner so the dev (or their
+    # agent) can verify the SSH host on first connect against a value
+    # they got out-of-band.
+    ssh_host_fingerprint = ""
+    host_pubkey_path = Path("/etc/ssh/ssh_host_ed25519_key.pub")
+    if host_pubkey_path.exists():
+        try:
+            result = _sp.run(
+                ["ssh-keygen", "-lf", str(host_pubkey_path)],
+                check=True, capture_output=True, text=True,
+            )
+            # Output: "256 SHA256:abc... root@host (ED25519)"
+            for tok in result.stdout.split():
+                if tok.startswith("SHA256:"):
+                    ssh_host_fingerprint = tok
+                    break
+        except (_sp.CalledProcessError, FileNotFoundError):
+            pass
+
     # ─── Generate the onboarding kit .md ──────────────────────────────
     kit_dir = _DEVBRAIN_HOME / "onboarding"
     kit_dir.mkdir(parents=True, exist_ok=True)
@@ -2203,8 +2272,10 @@ def setup_add_dev(cli: str | None = None, platform: str | None = None) -> None:
         bootstrap_expiry=bootstrap_expires,
         ssh_host=ONBOARDING_SSH_HOST,
         ssh_port=ONBOARDING_SSH_PORT,
+        ssh_host_fingerprint=ssh_host_fingerprint,
         cli=cli,
         platform=platform,
+        agent_app=agent_app,
     )
 
     # ─── Hand back to admin ───────────────────────────────────────────
@@ -2226,6 +2297,7 @@ def setup_add_dev(cli: str | None = None, platform: str | None = None) -> None:
             admin_name=admin_user,
             admin_contact=admin_user,
             cli=cli,
+            agent_app=agent_app,
         )
         if sent:
             _ok(f"Email sent to {email}.")

--- a/factory/tests/test_ai_cli_gemini.py
+++ b/factory/tests/test_ai_cli_gemini.py
@@ -1,13 +1,18 @@
 """Tests for GeminiAdapter."""
 from __future__ import annotations
 
+import io
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
-from ai_clis.gemini import GeminiAdapter
+from ai_clis.gemini import (
+    GeminiAdapter,
+    _read_gemini_key_from_env_file,
+    _stash_gemini_key,
+)
 
 
 @pytest.fixture
@@ -26,13 +31,15 @@ def dev_with_api_key():
         dev_id="bob",
         full_name="Bob Jones",
         email="bob@example.com",
-        gemini_api_key="test-api-key-12345",
+        gemini_api_key="AIzaTestKey12345",
     )
 
 
 def test_name():
     assert GeminiAdapter.name == "gemini"
 
+
+# ─── spawn_args ──────────────────────────────────────────────────────────────
 
 def test_spawn_args_sets_home(dev, tmp_path: Path):
     a = GeminiAdapter()
@@ -41,16 +48,25 @@ def test_spawn_args_sets_home(dev, tmp_path: Path):
     assert spawn.argv_prefix == ["gemini"]
 
 
-def test_spawn_args_omits_api_key_when_not_set(dev, tmp_path: Path):
+def test_spawn_args_omits_api_key_when_not_set_anywhere(dev, tmp_path: Path):
     a = GeminiAdapter()
     spawn = a.spawn_args(dev, tmp_path)
     assert "GEMINI_API_KEY" not in spawn.env
 
 
-def test_spawn_args_sets_api_key_when_present(dev_with_api_key, tmp_path: Path):
+def test_spawn_args_sets_api_key_from_dev_record(dev_with_api_key, tmp_path: Path):
     a = GeminiAdapter()
     spawn = a.spawn_args(dev_with_api_key, tmp_path)
-    assert spawn.env["GEMINI_API_KEY"] == "test-api-key-12345"
+    assert spawn.env["GEMINI_API_KEY"] == "AIzaTestKey12345"
+
+
+def test_spawn_args_sets_api_key_from_profile_env_file(dev, tmp_path: Path):
+    """Key stashed by `devbrain login` lands in <profile>/.devbrain/env;
+    spawn_args should pick it up even when the dev record has no key."""
+    _stash_gemini_key(tmp_path, "AIzaFromEnvFile")
+    a = GeminiAdapter()
+    spawn = a.spawn_args(dev, tmp_path)
+    assert spawn.env["GEMINI_API_KEY"] == "AIzaFromEnvFile"
 
 
 def test_spawn_args_sets_git_config_global(dev, tmp_path: Path):
@@ -59,19 +75,28 @@ def test_spawn_args_sets_git_config_global(dev, tmp_path: Path):
     assert spawn.env["GIT_CONFIG_GLOBAL"] == str(tmp_path / ".gitconfig")
 
 
-def test_is_logged_in_true_with_api_key(dev_with_api_key, tmp_path: Path):
+# ─── is_logged_in ────────────────────────────────────────────────────────────
+
+def test_is_logged_in_true_with_dev_record_api_key(dev_with_api_key, tmp_path: Path):
     a = GeminiAdapter()
     assert a.is_logged_in(dev_with_api_key, tmp_path) is True
 
 
-def test_is_logged_in_true_with_oauth_creds(dev, tmp_path: Path):
-    (tmp_path / ".gemini").mkdir()
-    (tmp_path / ".gemini" / "google_accounts.json").write_text("{}")
+def test_is_logged_in_true_with_profile_env_file_key(dev, tmp_path: Path):
+    _stash_gemini_key(tmp_path, "AIzaTestKey")
     a = GeminiAdapter()
     assert a.is_logged_in(dev, tmp_path) is True
 
 
-def test_is_logged_in_false_when_neither_present(dev, tmp_path: Path):
+def test_is_logged_in_false_when_no_key_anywhere(dev, tmp_path: Path):
+    a = GeminiAdapter()
+    assert a.is_logged_in(dev, tmp_path) is False
+
+
+def test_is_logged_in_false_when_only_old_oauth_creds(dev, tmp_path: Path):
+    """`google_accounts.json` is no longer the credential — env-file is."""
+    (tmp_path / ".gemini").mkdir()
+    (tmp_path / ".gemini" / "google_accounts.json").write_text("{}")
     a = GeminiAdapter()
     assert a.is_logged_in(dev, tmp_path) is False
 
@@ -79,40 +104,104 @@ def test_is_logged_in_false_when_neither_present(dev, tmp_path: Path):
 def test_required_dotfiles():
     a = GeminiAdapter()
     files = a.required_dotfiles()
-    assert ".gemini/" in files
+    assert ".devbrain/env" in files
     assert ".gitconfig" in files
 
 
-def test_login_with_api_key_skips_oauth(dev_with_api_key, tmp_path: Path):
+# ─── _stash_gemini_key + _read_gemini_key_from_env_file ──────────────────────
+
+def test_stash_and_read_round_trip(tmp_path: Path):
+    _stash_gemini_key(tmp_path, "AIzaRoundTripKey")
+    assert _read_gemini_key_from_env_file(tmp_path) == "AIzaRoundTripKey"
+
+
+def test_stash_creates_devbrain_dir(tmp_path: Path):
+    _stash_gemini_key(tmp_path, "AIzaKey")
+    assert (tmp_path / ".devbrain").is_dir()
+
+
+def test_stash_file_is_mode_600(tmp_path: Path):
+    _stash_gemini_key(tmp_path, "AIzaKey")
+    env_file = tmp_path / ".devbrain" / "env"
+    mode = oct(env_file.stat().st_mode)[-3:]
+    assert mode == "600"
+
+
+def test_stash_overwrites_existing_gemini_key(tmp_path: Path):
+    _stash_gemini_key(tmp_path, "AIzaOldKey")
+    _stash_gemini_key(tmp_path, "AIzaNewKey")
+    assert _read_gemini_key_from_env_file(tmp_path) == "AIzaNewKey"
+
+
+def test_stash_preserves_other_env_vars(tmp_path: Path):
+    """Other KEY=VALUE lines in .devbrain/env shouldn't be clobbered."""
+    env_dir = tmp_path / ".devbrain"
+    env_dir.mkdir()
+    (env_dir / "env").write_text("OTHER_VAR=preserved\nGEMINI_API_KEY=AIzaOld\n")
+    _stash_gemini_key(tmp_path, "AIzaNew")
+    content = (env_dir / "env").read_text()
+    assert "OTHER_VAR=preserved" in content
+    assert "GEMINI_API_KEY=AIzaNew" in content
+    assert "GEMINI_API_KEY=AIzaOld" not in content
+
+
+def test_read_returns_none_when_file_missing(tmp_path: Path):
+    assert _read_gemini_key_from_env_file(tmp_path) is None
+
+
+# ─── login() ─────────────────────────────────────────────────────────────────
+
+def test_login_with_api_key_on_dev_record_skips_prompt(
+    dev_with_api_key, tmp_path: Path
+):
     a = GeminiAdapter()
-    with patch("ai_clis.gemini.subprocess.run") as mock_run:
+    with patch("ai_clis.gemini._prompt_for_api_key") as mock_prompt:
         result = a.login(dev_with_api_key, tmp_path)
     assert result.success is True
-    assert "API_KEY" in result.hint
-    mock_run.assert_not_called()
+    mock_prompt.assert_not_called()
 
 
-def test_login_without_api_key_runs_gemini(dev, tmp_path: Path):
+def test_login_prompts_and_stashes_when_no_dev_record_key(dev, tmp_path: Path):
     a = GeminiAdapter()
-    with patch("ai_clis.gemini.subprocess.run", return_value=MagicMock(returncode=0)) as mock_run, \
-         patch.object(GeminiAdapter, "is_logged_in", return_value=True):
+    with patch("ai_clis.gemini._prompt_for_api_key", return_value="AIzaPastedByDev"):
         result = a.login(dev, tmp_path)
     assert result.success is True
-    args, kwargs = mock_run.call_args
-    assert args[0] == ["gemini"]
-    assert kwargs["env"]["HOME"] == str(tmp_path)
+    assert _read_gemini_key_from_env_file(tmp_path) == "AIzaPastedByDev"
 
 
-def test_login_handles_missing_cli(dev, tmp_path: Path):
+def test_login_rejects_empty_input(dev, tmp_path: Path):
     a = GeminiAdapter()
-    with patch("ai_clis.gemini.subprocess.run", side_effect=FileNotFoundError()):
+    with patch("ai_clis.gemini._prompt_for_api_key", return_value=""):
         result = a.login(dev, tmp_path)
     assert result.success is False
-    assert "not found" in result.error
+    assert "no API key" in result.error
+    assert _read_gemini_key_from_env_file(tmp_path) is None
 
 
-def test_login_returns_failure_on_nonzero_exit(dev, tmp_path: Path):
+def test_login_rejects_key_without_aiza_prefix(dev, tmp_path: Path):
     a = GeminiAdapter()
-    with patch("ai_clis.gemini.subprocess.run", return_value=MagicMock(returncode=1)):
+    with patch("ai_clis.gemini._prompt_for_api_key", return_value="not-a-real-key"):
         result = a.login(dev, tmp_path)
     assert result.success is False
+    assert "AIza" in result.error or "doesn't look like" in result.error
+    assert _read_gemini_key_from_env_file(tmp_path) is None
+
+
+def test_login_writes_mode_600_env_file(dev, tmp_path: Path):
+    a = GeminiAdapter()
+    with patch("ai_clis.gemini._prompt_for_api_key", return_value="AIzaSecure"):
+        a.login(dev, tmp_path)
+    env_file = tmp_path / ".devbrain" / "env"
+    mode = oct(env_file.stat().st_mode)[-3:]
+    assert mode == "600"
+
+
+def test_prompt_reads_from_provided_streams(tmp_path: Path):
+    """Decoupling streams lets tests drive the prompt without monkeypatching
+    sys.stdin globally."""
+    from ai_clis.gemini import _prompt_for_api_key
+    prompt_in = io.StringIO("AIzaFromStream\n")
+    prompt_out = io.StringIO()
+    result = _prompt_for_api_key(prompt_in=prompt_in, prompt_out=prompt_out)
+    assert result == "AIzaFromStream"
+    assert "API key" in prompt_out.getvalue()

--- a/factory/tests/test_onboarding_kit.py
+++ b/factory/tests/test_onboarding_kit.py
@@ -1,4 +1,4 @@
-"""Tests for the multi-CLI onboarding kit generator and rotate helper."""
+"""Tests for the redesigned onboarding kit generator and rotate helper."""
 from __future__ import annotations
 
 import json
@@ -9,7 +9,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from onboarding_kit import VALID_CLIS, VALID_PLATFORMS, write_onboarding_kit
+from onboarding_kit import (
+    VALID_AGENT_APPS,
+    VALID_CLIS,
+    VALID_PLATFORMS,
+    write_onboarding_kit,
+)
 
 
 COMMON_KWARGS = dict(
@@ -23,24 +28,52 @@ COMMON_KWARGS = dict(
     bootstrap_invite_id_short="abcd1234",
     bootstrap_expiry=datetime(2099, 1, 4, tzinfo=timezone.utc),
     ssh_host="lhts-mac-studio.local",
+    ssh_host_fingerprint="SHA256:test+fingerprint+for+unit+tests=",
 )
 
 
-def _write(tmp_path: Path, cli: str = "claude") -> str:
+def _write(tmp_path: Path, cli: str = "claude", **overrides) -> str:
+    kwargs = {**COMMON_KWARGS, **overrides}
     kit_path = tmp_path / f"alice-onboard-{cli}.md"
-    write_onboarding_kit(path=kit_path, cli=cli, **COMMON_KWARGS)
+    write_onboarding_kit(path=kit_path, cli=cli, **kwargs)
     return kit_path.read_text()
 
 
-# ─── Shared invariants ────────────────────────────────────────────────────────
+# ─── Validation + invariants ─────────────────────────────────────────────────
 
 def test_valid_clis_tuple():
     assert set(VALID_CLIS) == {"claude", "codex", "gemini"}
 
 
+def test_valid_platforms_tuple():
+    assert set(VALID_PLATFORMS) == {"auto", "mac", "linux", "windows"}
+
+
+def test_valid_agent_apps_tuple():
+    assert set(VALID_AGENT_APPS) == {
+        "auto",
+        "claude-desktop", "codex-desktop", "gemini-desktop",
+        "claude-cli", "codex-cli", "gemini-cli",
+    }
+
+
 def test_invalid_cli_raises(tmp_path):
     with pytest.raises(ValueError, match="cli must be one of"):
         write_onboarding_kit(path=tmp_path / "kit.md", cli="gpt4", **COMMON_KWARGS)
+
+
+def test_invalid_platform_raises(tmp_path):
+    with pytest.raises(ValueError, match="platform must be one of"):
+        write_onboarding_kit(
+            path=tmp_path / "kit.md", platform="bsd", **COMMON_KWARGS
+        )
+
+
+def test_invalid_agent_app_raises(tmp_path):
+    with pytest.raises(ValueError, match="agent_app must be one of"):
+        write_onboarding_kit(
+            path=tmp_path / "kit.md", agent_app="cursor", **COMMON_KWARGS
+        )
 
 
 def test_kit_file_mode_600(tmp_path):
@@ -51,6 +84,26 @@ def test_kit_file_mode_600(tmp_path):
     assert stat.S_IMODE(mode) == 0o600
 
 
+# ─── Frontmatter ─────────────────────────────────────────────────────────────
+
+def test_frontmatter_includes_axes(tmp_path):
+    """All three issuance axes (cli, platform, agent_app) appear in frontmatter."""
+    content = _write(tmp_path, cli="claude", platform="mac", agent_app="claude-desktop")
+    assert "cli: claude" in content
+    assert "platform: mac" in content
+    assert "agent_app: claude-desktop" in content
+
+
+def test_frontmatter_includes_invitation_id(tmp_path):
+    content = _write(tmp_path)
+    assert "devbrain_invite_id_short: abcd1234" in content
+
+
+def test_frontmatter_includes_host_fingerprint(tmp_path):
+    content = _write(tmp_path)
+    assert "SHA256:test+fingerprint+for+unit+tests=" in content
+
+
 def test_frontmatter_present_all_clis(tmp_path):
     for cli in VALID_CLIS:
         content = _write(tmp_path, cli)
@@ -59,28 +112,99 @@ def test_frontmatter_present_all_clis(tmp_path):
         assert f"cli: {cli}" in content
 
 
-def test_phase1_ssh_keygen_present_all_clis(tmp_path):
-    """Phase 1 (generate SSH keypair) must appear in every CLI's kit."""
+# ─── Phase 0: Trust banner ───────────────────────────────────────────────────
+
+def test_phase0_trust_banner_present_all_clis(tmp_path):
+    """Every kit leads with the trust banner."""
+    for cli in VALID_CLIS:
+        content = _write(tmp_path, cli)
+        assert "## Phase 0 — Verification" in content
+        assert "Lighthouse Therapy / DevBrain" in content
+        assert "SSH host key fingerprint" in content
+
+
+def test_phase0_includes_invitation_id_for_user_verification(tmp_path):
+    content = _write(tmp_path)
+    # The user/agent verifies the invitation ID matches what the admin said
+    assert "abcd1234" in content
+
+
+def test_phase0_includes_host_fingerprint_for_first_connect_verification(tmp_path):
+    content = _write(tmp_path)
+    assert "SHA256:test+fingerprint+for+unit+tests=" in content
+
+
+def test_phase0_falls_back_when_fingerprint_unset(tmp_path):
+    content = _write(tmp_path, ssh_host_fingerprint="")
+    assert "(verify on first SSH connect)" in content
+
+
+def test_phase0_asks_user_to_confirm_intent(tmp_path):
+    content = _write(tmp_path)
+    assert "agent:human" in content
+    assert "intent-confirmation" in content
+
+
+# ─── Phase 1: Environment check + dep install ────────────────────────────────
+
+def test_phase1_bash_present_when_platform_mac_or_linux(tmp_path):
+    for platform in ("mac", "linux"):
+        content = _write(tmp_path, platform=platform)
+        assert "macOS / Linux" in content
+        assert "command -v ssh" in content or "command -v \"$cmd\"" in content
+        # PowerShell variant should NOT appear when platform-specific
+        assert "Get-WindowsCapability" not in content
+
+
+def test_phase1_powershell_present_when_platform_windows(tmp_path):
+    content = _write(tmp_path, platform="windows")
+    assert "Get-WindowsCapability -Online -Name 'OpenSSH.Client*'" in content
+    assert "Add-WindowsCapability" in content
+    # Bash variant should NOT appear
+    assert "command -v" not in content
+
+
+def test_phase1_includes_both_when_platform_auto(tmp_path):
+    content = _write(tmp_path, platform="auto")
+    # Both shell variants present
+    assert "macOS / Linux" in content
+    assert "Get-WindowsCapability" in content
+
+
+# ─── Phase 2: Generate SSH keypair ───────────────────────────────────────────
+
+def test_phase2_ssh_keygen_present_all_clis(tmp_path):
+    """Every kit teaches the dev to generate a permanent ssh keypair."""
     for cli in VALID_CLIS:
         content = _write(tmp_path, cli)
         assert "ssh-keygen -t ed25519" in content
         assert "id_ed25519_devbrain" in content
 
 
-def test_phase4_bootstrap_key_block_present_all_clis(tmp_path):
-    """Phase 4 (stage bootstrap key) must appear in every CLI's kit."""
+def test_phase2_powershell_uses_userprofile_path(tmp_path):
+    """Windows variant uses %USERPROFILE% (PowerShell idiom), not ~/."""
+    content = _write(tmp_path, platform="windows")
+    assert "$env:USERPROFILE" in content
+
+
+# ─── Phase 3: Bootstrap key staging ──────────────────────────────────────────
+
+def test_phase3_bootstrap_key_block_present_all_clis(tmp_path):
     for cli in VALID_CLIS:
         content = _write(tmp_path, cli)
         assert "devbrain-bootstrap-alice" in content
-        assert "BOOTSTRAP_KEY_END" in content
 
 
-def test_phase8_verify_present_all_clis(tmp_path):
-    """Phase 8 (verify SSH + factory dashboard) must appear in every CLI's kit."""
-    for cli in VALID_CLIS:
-        content = _write(tmp_path, cli)
-        assert "lhtdev@lhts-mac-studio.local whoami" in content
-        assert "factory dashboard" in content
+def test_phase3_bash_uses_chmod_600(tmp_path):
+    content = _write(tmp_path, platform="mac")
+    assert "chmod 600" in content
+
+
+def test_phase3_powershell_uses_icacls(tmp_path):
+    """Windows ssh.exe rejects keys with loose ACLs — kit must lock them down."""
+    content = _write(tmp_path, platform="windows")
+    assert "icacls" in content
+    assert "/inheritance:r" in content
 
 
 def test_bootstrap_private_key_embedded(tmp_path):
@@ -88,127 +212,154 @@ def test_bootstrap_private_key_embedded(tmp_path):
     assert "FAKEKEY" in content
 
 
-# ─── Claude-specific ─────────────────────────────────────────────────────────
+# ─── Phase 4: Rotate pubkey to server ────────────────────────────────────────
 
-def test_claude_install_section(tmp_path):
-    content = _write(tmp_path, "claude")
-    assert "brew install --cask claude" in content
-    assert "claude /login" in content
+def test_phase4_payload_is_pubkey_only_all_clis(tmp_path):
+    """The rotate payload no longer carries credentials — pubkey only.
+
+    Targets the JSON shape inside the Phase 4 code block specifically.
+    Other parts of the kit can mention credential field names (e.g.,
+    `secret=gemini_api_key` agent metadata in Phase 5), but the rotate
+    request body itself must be pubkey-only.
+    """
+    for cli in VALID_CLIS:
+        content = _write(tmp_path, cli)
+        # Slice out Phase 4's content
+        p4_start = content.index("## Phase 4")
+        p5_start = content.index("## Phase 5")
+        p4 = content[p4_start:p5_start]
+        # Phase 4 carries only the pubkey field in its rotate payload
+        assert '"pubkey"' in p4
+        assert "oauth_token" not in p4
+        assert "codex_auth_json" not in p4
+        assert "gemini_api_key" not in p4
 
 
-def test_claude_token_section(tmp_path):
-    content = _write(tmp_path, "claude")
+def test_phase4_bash_uses_pipe_form(tmp_path):
+    """Phase 4's bash variant uses a regular pipe, not process substitution."""
+    content = _write(tmp_path, platform="mac")
+    assert "| ssh" in content
+    assert "< <(" not in content
+
+
+def test_phase4_powershell_uses_native_json(tmp_path):
+    content = _write(tmp_path, platform="windows")
+    assert "ConvertTo-Json" in content
+
+
+# ─── Phase 5: Server-side devbrain login ─────────────────────────────────────
+
+def test_phase5_invokes_devbrain_login(tmp_path):
+    for cli in VALID_CLIS:
+        content = _write(tmp_path, cli)
+        assert f"devbrain login --dev alice --cli {cli}" in content
+
+
+def test_phase5_uses_t_flag_for_interactive_session(tmp_path):
+    content = _write(tmp_path)
+    # -t flag is required for the paste-code-back interactive flow
+    assert " -t " in content or " -t \\\n" in content or "-t lhtdev@" in content
+
+
+def test_phase5_claude_mentions_setup_token_server_side(tmp_path):
+    content = _write(tmp_path, cli="claude")
     assert "claude setup-token" in content
-    assert "sk-ant-oat01-" in content
+    assert "server-side" in content
 
 
-def test_claude_rotation_payload(tmp_path):
-    content = _write(tmp_path, "claude")
-    assert "oauth_token" in content
-    # Should NOT mention codex_auth_json or gemini_api_key
-    assert "codex_auth_json" not in content
-    assert "gemini_api_key" not in content
-
-
-def test_claude_error_messages(tmp_path):
-    content = _write(tmp_path, "claude")
-    assert "oauth_token_rejected_by_anthropic" in content
-
-
-# ─── Codex-specific ───────────────────────────────────────────────────────────
-
-def test_codex_install_section(tmp_path):
-    content = _write(tmp_path, "codex")
-    assert "npm install" in content
-    assert "@openai/codex" in content
-
-
-def test_codex_login_section(tmp_path):
-    content = _write(tmp_path, "codex")
+def test_phase5_codex_mentions_device_auth(tmp_path):
+    content = _write(tmp_path, cli="codex")
     assert "codex login --device-auth" in content
-    assert "device-code" in content.lower() or "device code" in content.lower()
 
 
-def test_codex_token_section(tmp_path):
-    content = _write(tmp_path, "codex")
-    assert "auth.json" in content
-    assert ".codex" in content
-
-
-def test_codex_rotation_payload(tmp_path):
-    content = _write(tmp_path, "codex")
-    assert "codex_auth_json" in content
-    # Should NOT mention oauth_token or gemini_api_key
-    assert "oauth_token" not in content
-    assert "gemini_api_key" not in content
-
-
-def test_codex_error_messages(tmp_path):
-    content = _write(tmp_path, "codex")
-    assert "codex_auth_json_invalid" in content
-
-
-# ─── Gemini-specific ──────────────────────────────────────────────────────────
-
-def test_gemini_install_section(tmp_path):
-    content = _write(tmp_path, "gemini")
-    assert "npm install" in content
-    assert "@google/gemini-cli" in content
-
-
-def test_gemini_token_section(tmp_path):
-    content = _write(tmp_path, "gemini")
+def test_phase5_gemini_prompts_for_api_key(tmp_path):
+    content = _write(tmp_path, cli="gemini")
     assert "aistudio.google.com" in content
     assert "AIza" in content
 
 
-def test_gemini_rotation_payload(tmp_path):
-    content = _write(tmp_path, "gemini")
-    assert "gemini_api_key" in content
-    # Should NOT mention oauth_token or codex_auth_json
-    assert "oauth_token" not in content
-    assert "codex_auth_json" not in content
+def test_phase5_emphasizes_token_never_returns_to_dev(tmp_path):
+    """The whole point of the redesign — make this explicit in every kit.
+
+    The kit's preamble + Phase 0 + Phase 5 together must clearly state
+    that the auth credential never transits the dev's machine. We just
+    grep for the canonical phrase from Phase 0's invariants list.
+    """
+    for cli in VALID_CLIS:
+        content = _write(tmp_path, cli)
+        assert "never leaves the Mac Studio" in content
 
 
-def test_gemini_error_messages(tmp_path):
-    content = _write(tmp_path, "gemini")
-    assert "gemini_api_key_rejected" in content
+# ─── Phase 6: MCP wire-up + verify ───────────────────────────────────────────
 
-
-# ─── Backward compatibility ───────────────────────────────────────────────────
-
-def test_default_cli_is_claude(tmp_path):
-    """Calling write_onboarding_kit with no cli arg → claude kit."""
-    kit_path = tmp_path / "alice-default.md"
-    write_onboarding_kit(path=kit_path, **COMMON_KWARGS)
-    content = kit_path.read_text()
-    assert "brew install --cask claude" in content
-    assert "claude setup-token" in content
-    assert "oauth_token" in content
-
-
-def test_mcp_config_path_varies_by_cli(tmp_path):
-    """Each CLI's Phase 7 MCP config path must differ."""
+def test_phase6_mcp_config_path_varies_by_cli(tmp_path):
     from onboarding_kit import _MCP_CONFIG_PATHS
-    # Ensure each CLI has its own distinct config path
-    assert len(set(_MCP_CONFIG_PATHS.values())) == len(VALID_CLIS), \
-        f"Expected {len(VALID_CLIS)} distinct MCP config paths, got: {_MCP_CONFIG_PATHS}"
-
-    # Ensure each path appears in the corresponding CLI's kit content
+    assert len(set(_MCP_CONFIG_PATHS.values())) == len(VALID_CLIS)
     for cli in VALID_CLIS:
         content = _write(tmp_path, cli)
         assert _MCP_CONFIG_PATHS[cli] in content, \
             f"MCP config path {_MCP_CONFIG_PATHS[cli]!r} not found in {cli} kit"
 
 
-# ─── Rotate helper: accept each CLI's payload ─────────────────────────────────
+def test_phase6_verify_command_present_all_clis(tmp_path):
+    for cli in VALID_CLIS:
+        content = _write(tmp_path, cli)
+        assert "lhtdev@lhts-mac-studio.local" in content
+        assert "whoami" in content
+
+
+# ─── Phase 7: Cleanup ────────────────────────────────────────────────────────
+
+def test_phase7_removes_bootstrap_key_all_clis(tmp_path):
+    for cli in VALID_CLIS:
+        content = _write(tmp_path, cli)
+        # bash variant uses shred or rm
+        assert "rm -f ~/.ssh/devbrain-bootstrap-alice" in content \
+            or "shred -u ~/.ssh/devbrain-bootstrap-alice" in content
+        # PowerShell variant uses Remove-Item (when auto or windows)
+
+
+def test_phase7_powershell_uses_remove_item(tmp_path):
+    content = _write(tmp_path, platform="windows")
+    assert "Remove-Item" in content
+
+
+# ─── Agent-app axis ──────────────────────────────────────────────────────────
+
+def test_agent_app_appears_in_phase6_text(tmp_path):
+    """When the dev's agent app is specified, it's named in Phase 6 framing."""
+    content = _write(tmp_path, agent_app="claude-desktop")
+    assert "Claude Desktop" in content
+
+
+def test_agent_app_auto_uses_generic_phrasing(tmp_path):
+    content = _write(tmp_path, agent_app="auto")
+    assert "your AI agent" in content
+
+
+# ─── Default values ──────────────────────────────────────────────────────────
+
+def test_default_platform_is_auto(tmp_path):
+    """Omitting platform defaults to 'auto'."""
+    kit_default = tmp_path / "default.md"
+    kit_auto = tmp_path / "auto.md"
+    write_onboarding_kit(path=kit_default, **COMMON_KWARGS)
+    write_onboarding_kit(path=kit_auto, platform="auto", **COMMON_KWARGS)
+    assert kit_default.read_text() == kit_auto.read_text()
+
+
+def test_default_agent_app_is_auto(tmp_path):
+    kit_default = tmp_path / "default.md"
+    kit_auto = tmp_path / "auto.md"
+    write_onboarding_kit(path=kit_default, **COMMON_KWARGS)
+    write_onboarding_kit(path=kit_auto, agent_app="auto", **COMMON_KWARGS)
+    assert kit_default.read_text() == kit_auto.read_text()
+
+
+# ─── Rotate helper: pubkey-only payloads ─────────────────────────────────────
 
 def _run_helper(stdin_body: dict, invite_id_short: str = "abcd1234") -> int:
-    """Run onboard_rotate_helper.main() with mocked DB and stdin.
-
-    Returns the process exit code. The helper does lazy imports of FactoryDB
-    and DATABASE_URL inside main(), so we patch them at their source modules.
-    """
+    """Run onboard_rotate_helper.main() with mocked DB and stdin."""
     import io
     import onboard_rotate_helper as _h
 
@@ -235,8 +386,6 @@ def _run_helper(stdin_body: dict, invite_id_short: str = "abcd1234") -> int:
         original_stdin = sys.stdin
         sys.stdin = io.StringIO(json.dumps(stdin_body))
 
-        # Patch at the state_machine and config module level (where helper
-        # imports them lazily inside main()).
         with patch("state_machine.FactoryDB", mock_factory_db_cls), \
              patch("config.DATABASE_URL", "postgresql://fake/fake"):
             return _h.main()
@@ -245,29 +394,37 @@ def _run_helper(stdin_body: dict, invite_id_short: str = "abcd1234") -> int:
         sys.stdin = original_stdin
 
 
-def test_rotate_helper_accepts_claude_payload():
+def test_rotate_helper_accepts_claude_pubkey_only():
     body = {
         "pubkey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI alice@example.com",
         "cli": "claude",
-        "oauth_token": "sk-ant-oat01-FAKETOKEN",
     }
     assert _run_helper(body) == 0
 
 
-def test_rotate_helper_accepts_codex_payload():
+def test_rotate_helper_accepts_codex_pubkey_only():
     body = {
         "pubkey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI alice@example.com",
         "cli": "codex",
-        "codex_auth_json": {"accessToken": "sk-ant-oat01-FAKECODEXTOKEN", "other": "data"},
     }
     assert _run_helper(body) == 0
 
 
-def test_rotate_helper_accepts_gemini_payload():
+def test_rotate_helper_accepts_gemini_pubkey_only():
     body = {
         "pubkey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI alice@example.com",
         "cli": "gemini",
-        "gemini_api_key": "AIzaSyFAKEKEY",
+    }
+    assert _run_helper(body) == 0
+
+
+def test_rotate_helper_ignores_legacy_credential_fields():
+    """Older kits (pre-2026-05-07) shipped credentials in the rotate payload.
+    The new helper ignores those fields rather than rejecting."""
+    body = {
+        "pubkey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI alice@example.com",
+        "cli": "claude",
+        "oauth_token": "sk-ant-oat01-LEGACY-IGNORED",
     }
     assert _run_helper(body) == 0
 
@@ -276,7 +433,6 @@ def test_rotate_helper_rejects_bad_pubkey():
     body = {
         "pubkey": "not-a-valid-key",
         "cli": "claude",
-        "oauth_token": "sk-ant-oat01-FAKE",
     }
     assert _run_helper(body) == 2
 
@@ -285,77 +441,10 @@ def test_rotate_helper_rejects_unknown_cli():
     body = {
         "pubkey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI alice@example.com",
         "cli": "gpt5",
-        "oauth_token": "sk-ant-oat01-FAKE",
     }
     assert _run_helper(body) == 2
 
 
-def test_rotate_helper_missing_gemini_key_returns_error():
-    body = {
-        "pubkey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI alice@example.com",
-        "cli": "gemini",
-        # gemini_api_key intentionally omitted
-    }
+def test_rotate_helper_rejects_missing_pubkey():
+    body = {"cli": "claude"}
     assert _run_helper(body) == 2
-
-
-def test_rotate_helper_gemini_format_check():
-    """Gemini API keys must start with AIza."""
-    body = {
-        "pubkey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI alice@example.com",
-        "cli": "gemini",
-        "gemini_api_key": "not-a-google-key",
-    }
-    assert _run_helper(body) == 2
-
-
-# ─── Windows preflight (platform=windows) ─────────────────────────────────────
-
-
-def test_valid_platforms_tuple():
-    assert set(VALID_PLATFORMS) == {"auto", "mac", "linux", "windows"}
-
-
-def test_invalid_platform_raises(tmp_path):
-    with pytest.raises(ValueError, match="platform must be one of"):
-        write_onboarding_kit(
-            path=tmp_path / "kit.md", platform="bsd", **COMMON_KWARGS
-        )
-
-
-def test_windows_platform_includes_phase0(tmp_path):
-    """platform='windows' prepends a Phase 0 preflight section."""
-    kit_path = tmp_path / "alice-onboard-win.md"
-    write_onboarding_kit(path=kit_path, platform="windows", **COMMON_KWARGS)
-    content = kit_path.read_text()
-    assert "Phase 0 — Windows preflight" in content
-    # Verify-before-install pattern: the kit checks WSL status BEFORE
-    # offering to install — never blindly runs the installer.
-    assert "wsl --status" in content
-    assert "if installed:" in content.lower() or "if Step 0.1 reported missing" in content
-    # Apt prereqs are also verified before install (Step 0.3 → 0.4).
-    assert "command -v" in content
-    assert "for cmd in jq ssh curl openssl" in content
-
-
-def test_non_windows_platforms_omit_phase0(tmp_path):
-    """auto / mac / linux must NOT emit the Windows preflight."""
-    for plat in ("auto", "mac", "linux"):
-        kit_path = tmp_path / f"alice-onboard-{plat}.md"
-        write_onboarding_kit(
-            path=kit_path, platform=plat, **COMMON_KWARGS
-        )
-        content = kit_path.read_text()
-        assert "Phase 0 — Windows preflight" not in content, (
-            f"platform={plat!r} should not emit Phase 0"
-        )
-
-
-def test_default_platform_is_auto(tmp_path):
-    """Omitting the platform kwarg defaults to 'auto' — same shape as
-    explicit 'auto'."""
-    kit_default = tmp_path / "default.md"
-    kit_auto = tmp_path / "auto.md"
-    write_onboarding_kit(path=kit_default, **COMMON_KWARGS)
-    write_onboarding_kit(path=kit_auto, platform="auto", **COMMON_KWARGS)
-    assert kit_default.read_text() == kit_auto.read_text()


### PR DESCRIPTION
## Summary

Implements steps 2-5 of the redesign in `docs/plans/2026-05-07-onboarding-server-side-auth-design.md` (#111). Step 1 (Claude adapter) shipped in #112.

**The whole point:** the dev's AI subscription auth credential never transits the dev's machine. It's generated server-side inside the dev's profile dir on the Mac Studio and stays there. The kit on the dev's box only does SSH connectivity setup.

## Changes

| File | Δ | Purpose |
|---|---|---|
| `factory/onboard_rotate.sh` | -164 LOC | Drop per-CLI credential extraction + API validation; payload is now `{"pubkey":"..."}` only |
| `factory/onboard_rotate_helper.py` | -60 LOC | Persist pubkey only; ignore legacy credential fields |
| `factory/onboard_reconciler.py` | +15 LOC | Tolerate NULL oauth_token at activation; differentiate notification text |
| `factory/ai_clis/gemini.py` | rewrite | Prompt-based API-key login (replaces unverified OAuth path); env-file stash |
| `factory/onboarding_kit.py` | rewrite | Trust banner + `--agent-app` axis + bash/PowerShell variants + pubkey-only Phase 4 + server-side `devbrain login` Phase 5 |
| `factory/setup.py` | +60 LOC | New `--agent-app` arg; SSH host fingerprint discovery |
| `factory/onboarding_email.py` | rewrite | Body branches on agent_app; new "auto" mode lists install pointers |

## Test plan

- [x] 528 / 0 failed across full factory suite (was 504 / 0 before this PR)
- [x] Bash syntax check passes on `factory/onboard_rotate.sh`
- [x] All modules import cleanly; `setup.setup_add_dev` signature gained `agent_app`
- [x] 49 kit tests covering agent-app axis, host fingerprint embedding, Phase 0 trust banner, Phase 4 pubkey-only payload, bash/PowerShell variant selection
- [x] 23 Gemini adapter tests covering prompt-based login + env-file stash
- [ ] End-to-end: re-onboard Mark + Mike under the new flow (step 6 of redesign — landing in a follow-up after merge)

## Notes for review

- The empirical verification of `claude setup-token`'s paste-back path that was outstanding in #112 is still pending (Patrick was going to drive it). The adapter code in #112 already merged on the assumption it works; this PR doesn't change that assumption. If the assumption breaks, the Claude path will need a separate adapter fix; the rest of this PR (rotate simplification, agent-app axis, PowerShell variants, Gemini overhaul) holds either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)