### PR TITLE
fix(adapter): broaden Claude OAuth token regex; strip intra-token TTY escapes

### DIFF
--- a/factory/ai_clis/claude.py
+++ b/factory/ai_clis/claude.py
@@ -58,9 +58,21 @@ _PASSWORD_REL = Path(".claude") / ".keychain-password"
 _OAUTH_TOKEN_REL = Path(".claude") / "oauth-token"
 _FAKEBIN_REL = Path(".claude") / ".devbrain-fakebin"
 
-# `claude setup-token` prints the issued token verbatim in its output stream.
-# Pattern: sk-ant-oat01- followed by url-safe base64-ish chars.
-_OAUTH_TOKEN_RE = re.compile(r"sk-ant-oat01-[A-Za-z0-9_\-]+")
+# `claude setup-token` prints the issued token in its TTY output. Two
+# wrinkles caught in the 2026-05-08 E2E test:
+#   1. Anthropic's actual prefix is `sk-ant-oatN-` where N is one or
+#      more digits (observed `sk-ant-oat1-` against claude 2.1.132,
+#      vs `sk-ant-oat01-` shown in their docs). Match a digit run.
+#   2. `script(1)` captures the rendered TTY stream including cursor-
+#      positioning escapes that claude injects MID-TOKEN to display
+#      it across visual lines (`\x1b[1C` cursor right, `\r\x1b[1B`
+#      CR + cursor down 1 = visual line wrap). We strip those so the
+#      token reassembles contiguously, but we LEAVE post-token escapes
+#      like `\x1b[2B` (cursor down 2 = paragraph break) intact so the
+#      regex stops at the right place rather than slurping the next
+#      message ("Store this token securely…").
+_OAUTH_TOKEN_RE = re.compile(r"sk-ant-oat\d+-[A-Za-z0-9_\-]+")
+_TOKEN_NOISE_RE = re.compile(r"\x1b\[1C|\r\x1b\[1B")
 
 
 def _read_or_generate_keychain_password(profile_dir: Path) -> str:
@@ -133,12 +145,16 @@ def _ensure_keychain(profile_dir: Path) -> Path:
 
 
 def _extract_oauth_token(text: str) -> str | None:
-    """Find the first sk-ant-oat01-... token in claude setup-token output.
+    """Find the first sk-ant-oatN-... token in claude setup-token output.
 
-    Captured TTY output from script(1) contains escape sequences and
-    interleaved status lines; just scan for the token pattern.
+    Strips intra-token cursor-positioning escapes (cursor-right and
+    single-line wraps) so the token reassembles contiguously. Post-
+    token escapes (cursor-down-2 and beyond) are deliberately left in
+    place so the regex stops at the message boundary rather than
+    slurping subsequent text.
     """
-    match = _OAUTH_TOKEN_RE.search(text)
+    cleaned = _TOKEN_NOISE_RE.sub("", text)
+    match = _OAUTH_TOKEN_RE.search(cleaned)
     return match.group(0) if match else None
 
 
@@ -241,7 +257,7 @@ class ClaudeAdapter(AICliAdapter):
         if token is None:
             return LoginResult(
                 success=False,
-                error="claude setup-token completed but no sk-ant-oat01-... token found in captured output",
+                error="claude setup-token completed but no sk-ant-oatN-... token found in captured output",
                 hint="The OAuth flow may not have completed — verify you signed in and pasted the verification code.",
             )
 

--- a/factory/tests/test_ai_cli_claude.py
+++ b/factory/tests/test_ai_cli_claude.py
@@ -100,6 +100,39 @@ def test_extract_oauth_token_handles_ansi_escapes():
     assert _extract_oauth_token(text) == "sk-ant-oat01-tok_with_dashes-and_underscores"
 
 
+def test_extract_oauth_token_handles_cursor_positioning_inside_token():
+    """Real-world reproduction from the 2026-05-08 E2E test: claude renders
+    the token across visual TTY lines by injecting `\\x1b[1C` (cursor right)
+    and `\\r\\x1b[1B` (CR + cursor down) escapes mid-token. The extractor
+    strips those before matching."""
+    real_world_capture = (
+        "Long-lived authentication token created successfully!\n"
+        "sk-ant-oat\x1b[1C1-fO5B\x1b[1CyG_n4rstUKSfpUzIAT37ppUyqpgXKwjHa6"
+        "fneODMXTqCCA-25WUIqqiE4Al0Zr\r\x1b[1B4TcP0P7q1U-4m6C_x-A-6uvrsAAA\r\x1b[2B"
+        "Store this token securely.\n"
+    )
+    expected = (
+        "sk-ant-oat1-fO5ByG_n4rstUKSfpUzIAT37ppUyqpgXKwjHa6"
+        "fneODMXTqCCA-25WUIqqiE4Al0Zr4TcP0P7q1U-4m6C_x-A-6uvrsAAA"
+    )
+    assert _extract_oauth_token(real_world_capture) == expected
+
+
+def test_extract_oauth_token_accepts_oat_prefix_with_one_digit():
+    """Anthropic's actual prefix observed in the wild is `sk-ant-oat1-`,
+    not `sk-ant-oat01-` as the docs imply. The regex is permissive on
+    the digit run."""
+    text = "Token: sk-ant-oat1-AbCdEf\n"
+    assert _extract_oauth_token(text) == "sk-ant-oat1-AbCdEf"
+
+
+def test_extract_oauth_token_accepts_oat_prefix_with_two_digits():
+    """Documented prefix per Anthropic's auth docs is `sk-ant-oat01-`.
+    Regex still matches it."""
+    text = "Token: sk-ant-oat01-AbCdEf\n"
+    assert _extract_oauth_token(text) == "sk-ant-oat01-AbCdEf"
+
+
 def test_extract_oauth_token_picks_first_match_when_multiple():
     text = "first sk-ant-oat01-FIRST then sk-ant-oat01-SECOND"
     assert _extract_oauth_token(text) == "sk-ant-oat01-FIRST"
@@ -251,7 +284,7 @@ def test_login_returns_failure_on_nonzero_exit(
 def test_login_returns_failure_when_token_not_in_log(
     mock_run, mock_keychain, dev, tmp_path: Path
 ):
-    """If claude exits 0 but no sk-ant-oat01-... in captured output, fail."""
+    """If claude exits 0 but no sk-ant-oatN-... in captured output, fail."""
     def no_token_run(*args, **kwargs):
         cmd = args[0]
         if cmd[0] == "script":
@@ -263,7 +296,7 @@ def test_login_returns_failure_when_token_not_in_log(
     a = ClaudeAdapter()
     result = a.login(dev, tmp_path)
     assert result.success is False
-    assert "no sk-ant-oat01" in result.error
+    assert "no sk-ant-oatN" in result.error
 
 
 @patch("ai_clis.claude._ensure_keychain")


### PR DESCRIPTION
## Summary

E2E test on 2026-05-08 issued a real `claude setup-token` token end-to-end against the adapter shipped in #112. Both halves of the flow worked (URL print + paste-code-back exchange + token issuance), but the adapter's extraction code couldn't pick the token out of the captured output. Two bugs:

1. **Wrong prefix anchor.** Anthropic's actual format is `sk-ant-oatN-` (observed `sk-ant-oat1-` against claude 2.1.132); their auth docs show `sk-ant-oat01-`. The regex was anchored on the docs format. Widened to `sk-ant-oat\d+-`.

2. **TTY cursor-positioning escapes interleaved mid-token.** `script(1)` captures the rendered TTY stream verbatim, and claude renders the token across visual lines using `\x1b[1C` (cursor right) and `\r\x1b[1B` (CR + cursor down 1) escapes. The bytes look like `sk-ant-oat\x1b[1C1-fO5B\x1b[1CyG_...Al0Zr\r\x1b[1B4TcP...` — not contiguous. Strip just those *intra-token* escapes; deliberately leave the post-token `\x1b[2B` (cursor down 2 = paragraph break) intact so the regex stops at the message boundary instead of slurping the next message ("Store this token securely…").

## Test plan

- [x] 27 / 0 claude adapter tests
- [x] 531 / 0 across full factory suite
- [x] Two new tests:
  - `test_extract_oauth_token_handles_cursor_positioning_inside_token` — real-world capture lifted byte-for-byte from the 2026-05-08 probe; reassembly must produce the exact token
  - `test_extract_oauth_token_accepts_oat_prefix_with_one_digit` + `…_two_digits` — prefix permissiveness across both observed and documented formats
- [x] Verified end-to-end against the real `claude setup-token` flow

## Notes

Observed token prefix is `sk-ant-oat1-` not `sk-ant-oat01-`. The kit's user-facing text in `factory/onboarding_kit.py` still mentions `sk-ant-oat01-...` in places (matching Anthropic's docs). Not changing that text in this PR — the kit's mention is informational for the dev/agent, not a parser anchor — but worth a follow-up if we want the kit to match observed reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)