### PR TITLE
docs(claude.md): clarify mcp__devbrain__* vs mcp__brightbrain__* routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,14 +5,29 @@
 You have access to DevBrain, a shared persistent memory system via MCP tools.
 DevBrain remembers across sessions and across different AI tools.
 
+### MCP routing (THIS project)
+
+This project's memory lives in the **local DevBrain on Patrick's laptop**
+(`mcp__devbrain__*`). NOT BrightBrain — that's the LHT Mac Studio for
+BrightBot / lht-vps / brightbot-v4 work only.
+
+- Default `project` argument: `devbrain` (the MCP normalizes; the DB-visible
+  display name is `DevBrain` but the MCP accepts the lowercase form).
+- Examples: `mcp__devbrain__get_project_context`, `mcp__devbrain__deep_search`,
+  `mcp__devbrain__store`, `mcp__devbrain__end_session`,
+  `mcp__devbrain__factory_plan`, `mcp__devbrain__factory_status`.
+
+If you find yourself accidentally calling `mcp__brightbrain__*` while in
+this repo, you're hitting the wrong DB. Stop and re-route to `mcp__devbrain__*`.
+
 ### ALWAYS do these things:
-1. **Start of session**: Call `get_project_context` to load project context, recent decisions, and known issues
-2. **Before starting work**: Call `deep_search` to check for relevant past decisions, patterns, and implementation history — never assume
-3. **During work**: Call `store` when you:
+1. **Start of session**: Call `get_project_context` (via `mcp__devbrain__*`) to load project context, recent decisions, and known issues
+2. **Before starting work**: Call `deep_search` (via `mcp__devbrain__*`) to check for relevant past decisions, patterns, and implementation history — never assume
+3. **During work**: Call `store` (via `mcp__devbrain__*`) when you:
    - Make an architecture or design decision (type="decision")
    - Discover a reusable pattern (type="pattern")
    - Fix a bug worth remembering (type="issue")
-4. **End of session**: Call `end_session` with a summary of what was accomplished, decisions made, files changed, and next steps
+4. **End of session**: Call `end_session` (via `mcp__devbrain__*`) with a summary of what was accomplished, decisions made, files changed, and next steps
 
 ### DevBrain Search Tips:
 - `deep_search` with depth="auto" will automatically fetch raw transcript context for high-confidence matches


### PR DESCRIPTION
## Summary

Adds an MCP-routing-clarification section to CLAUDE.md so future sessions in this repo route correctly. After today's laptop devbrain ↔ Mac Studio brightbrain consolidation, the two DBs have distinct MCP namespaces:

- `mcp__devbrain__*` → laptop DB (this project, plus non-LHT projects)
- `mcp__brightbrain__*` → Mac Studio DB (BrightBot / lht-vps / brightbot-v4)

Without this guidance, agents working in this repo can land in the wrong DB on read/write (the same mismatch that bit Patrick yesterday).

## Changes

- New `### MCP routing (THIS project)` section before the standard checklist
- Each item in the "ALWAYS do these things" checklist annotated with `(via mcp__devbrain__*)` for explicitness

## Test plan

- [ ] Reviewer: confirm the wording matches expected routing policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)