### PR TITLE
feat(onboarding): inline-reconcile after rotate handler success

### DIFF
--- a/factory/onboard_rotate_helper.py
+++ b/factory/onboard_rotate_helper.py
@@ -83,6 +83,20 @@ def main() -> int:
 
     inv_id, dev_id, status = row
     print(f"rotated dev={dev_id} invite={str(inv_id)[:8]} cli={cli} status={status}")
+
+    # Inline reconciliation: activate immediately so the dev's pubkey
+    # lands in authorized_keys before they retry SSH. The launchd
+    # reconciler daemon (com.devbrain.reconciler) is a safety net if
+    # this inline path fails for any reason (DB hiccup, transient
+    # filesystem error, mid-handler crash before this point ran). Best-
+    # effort: a failure here doesn't fail the rotate response — the
+    # daemon will pick up the row on its next tick.
+    try:
+        from onboard_reconciler import reconcile_once
+        reconcile_once(db)
+    except Exception as e:
+        print(f"inline-reconcile failed (daemon will retry): {e}", file=sys.stderr)
+
     return 0
 
 

--- a/factory/tests/test_onboarding_kit.py
+++ b/factory/tests/test_onboarding_kit.py
@@ -448,3 +448,90 @@ def test_rotate_helper_rejects_unknown_cli():
 def test_rotate_helper_rejects_missing_pubkey():
     body = {"cli": "claude"}
     assert _run_helper(body) == 2
+
+
+def test_rotate_helper_triggers_inline_reconcile_on_success():
+    """After a successful pubkey rotation, the helper should call
+    `reconcile_once` synchronously so the dev's pubkey lands in
+    authorized_keys before they retry SSH — eliminating the launchd-
+    reconciler-not-running race condition that bit Mike on 2026-05-08."""
+    import io
+    import onboard_rotate_helper as _h
+
+    fake_row = ("some-uuid-here", "alice", "ready")
+
+    mock_cur = MagicMock()
+    mock_cur.fetchone.return_value = fake_row
+    mock_cur.__enter__ = lambda s: s
+    mock_cur.__exit__ = MagicMock(return_value=False)
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cur
+    mock_conn.__enter__ = lambda s: s
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_db = MagicMock()
+    mock_db._conn.return_value = mock_conn
+
+    body = {
+        "pubkey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI alice@example.com",
+        "cli": "claude",
+    }
+
+    original_argv = sys.argv
+    original_stdin = sys.stdin
+    try:
+        sys.argv = ["onboard_rotate_helper.py", "--invite-id-short", "abcd1234"]
+        sys.stdin = io.StringIO(json.dumps(body))
+        with patch("state_machine.FactoryDB", MagicMock(return_value=mock_db)), \
+             patch("config.DATABASE_URL", "postgresql://fake/fake"), \
+             patch("onboard_reconciler.reconcile_once") as mock_reconcile:
+            rc = _h.main()
+    finally:
+        sys.argv = original_argv
+        sys.stdin = original_stdin
+
+    assert rc == 0
+    mock_reconcile.assert_called_once_with(mock_db)
+
+
+def test_rotate_helper_succeeds_even_when_inline_reconcile_raises():
+    """Inline reconciliation is best-effort. If it raises (DB hiccup,
+    permission error, etc.) the helper still returns success — the
+    launchd daemon catches the row on its next tick as fallback."""
+    import io
+    import onboard_rotate_helper as _h
+
+    fake_row = ("some-uuid-here", "alice", "ready")
+
+    mock_cur = MagicMock()
+    mock_cur.fetchone.return_value = fake_row
+    mock_cur.__enter__ = lambda s: s
+    mock_cur.__exit__ = MagicMock(return_value=False)
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cur
+    mock_conn.__enter__ = lambda s: s
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_db = MagicMock()
+    mock_db._conn.return_value = mock_conn
+
+    body = {
+        "pubkey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI alice@example.com",
+        "cli": "claude",
+    }
+
+    original_argv = sys.argv
+    original_stdin = sys.stdin
+    try:
+        sys.argv = ["onboard_rotate_helper.py", "--invite-id-short", "abcd1234"]
+        sys.stdin = io.StringIO(json.dumps(body))
+        with patch("state_machine.FactoryDB", MagicMock(return_value=mock_db)), \
+             patch("config.DATABASE_URL", "postgresql://fake/fake"), \
+             patch("onboard_reconciler.reconcile_once",
+                   side_effect=RuntimeError("simulated transient failure")):
+            rc = _h.main()
+    finally:
+        sys.argv = original_argv
+        sys.stdin = original_stdin
+
+    # Helper still returns 0 — the SSH client gets {"status":"ok"} and
+    # the daemon picks up the still-ready row asynchronously.
+    assert rc == 0


### PR DESCRIPTION
## Summary

Eliminates the activation-latency race that bit Mike on 2026-05-08. The rotate handler now calls `reconcile_once(db)` synchronously after marking the row `ready`, so the dev's pubkey lands in `authorized_keys` *before* the rotate SSH command returns to them.

## Why this matters

Even with the launchd reconciler daemon installed (PR #117), there's a 1-30s polling window where a dev's `Phase 4 succeeded → SSH retry` sequence could race the daemon's tick. Inline reconciliation closes the window to zero — by the time the dev sees `{"status":"ok"}`, their permanent key is already authorized.

## Best-effort semantics

If `reconcile_once` raises (transient DB error, FS permission glitch, etc.), the helper still returns `{"status":"ok"}` to the dev. The row IS in `ready` state, so the launchd daemon catches it on its next 30s tick. The daemon's role flips: was load-bearing → now safety net for failure modes that shouldn't occur but might.

## Test plan

- [x] 2 new tests in `test_onboarding_kit.py`:
  - `test_rotate_helper_triggers_inline_reconcile_on_success` — verifies `reconcile_once` is called with the helper's `db` handle on the happy path.
  - `test_rotate_helper_succeeds_even_when_inline_reconcile_raises` — verifies failure semantics (raise → log → return 0; row stays ready for daemon retry).
- [x] 537 / 0 passed across full factory suite (was 535).

🤖 Generated with [Claude Code](https://claude.com/claude-code)