### PR TITLE
fix(cognify): add Claude Code SDK fingerprint to OAuth path (completes #119)

### DIFF
--- a/factory/cognify/_anthropic_auth.py
+++ b/factory/cognify/_anthropic_auth.py
@@ -18,17 +18,48 @@ shapes are accepted:
 Returns the kwargs to pass into `anthropic.Anthropic(...)`. Returns
 None when no credential is available; callers should skip the LLM
 work gracefully.
+
+OAuth path notes
+----------------
+For subscription OAuth tokens to be honored at `/v1/messages`, Anthropic
+requires two things beyond the Bearer header alone:
+
+  * `anthropic-beta: oauth-2025-04-20` request header — added here via
+    `default_headers` so every SDK call carries it.
+  * The request's first system block must be the Claude Code SDK
+    fingerprint string (see `claude_code_system_prefix`). Without it,
+    `/v1/messages` returns 429 `rate_limit_error` with a terse "Error"
+    body — not a real rate limit, an identity-gate rejection masked as
+    one. Callers must prepend the prefix to their system prompt when
+    this resolver returns the OAuth shape.
 """
 from __future__ import annotations
 
 import os
+from typing import Any
+
+# Required `anthropic-beta` header value for subscription OAuth.
+_OAUTH_BETA_HEADER = "oauth-2025-04-20"
+
+# Claude Code SDK fingerprint baked into the official binary. Anthropic
+# gates subscription OAuth on the request's first system block matching
+# this string literally.
+_CLAUDE_CODE_SYSTEM_PREFIX = (
+    "You are Claude Code, Anthropic's official CLI for Claude, "
+    "running within the Claude Agent SDK."
+)
 
 
-def resolve_anthropic_auth() -> dict[str, str] | None:
+def resolve_anthropic_auth() -> dict[str, Any] | None:
     """Return SDK kwargs dict, or None if no credential present.
 
     Precedence: ANTHROPIC_API_KEY (Console) wins if set, since it gives
     deterministic per-call billing; OAuth bearer tokens are the fallback.
+
+    Console path returns: ``{"api_key": "<value>"}``.
+    OAuth path returns: ``{"auth_token": "<value>", "default_headers":
+    {"anthropic-beta": "oauth-2025-04-20"}}`` — and callers must also
+    prepend ``claude_code_system_prefix()`` to their system prompt.
     """
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if api_key:
@@ -39,6 +70,32 @@ def resolve_anthropic_auth() -> dict[str, str] | None:
         or os.environ.get("ANTHROPIC_AUTH_TOKEN")
     )
     if bearer:
-        return {"auth_token": bearer}
+        return {
+            "auth_token": bearer,
+            "default_headers": {"anthropic-beta": _OAUTH_BETA_HEADER},
+        }
 
+    return None
+
+
+def claude_code_system_prefix() -> str | None:
+    """Return the system-prompt fingerprint string for the OAuth path.
+
+    Returns the Claude Code SDK fingerprint when the active credential
+    is a subscription OAuth token; returns None when the active
+    credential is a Console API key (no prefix needed) or when no
+    credential is configured.
+
+    Callers should prepend the returned string as the *first* system
+    block (above their own task-specific system prompt). Without it,
+    `/v1/messages` rejects OAuth-token requests with a 429
+    `rate_limit_error` — an identity-gate rejection, not a real rate
+    limit.
+    """
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return None
+    if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get(
+        "ANTHROPIC_AUTH_TOKEN"
+    ):
+        return _CLAUDE_CODE_SYSTEM_PREFIX
     return None

--- a/factory/cognify/edges.py
+++ b/factory/cognify/edges.py
@@ -333,7 +333,10 @@ def _llm_judge_contradiction(
     except ImportError:
         return False, _empty_usage
 
-    from cognify._anthropic_auth import resolve_anthropic_auth
+    from cognify._anthropic_auth import (
+        claude_code_system_prefix,
+        resolve_anthropic_auth,
+    )
     auth_kwargs = resolve_anthropic_auth()
     if auth_kwargs is None:
         return False, _empty_usage
@@ -344,12 +347,19 @@ def _llm_judge_contradiction(
         "Reply with only 'YES' or 'NO'.\n\n"
         f"Entry A:\n{content_a[:500]}\n\nEntry B:\n{content_b[:500]}"
     )
+    # OAuth path requires the Claude Code SDK fingerprint as the system
+    # prompt — without it /v1/messages 429s on subscription tokens.
+    # Console API key path returns None and the call uses no system prompt.
+    create_kwargs: dict[str, Any] = {
+        "model": _EDGES_MODEL,
+        "max_tokens": 8,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    oauth_prefix = claude_code_system_prefix()
+    if oauth_prefix:
+        create_kwargs["system"] = oauth_prefix
     try:
-        response = client.messages.create(
-            model=_EDGES_MODEL,
-            max_tokens=8,
-            messages=[{"role": "user", "content": prompt}],
-        )
+        response = client.messages.create(**create_kwargs)
         usage = response.usage
         token_usage = {
             "input_tokens": getattr(usage, "input_tokens", 0),

--- a/factory/cognify/extract.py
+++ b/factory/cognify/extract.py
@@ -400,17 +400,27 @@ def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
         "Return only the JSON, no preamble."
     )
 
+    # OAuth path requires the Claude Code SDK fingerprint as the first
+    # system block — without it /v1/messages 429s on subscription tokens.
+    # Console API key path returns None and is unaffected.
+    from cognify._anthropic_auth import claude_code_system_prefix
+    system_blocks: list[dict[str, Any]] = []
+    oauth_prefix = claude_code_system_prefix()
+    if oauth_prefix:
+        system_blocks.append({"type": "text", "text": oauth_prefix})
+    system_blocks.append(
+        {
+            "type": "text",
+            "text": system_prompt,
+            "cache_control": {"type": "ephemeral"},
+        }
+    )
+
     try:
         response = client.messages.create(
             model=_EXTRACT_MODEL,
             max_tokens=2048,
-            system=[
-                {
-                    "type": "text",
-                    "text": system_prompt,
-                    "cache_control": {"type": "ephemeral"},
-                }
-            ],
+            system=system_blocks,
             messages=[
                 {
                     "role": "user",
@@ -438,7 +448,7 @@ def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
         return {"lessons": [], "decisions": [], "_usage": _empty_usage}
 
 
-def _resolve_auth() -> dict[str, str] | None:
+def _resolve_auth() -> dict[str, Any] | None:
     """Resolve Anthropic credential to SDK kwargs (api_key= or auth_token=).
 
     Accepts a Console API key OR a subscription OAuth token; the SDK

--- a/factory/tests/test_cognify_anthropic_auth.py
+++ b/factory/tests/test_cognify_anthropic_auth.py
@@ -5,13 +5,26 @@ Resolution order:
   2. CLAUDE_CODE_OAUTH_TOKEN (subscription OAuth, Bearer → `auth_token=`)
   3. ANTHROPIC_AUTH_TOKEN (same shape as 2, Anthropic-docs name)
   4. None → caller skips LLM work gracefully
+
+OAuth path additionally carries the `anthropic-beta: oauth-2025-04-20`
+default header and requires callers to prepend the Claude Code SDK
+fingerprint to their system prompt (see `claude_code_system_prefix`).
 """
 from __future__ import annotations
 
 import os
 from unittest.mock import patch
 
-from cognify._anthropic_auth import resolve_anthropic_auth
+from cognify._anthropic_auth import (
+    claude_code_system_prefix,
+    resolve_anthropic_auth,
+)
+
+_OAUTH_BETA = {"anthropic-beta": "oauth-2025-04-20"}
+_OAUTH_PREFIX = (
+    "You are Claude Code, Anthropic's official CLI for Claude, "
+    "running within the Claude Agent SDK."
+)
 
 
 def _isolated_env(**vars):
@@ -32,14 +45,20 @@ def test_console_api_key_routes_to_api_key_kwarg():
         assert resolve_anthropic_auth() == {"api_key": "sk-ant-api03-FAKE"}
 
 
-def test_oauth_token_routes_to_auth_token_kwarg():
+def test_oauth_token_routes_to_auth_token_kwarg_with_beta_header():
     with patch.dict(os.environ, _isolated_env(CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat1-FAKE"), clear=True):
-        assert resolve_anthropic_auth() == {"auth_token": "sk-ant-oat1-FAKE"}
+        assert resolve_anthropic_auth() == {
+            "auth_token": "sk-ant-oat1-FAKE",
+            "default_headers": _OAUTH_BETA,
+        }
 
 
-def test_anthropic_auth_token_also_routes_to_auth_token():
+def test_anthropic_auth_token_also_routes_to_auth_token_with_beta_header():
     with patch.dict(os.environ, _isolated_env(ANTHROPIC_AUTH_TOKEN="sk-ant-oat1-OTHER"), clear=True):
-        assert resolve_anthropic_auth() == {"auth_token": "sk-ant-oat1-OTHER"}
+        assert resolve_anthropic_auth() == {
+            "auth_token": "sk-ant-oat1-OTHER",
+            "default_headers": _OAUTH_BETA,
+        }
 
 
 def test_console_key_wins_over_oauth_when_both_set():
@@ -52,6 +71,7 @@ def test_console_key_wins_over_oauth_when_both_set():
         result = resolve_anthropic_auth()
         assert result == {"api_key": "sk-ant-api03-WINS"}
         assert "auth_token" not in result
+        assert "default_headers" not in result
 
 
 def test_claude_code_token_wins_over_generic_auth_token():
@@ -62,7 +82,10 @@ def test_claude_code_token_wins_over_generic_auth_token():
         ANTHROPIC_AUTH_TOKEN="sk-ant-oat1-FROM-GENERIC",
     )
     with patch.dict(os.environ, env, clear=True):
-        assert resolve_anthropic_auth() == {"auth_token": "sk-ant-oat1-FROM-CLAUDE-CODE"}
+        assert resolve_anthropic_auth() == {
+            "auth_token": "sk-ant-oat1-FROM-CLAUDE-CODE",
+            "default_headers": _OAUTH_BETA,
+        }
 
 
 def test_empty_string_env_treated_as_unset():
@@ -73,4 +96,43 @@ def test_empty_string_env_treated_as_unset():
         CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat1-USE-ME",
     )
     with patch.dict(os.environ, env, clear=True):
-        assert resolve_anthropic_auth() == {"auth_token": "sk-ant-oat1-USE-ME"}
+        assert resolve_anthropic_auth() == {
+            "auth_token": "sk-ant-oat1-USE-ME",
+            "default_headers": _OAUTH_BETA,
+        }
+
+
+# ── claude_code_system_prefix ────────────────────────────────────────────────
+
+
+def test_system_prefix_none_when_no_credential():
+    with patch.dict(os.environ, _isolated_env(), clear=True):
+        assert claude_code_system_prefix() is None
+
+
+def test_system_prefix_none_for_console_api_key():
+    """Console keys don't need the fingerprint — the SDK X-Api-Key path is
+    not gated on the system-prompt fingerprint."""
+    with patch.dict(os.environ, _isolated_env(ANTHROPIC_API_KEY="sk-ant-api03-FAKE"), clear=True):
+        assert claude_code_system_prefix() is None
+
+
+def test_system_prefix_present_for_oauth_token():
+    with patch.dict(os.environ, _isolated_env(CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat1-FAKE"), clear=True):
+        assert claude_code_system_prefix() == _OAUTH_PREFIX
+
+
+def test_system_prefix_present_for_anthropic_auth_token():
+    with patch.dict(os.environ, _isolated_env(ANTHROPIC_AUTH_TOKEN="sk-ant-oat1-OTHER"), clear=True):
+        assert claude_code_system_prefix() == _OAUTH_PREFIX
+
+
+def test_system_prefix_none_when_console_wins_over_oauth():
+    """Console key takes precedence as the active credential, so no prefix
+    is needed — matches resolve_anthropic_auth() returning the api_key shape."""
+    env = _isolated_env(
+        ANTHROPIC_API_KEY="sk-ant-api03-WINS",
+        CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat1-LOSES",
+    )
+    with patch.dict(os.environ, env, clear=True):
+        assert claude_code_system_prefix() is None


### PR DESCRIPTION
## Summary

PR #119 added subscription OAuth token acceptance for cognify's LLM passes but the path was **non-functional in production**: every call to `/v1/messages` returned `429 rate_limit_error` with a terse `"Error"` body — not a real rate limit, an identity-gate rejection masked as one. This was undetected because every recorded `cognify_extract` run on Mac Studio was `dry_run: true, candidate_sessions: 0` — the OAuth code path had never been exercised live.

## Diagnostic story

Binary-inspected the official Claude Code 2.1.140 (`/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe`) and disambiguated via curl against the live API. Anthropic's backend gates subscription OAuth tokens on **two** things beyond the Bearer header:

1. `anthropic-beta: oauth-2025-04-20` request header — required.
2. The request's first system block must be the literal Claude Code SDK fingerprint string baked into the binary:
   ```
   You are Claude Code, Anthropic's official CLI for Claude, running within the Claude Agent SDK.
   ```

Confirmed via direct curl: same auth + same headers + **with** fingerprint = `200 OK` (returned `"Hi there, friend!"`); same auth + same headers + **without** fingerprint = `429 rate_limit_error` (terse body).

## Changes

- **`factory/cognify/_anthropic_auth.py`**
  - OAuth return shape now includes `default_headers={"anthropic-beta": "oauth-2025-04-20"}`.
  - New helper `claude_code_system_prefix()` returns the fingerprint when OAuth is the active credential, `None` for Console API key path.
- **`factory/cognify/extract.py`**
  - Prepends fingerprint as the first (uncached) system block when OAuth is active. The cognify-specific system prompt keeps its `cache_control` so prompt caching still works.
- **`factory/cognify/edges.py`**
  - Previously sent no system prompt; now conditionally sets `system=<fingerprint>` when OAuth is active.
- **`factory/tests/test_cognify_anthropic_auth.py`**
  - 7 existing tests updated to expect new OAuth return shape.
  - 5 new tests for `claude_code_system_prefix()` covering all four env-var combinations.

**Console API key path is unaffected** — `X-Api-Key` requests are not gated on the system-prompt fingerprint.

## End-to-end verification

Patched files deployed to Mac Studio, ran:

```
devbrain cognify-reextract --session=126830a7-... --project=brightbot --json
```

Result:
```json
{ "sessions_targeted": 1, "lessons_created": 6, "decisions_created": 5 }
```

Atomic memory rows confirmed in `devbrain.memory`: 5 `decision` + 6 `pattern` rows (CLI says "lessons", storage kind is "pattern" — pre-existing nomenclature mismatch, separate from this PR). Every prior run with the same token had returned 429.

## Test plan

- [x] `pytest factory/tests/test_cognify_anthropic_auth.py` — 12/12 pass (7 updated + 5 new)
- [x] `pytest factory/tests/ -k cognify` — 24 pass, 56 skipped (DB-dependent), 0 fail
- [x] Live end-to-end: single-session reextract on Mac Studio produces atomic rows
- [ ] Reviewer: confirm the system-prompt-fingerprint approach is acceptable (see ToS note below)

## ToS posture — please weigh in

The fingerprint mechanism this PR uses is the same one third-party harnesses (claude-max-api-proxy, CLIProxyAPI) use to route Max subscription tokens through `/v1/messages`. Anthropic's 2026-02 crackdown (Issue #18340, VentureBeat coverage) was aimed at exactly this technique. Reasonable interpretation: the subscription owner generating their own token via the official `claude setup-token` flow and using it from their own automation is a self-use case the policy net wasn't primarily targeting. Strict interpretation: ToS limits Pro/Max usage to claude.ai, Claude Code, and Claude Desktop. Cognify is none of those.

Patrick explicitly chose this path (option 1 of three offered) over switching to Console API key. Decision documented here for transparency; this PR honors that choice.

## Known follow-up (separate PR)

`_EXTRACT_MODEL` system prompt currently caps at `max_tokens=2048`, which truncates JSON output for session summaries >~8K chars. Discovered while testing this PR: the 19:17 handoff (15,731 chars) produced an `Unterminated string at char 8445` JSON parse error even though the LLM call itself succeeded. This was never exercised in production while cognify ran in dry-run mode; now that it's functional, larger sessions need a higher cap or chunking strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)