### PR TITLE
feat(cognify): accept subscription OAuth tokens for LLM passes

### DIFF
--- a/factory/cognify/_anthropic_auth.py
+++ b/factory/cognify/_anthropic_auth.py
@@ -1,0 +1,44 @@
+"""Anthropic credential resolution for cognify's LLM passes.
+
+The cognify pipeline's extract + edges passes call the Anthropic API
+to derive lessons / contradictions from session content. Two credential
+shapes are accepted:
+
+  1. Console API key — `sk-ant-api03-...`. Created at
+     console.anthropic.com → Settings → API keys. Sent by the SDK as
+     the `X-Api-Key` header. Set via env var `ANTHROPIC_API_KEY`.
+
+  2. Subscription OAuth token — `sk-ant-oat<N>-...`. Created by
+     `claude setup-token` against a Pro/Max/Team/Enterprise account.
+     Sent by the SDK as `Authorization: Bearer`. Set via env var
+     `CLAUDE_CODE_OAUTH_TOKEN` (the name Claude Code's docs use) or
+     `ANTHROPIC_AUTH_TOKEN` (the name the SDK's auth-precedence docs
+     use). Either works — both resolve to the same SDK kwarg.
+
+Returns the kwargs to pass into `anthropic.Anthropic(...)`. Returns
+None when no credential is available; callers should skip the LLM
+work gracefully.
+"""
+from __future__ import annotations
+
+import os
+
+
+def resolve_anthropic_auth() -> dict[str, str] | None:
+    """Return SDK kwargs dict, or None if no credential present.
+
+    Precedence: ANTHROPIC_API_KEY (Console) wins if set, since it gives
+    deterministic per-call billing; OAuth bearer tokens are the fallback.
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if api_key:
+        return {"api_key": api_key}
+
+    bearer = (
+        os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+        or os.environ.get("ANTHROPIC_AUTH_TOKEN")
+    )
+    if bearer:
+        return {"auth_token": bearer}
+
+    return None

--- a/factory/cognify/edges.py
+++ b/factory/cognify/edges.py
@@ -333,12 +333,12 @@ def _llm_judge_contradiction(
     except ImportError:
         return False, _empty_usage
 
-    import os
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
+    from cognify._anthropic_auth import resolve_anthropic_auth
+    auth_kwargs = resolve_anthropic_auth()
+    if auth_kwargs is None:
         return False, _empty_usage
 
-    client = anthropic.Anthropic(api_key=api_key)
+    client = anthropic.Anthropic(**auth_kwargs)
     prompt = (
         "Do these two memory entries contradict each other? "
         "Reply with only 'YES' or 'NO'.\n\n"

--- a/factory/cognify/extract.py
+++ b/factory/cognify/extract.py
@@ -379,12 +379,16 @@ def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
         logger.warning("cognify_extract: anthropic SDK not available; skipping LLM")
         return {"lessons": [], "decisions": [], "_usage": _empty_usage}
 
-    api_key = _get_api_key()
-    if not api_key:
-        logger.warning("cognify_extract: no API key configured; skipping LLM")
+    auth_kwargs = _resolve_auth()
+    if auth_kwargs is None:
+        logger.warning(
+            "cognify_extract: no Anthropic credential configured "
+            "(ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_AUTH_TOKEN); "
+            "skipping LLM"
+        )
         return {"lessons": [], "decisions": [], "_usage": _empty_usage}
 
-    client = anthropic.Anthropic(api_key=api_key)
+    client = anthropic.Anthropic(**auth_kwargs)
 
     system_prompt = (
         "You are a structured knowledge extractor. Given raw session content, "
@@ -434,8 +438,19 @@ def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
         return {"lessons": [], "decisions": [], "_usage": _empty_usage}
 
 
+def _resolve_auth() -> dict[str, str] | None:
+    """Resolve Anthropic credential to SDK kwargs (api_key= or auth_token=).
+
+    Accepts a Console API key OR a subscription OAuth token; the SDK
+    routes them through different headers. See cognify._anthropic_auth
+    for the resolution order and accepted env var names.
+    """
+    from cognify._anthropic_auth import resolve_anthropic_auth
+    return resolve_anthropic_auth()
+
+
 def _get_api_key() -> str | None:
-    """Resolve the Anthropic API key from environment or config."""
+    """Deprecated — kept for any external callers. Use _resolve_auth()."""
     import os
     return os.environ.get("ANTHROPIC_API_KEY")
 

--- a/factory/tests/test_cognify_anthropic_auth.py
+++ b/factory/tests/test_cognify_anthropic_auth.py
@@ -1,0 +1,76 @@
+"""Tests for cognify._anthropic_auth.
+
+Resolution order:
+  1. ANTHROPIC_API_KEY (Console key, X-Api-Key header → `api_key=`)
+  2. CLAUDE_CODE_OAUTH_TOKEN (subscription OAuth, Bearer → `auth_token=`)
+  3. ANTHROPIC_AUTH_TOKEN (same shape as 2, Anthropic-docs name)
+  4. None → caller skips LLM work gracefully
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from cognify._anthropic_auth import resolve_anthropic_auth
+
+
+def _isolated_env(**vars):
+    """Strip the target env vars to start clean, then layer in `vars`."""
+    base = {k: v for k, v in os.environ.items()
+            if k not in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN")}
+    base.update(vars)
+    return base
+
+
+def test_returns_none_when_no_credential():
+    with patch.dict(os.environ, _isolated_env(), clear=True):
+        assert resolve_anthropic_auth() is None
+
+
+def test_console_api_key_routes_to_api_key_kwarg():
+    with patch.dict(os.environ, _isolated_env(ANTHROPIC_API_KEY="sk-ant-api03-FAKE"), clear=True):
+        assert resolve_anthropic_auth() == {"api_key": "sk-ant-api03-FAKE"}
+
+
+def test_oauth_token_routes_to_auth_token_kwarg():
+    with patch.dict(os.environ, _isolated_env(CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat1-FAKE"), clear=True):
+        assert resolve_anthropic_auth() == {"auth_token": "sk-ant-oat1-FAKE"}
+
+
+def test_anthropic_auth_token_also_routes_to_auth_token():
+    with patch.dict(os.environ, _isolated_env(ANTHROPIC_AUTH_TOKEN="sk-ant-oat1-OTHER"), clear=True):
+        assert resolve_anthropic_auth() == {"auth_token": "sk-ant-oat1-OTHER"}
+
+
+def test_console_key_wins_over_oauth_when_both_set():
+    """If both shapes are configured, prefer Console (deterministic billing)."""
+    env = _isolated_env(
+        ANTHROPIC_API_KEY="sk-ant-api03-WINS",
+        CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat1-LOSES",
+    )
+    with patch.dict(os.environ, env, clear=True):
+        result = resolve_anthropic_auth()
+        assert result == {"api_key": "sk-ant-api03-WINS"}
+        assert "auth_token" not in result
+
+
+def test_claude_code_token_wins_over_generic_auth_token():
+    """When both bearer-style envs are set, prefer the Claude Code one
+    (the documented Claude Code env var name; more idiomatic)."""
+    env = _isolated_env(
+        CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat1-FROM-CLAUDE-CODE",
+        ANTHROPIC_AUTH_TOKEN="sk-ant-oat1-FROM-GENERIC",
+    )
+    with patch.dict(os.environ, env, clear=True):
+        assert resolve_anthropic_auth() == {"auth_token": "sk-ant-oat1-FROM-CLAUDE-CODE"}
+
+
+def test_empty_string_env_treated_as_unset():
+    """An empty string for ANTHROPIC_API_KEY should fall through to OAuth, not
+    return {"api_key": ""} which the SDK would reject."""
+    env = _isolated_env(
+        ANTHROPIC_API_KEY="",
+        CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat1-USE-ME",
+    )
+    with patch.dict(os.environ, env, clear=True):
+        assert resolve_anthropic_auth() == {"auth_token": "sk-ant-oat1-USE-ME"}


### PR DESCRIPTION
## Summary

Cognify's `extract` + `edges` passes have always read `ANTHROPIC_API_KEY` (Console key, `X-Api-Key` header) and bombed if it wasn't set. Patrick uses a Claude Max subscription with OAuth — no Console key — so these two LLM passes have **never actually run** on either his laptop or Mac Studio.

New `cognify._anthropic_auth.resolve_anthropic_auth()` returns the right kwargs for `anthropic.Anthropic(...)`:

| Env var | SDK kwarg | Header |
|---|---|---|
| `ANTHROPIC_API_KEY` | `api_key=` | `X-Api-Key` |
| `CLAUDE_CODE_OAUTH_TOKEN` | `auth_token=` | `Authorization: Bearer` |
| `ANTHROPIC_AUTH_TOKEN` | `auth_token=` | `Authorization: Bearer` |

Console key wins if both shapes are configured (deterministic billing surface). Empty string treated as unset.

`extract.py` and `edges.py` swap their inline lookups for `resolve_anthropic_auth()`. Existing Console-key callers see no behavior change; the new OAuth path lights up cognify's LLM passes against a Max/Pro/Team subscription token issued by `claude setup-token`.

## Operational deployment after merge

```bash
# Run once on a machine with a browser:
claude setup-token
# (paste the resulting sk-ant-oat1-... value)

# On both machines, add to .env:
echo "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat1-..." >> ~/devbrain/.env

# Reload cognify launchd jobs on Mac Studio:
launchctl unload ~/Library/LaunchAgents/com.devbrain.cognify-extract.plist
launchctl load   ~/Library/LaunchAgents/com.devbrain.cognify-extract.plist
launchctl unload ~/Library/LaunchAgents/com.devbrain.cognify-edges.plist
launchctl load   ~/Library/LaunchAgents/com.devbrain.cognify-edges.plist
```

Same token works on both machines. Token never appears in plists or world-readable files (`.env` is mode 600).

## Test plan

- [x] 7 new tests in `test_cognify_anthropic_auth.py` covering precedence + edge cases
- [x] 544 passed / 0 failed across full factory suite (was 537)
- [x] Existing `extract.py` and `edges.py` skip-when-no-credential paths preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)