### PR TITLE
feat(cognify): add setup-cognify-launchd installer command

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -403,6 +403,55 @@ def setup_multi_dev_cmd(host, port, database, username, password):
         sys.exit(1)
 
 
+@cli.command(name="setup-cognify-launchd")
+@click.option(
+    "--project", "project_slug", required=True,
+    help="Project slug to scope LLM-cost passes (extract, edges, strengthen). "
+         "Must match an existing project in DevBrain.",
+)
+@click.option(
+    "--reload/--no-reload", default=True,
+    help="Run `launchctl unload && launchctl load` on each installed plist. "
+         "Default: yes — picks up the new schedule immediately.",
+)
+def setup_cognify_launchd_cmd(project_slug, reload):
+    """Install + configure the 5 cognify launchd jobs on this user.
+
+    Renders the source plist templates from `factory/cognify/launchd/`
+    (substituting ${DEVBRAIN_HOME}, ${USER}, ${PROJECT_SLUG}, and the
+    credential env block) and writes the resulting plists to
+    ~/Library/LaunchAgents/. chmod 0600 on the two that carry an
+    Anthropic credential (extract + edges); 0644 on the other three.
+
+    The Anthropic credential is resolved from the current env:
+    ANTHROPIC_API_KEY wins; CLAUDE_CODE_OAUTH_TOKEN (or
+    ANTHROPIC_AUTH_TOKEN) is the fallback. Errors if neither is set.
+
+    Idempotent — safe to re-run with the same args.
+
+    Replaces the manual `cp factory/cognify/launchd/*.plist
+    ~/Library/LaunchAgents/` workflow that leaves literal
+    ${PROJECT_SLUG} placeholders in the installed files (the 2026-05-11
+    regression on Mac Studio).
+    """
+    from cognify.setup_launchd import install_cognify_launchd
+    try:
+        installed = install_cognify_launchd(
+            project_slug=project_slug,
+            reload=reload,
+        )
+    except ValueError as exc:
+        click.echo(f"error: {exc}", err=True)
+        sys.exit(2)
+    except FileNotFoundError as exc:
+        click.echo(f"error: {exc}", err=True)
+        sys.exit(2)
+    for path in installed:
+        click.echo(f"installed: {path}")
+    if reload:
+        click.echo(f"reloaded {len(installed)} launchd job(s)")
+
+
 @cli.command(name="add-channel")
 @click.option("--dev-id", default=None)
 @click.option("--channel", "channel_spec", required=True, help="TYPE:ADDRESS")

--- a/factory/cognify/launchd/com.devbrain.cognify-decay.plist
+++ b/factory/cognify/launchd/com.devbrain.cognify-decay.plist
@@ -2,9 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
     "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!-- cognify_decay: hourly time-based strength decay. Zero LLM cost.         -->
-<!-- Install: cp this file to ~/Library/LaunchAgents/ and launchctl load it. -->
-<!-- Placeholders: ${DEVBRAIN_HOME} and ${USER} are filled in by             -->
-<!--   `devbrain setup` (or replace manually before loading).                -->
+<!-- Placeholders ${DEVBRAIN_HOME} and ${USER} are substituted by            -->
+<!-- `devbrain setup-cognify-launchd`. Do NOT cp this file directly into     -->
+<!-- ~/Library/LaunchAgents/ — placeholders won't expand and launchd will    -->
+<!-- fail at runtime.                                                        -->
 <plist version="1.0">
 <dict>
     <key>Label</key>

--- a/factory/cognify/launchd/com.devbrain.cognify-edges.plist
+++ b/factory/cognify/launchd/com.devbrain.cognify-edges.plist
@@ -3,8 +3,11 @@
     "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!-- cognify_edges: every-6h cites + contradicts edge inference.             -->
 <!-- Up to 15 LLM calls per run (contradicts detection only).                -->
-<!-- Placeholders: ${DEVBRAIN_HOME}, ${USER}, ${PROJECT_SLUG} filled by      -->
-<!--   `devbrain setup` or replaced manually before loading.                 -->
+<!-- Placeholders ${DEVBRAIN_HOME}, ${USER}, ${PROJECT_SLUG}, and the        -->
+<!-- credential-env marker are substituted by                                -->
+<!-- `devbrain setup-cognify-launchd`. Do NOT cp this file directly into     -->
+<!-- ~/Library/LaunchAgents/ — placeholders won't expand and launchd will    -->
+<!-- fail at runtime with a literal "${PROJECT_SLUG}" error.                 -->
 <plist version="1.0">
 <dict>
     <key>Label</key>
@@ -29,8 +32,8 @@
         <string>${DEVBRAIN_HOME}</string>
         <key>PYTHONPATH</key>
         <string>${DEVBRAIN_HOME}/factory</string>
-        <key>ANTHROPIC_API_KEY</key>
-        <string>${ANTHROPIC_API_KEY}</string>
+        <!-- @CREDENTIAL_ENV_BLOCK@ — installer emits ANTHROPIC_API_KEY or  -->
+        <!-- CLAUDE_CODE_OAUTH_TOKEN here based on env at install time.    -->
     </dict>
 
     <key>WorkingDirectory</key>

--- a/factory/cognify/launchd/com.devbrain.cognify-extract.plist
+++ b/factory/cognify/launchd/com.devbrain.cognify-extract.plist
@@ -2,9 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
     "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!-- cognify_extract: hourly lesson/decision extraction. Up to 20 LLM calls. -->
-<!-- Requires: ANTHROPIC_API_KEY and --project=<slug> for LLM-cost pass.     -->
-<!-- Placeholders: ${DEVBRAIN_HOME}, ${USER}, ${PROJECT_SLUG} are filled in  -->
-<!--   by `devbrain setup` or replaced manually before loading.              -->
+<!-- Requires an Anthropic credential and --project=<slug> for LLM-cost pass.-->
+<!-- Placeholders ${DEVBRAIN_HOME}, ${USER}, ${PROJECT_SLUG}, and the         -->
+<!-- credential-env marker are substituted by                                 -->
+<!-- `devbrain setup-cognify-launchd`. Do NOT cp this file directly into      -->
+<!-- ~/Library/LaunchAgents/ — placeholders won't expand and launchd will     -->
+<!-- fail at runtime with a literal "${PROJECT_SLUG}" error.                  -->
 <plist version="1.0">
 <dict>
     <key>Label</key>
@@ -29,8 +32,8 @@
         <string>${DEVBRAIN_HOME}</string>
         <key>PYTHONPATH</key>
         <string>${DEVBRAIN_HOME}/factory</string>
-        <key>ANTHROPIC_API_KEY</key>
-        <string>${ANTHROPIC_API_KEY}</string>
+        <!-- @CREDENTIAL_ENV_BLOCK@ — installer emits ANTHROPIC_API_KEY or  -->
+        <!-- CLAUDE_CODE_OAUTH_TOKEN here based on env at install time.    -->
     </dict>
 
     <key>WorkingDirectory</key>

--- a/factory/cognify/launchd/com.devbrain.cognify-gc.plist
+++ b/factory/cognify/launchd/com.devbrain.cognify-gc.plist
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
     "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!-- cognify_gc: weekly archive of low-strength orphans. Zero LLM cost.     -->
+<!-- cognify_gc: weekly archive of low-strength orphans. Zero LLM cost.      -->
 <!-- NEVER deletes rows — sets archived_at only (HIPAA audit trail).         -->
-<!-- Placeholders: ${DEVBRAIN_HOME} and ${USER} filled by `devbrain setup`   -->
-<!--   or replaced manually before loading.                                  -->
+<!-- Placeholders ${DEVBRAIN_HOME} and ${USER} are substituted by            -->
+<!-- `devbrain setup-cognify-launchd`. Do NOT cp this file directly into     -->
+<!-- ~/Library/LaunchAgents/ — placeholders won't expand and launchd will    -->
+<!-- fail at runtime.                                                        -->
 <plist version="1.0">
 <dict>
     <key>Label</key>

--- a/factory/cognify/launchd/com.devbrain.cognify-strengthen.plist
+++ b/factory/cognify/launchd/com.devbrain.cognify-strengthen.plist
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
     "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!-- cognify_strengthen: daily graduation + demotion sweep. Zero LLM cost.  -->
-<!-- Placeholders: ${DEVBRAIN_HOME}, ${USER}, ${PROJECT_SLUG} filled by      -->
-<!--   `devbrain setup` or replaced manually before loading.                 -->
+<!-- cognify_strengthen: daily graduation + demotion sweep. Zero LLM cost.   -->
+<!-- Placeholders ${DEVBRAIN_HOME}, ${USER}, ${PROJECT_SLUG} are substituted -->
+<!-- by `devbrain setup-cognify-launchd`. Do NOT cp this file directly into  -->
+<!-- ~/Library/LaunchAgents/ — placeholders won't expand and launchd will    -->
+<!-- fail at runtime with a literal "${PROJECT_SLUG}" error.                 -->
 <plist version="1.0">
 <dict>
     <key>Label</key>

--- a/factory/cognify/setup_launchd.py
+++ b/factory/cognify/setup_launchd.py
@@ -1,0 +1,288 @@
+"""Install + configure the cognify launchd jobs on the current macOS user.
+
+Reads source plist templates from this package's `launchd/` subdirectory,
+substitutes the four required placeholders, writes the resulting plists
+to `~/Library/LaunchAgents/` with `chmod 0600` on the two files that
+carry Anthropic credentials, and optionally reloads `launchctl`.
+
+Why this exists
+---------------
+The launchd plist templates in `factory/cognify/launchd/*.plist` contain
+shell-style `${PLACEHOLDER}` tokens that launchd itself does *not*
+substitute. Copying them directly into `~/Library/LaunchAgents/` leaves
+the placeholders literal, which produces the runtime error:
+
+    Error: Project '${PROJECT_SLUG}' not found.
+
+This was the regression that broke cognify_extract on Mac Studio on
+2026-05-11. This installer is the only correct way to render and place
+these plists.
+
+Placeholders
+------------
+- ``${DEVBRAIN_HOME}`` — absolute path to the devbrain checkout
+  (typically `/Users/lhtdev/devbrain` on Mac Studio).
+- ``${USER}`` — current user's login name; used to compose the log
+  paths under `/Users/<user>/.devbrain/logs/`.
+- ``${PROJECT_SLUG}`` — slug of the project that the LLM-cost passes
+  (extract + edges + strengthen) should scope to.
+- ``@CREDENTIAL_ENV_BLOCK@`` — XML marker replaced by either an
+  ``ANTHROPIC_API_KEY`` or ``CLAUDE_CODE_OAUTH_TOKEN`` env entry in
+  the two LLM-cost plists (extract + edges). The non-LLM plists
+  (decay + strengthen + gc) don't carry this marker.
+
+Idempotency
+-----------
+Safe to re-run with the same args — existing installed plists are
+replaced atomically (write to temp file in the same directory, then
+rename). With ``reload=True``, an already-loaded job is unloaded and
+reloaded; an unloaded job is just loaded.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+_TEMPLATE_DIR = Path(__file__).resolve().parent / "launchd"
+
+# Plists that don't carry credentials — emitted with mode 0644.
+_NO_CRED_PLISTS = (
+    "com.devbrain.cognify-decay.plist",
+    "com.devbrain.cognify-strengthen.plist",
+    "com.devbrain.cognify-gc.plist",
+)
+
+# Plists that DO carry credentials — emitted with mode 0600.
+_CRED_PLISTS = (
+    "com.devbrain.cognify-extract.plist",
+    "com.devbrain.cognify-edges.plist",
+)
+
+# All five, in installation order.
+ALL_PLISTS = _NO_CRED_PLISTS + _CRED_PLISTS
+
+# The marker the credential block replaces. Multi-line; the installer
+# replaces the *entire* HTML comment block plus the marker line.
+_CRED_MARKER = "<!-- @CREDENTIAL_ENV_BLOCK@"
+
+
+@dataclass(frozen=True)
+class CredentialChoice:
+    """The Anthropic credential to bake into LLM-cost plists.
+
+    ``env_name`` is the env-var key launchd will inject into the
+    cognify process (``ANTHROPIC_API_KEY`` or
+    ``CLAUDE_CODE_OAUTH_TOKEN``). ``value`` is the secret itself.
+    """
+
+    env_name: str
+    value: str
+
+    def __post_init__(self) -> None:
+        if self.env_name not in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"):
+            raise ValueError(
+                f"unsupported credential env_name: {self.env_name!r} — "
+                "must be ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN"
+            )
+        if not self.value:
+            raise ValueError("credential value must be non-empty")
+
+
+def resolve_credential_from_env() -> CredentialChoice | None:
+    """Pick the right Anthropic credential from the current process env.
+
+    Precedence matches ``cognify._anthropic_auth.resolve_anthropic_auth``:
+    Console API key first, OAuth token second. Returns None if neither
+    is present — caller must decide whether to error (LLM plists need
+    one) or skip (non-LLM plists don't).
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if api_key:
+        return CredentialChoice("ANTHROPIC_API_KEY", api_key)
+
+    bearer = (
+        os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+        or os.environ.get("ANTHROPIC_AUTH_TOKEN")
+    )
+    if bearer:
+        return CredentialChoice("CLAUDE_CODE_OAUTH_TOKEN", bearer)
+
+    return None
+
+
+def render_plist(
+    template_text: str,
+    *,
+    devbrain_home: str,
+    user: str,
+    project_slug: str,
+    credential: CredentialChoice | None,
+) -> str:
+    """Substitute the four placeholder kinds in a template.
+
+    Pure function; no I/O. Tested directly in unit tests.
+
+    Raises ValueError if the template carries `@CREDENTIAL_ENV_BLOCK@`
+    but no `credential` was supplied — that combination would emit
+    a plist that can never authenticate.
+    """
+    out = template_text.replace("${DEVBRAIN_HOME}", devbrain_home)
+    out = out.replace("${USER}", user)
+    out = out.replace("${PROJECT_SLUG}", project_slug)
+
+    if _CRED_MARKER in out:
+        if credential is None:
+            raise ValueError(
+                "template carries @CREDENTIAL_ENV_BLOCK@ but no credential "
+                "was supplied — extract + edges plists require one of "
+                "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN"
+            )
+        cred_xml = (
+            f"        <key>{credential.env_name}</key>\n"
+            f"        <string>{credential.value}</string>"
+        )
+        # Replace the entire two-line comment block + marker with the
+        # rendered key/string pair. The template uses:
+        #   <!-- @CREDENTIAL_ENV_BLOCK@ — installer emits ANTHROPIC_API_KEY or  -->
+        #   <!-- CLAUDE_CODE_OAUTH_TOKEN here based on env at install time.    -->
+        # We match from the marker to the closing `-->` of the SECOND line.
+        marker_pos = out.find(_CRED_MARKER)
+        # Find the end of the second comment line: search for the next
+        # `-->` after the marker, twice.
+        first_close = out.index("-->", marker_pos) + len("-->")
+        second_close = out.index("-->", first_close) + len("-->")
+        # Preserve leading whitespace on the marker line for indentation.
+        line_start = out.rfind("\n", 0, marker_pos) + 1
+        prefix = out[line_start:marker_pos]  # e.g. "        "
+        out = out[:line_start] + cred_xml.lstrip() + out[second_close:]
+        # Re-indent the credential xml to match the original marker indent.
+        out = out.replace(
+            cred_xml.lstrip(),
+            "\n".join(prefix + line.lstrip() for line in cred_xml.splitlines()),
+            1,
+        )
+
+    return out
+
+
+def install_one(
+    template_path: Path,
+    *,
+    target_dir: Path,
+    devbrain_home: str,
+    user: str,
+    project_slug: str,
+    credential: CredentialChoice | None,
+) -> Path:
+    """Render one template and write it to ``target_dir``.
+
+    chmod 0600 on plists that carry credentials, 0644 otherwise.
+    Atomic write: temp file in target_dir, then rename.
+
+    Returns the absolute path of the installed plist.
+    """
+    text = template_path.read_text()
+    rendered = render_plist(
+        text,
+        devbrain_home=devbrain_home,
+        user=user,
+        project_slug=project_slug,
+        credential=credential,
+    )
+    target = target_dir / template_path.name
+    needs_secret_perms = template_path.name in _CRED_PLISTS
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=template_path.name + ".", suffix=".tmp", dir=str(target_dir)
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(rendered)
+        os.chmod(tmp_path, 0o600 if needs_secret_perms else 0o644)
+        os.replace(tmp_path, target)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    return target
+
+
+def install_cognify_launchd(
+    *,
+    project_slug: str,
+    credential: CredentialChoice | None = None,
+    devbrain_home: str | None = None,
+    user: str | None = None,
+    target_dir: Path | None = None,
+    reload: bool = False,
+    runner: callable = subprocess.run,  # injection point for tests
+) -> list[Path]:
+    """Render and install all five cognify launchd plists.
+
+    Defaults:
+      * ``credential`` ← ``resolve_credential_from_env()``
+      * ``devbrain_home`` ← parent-parent of this file
+      * ``user`` ← $USER
+      * ``target_dir`` ← ``~/Library/LaunchAgents``
+
+    With ``reload=True``, runs ``launchctl unload`` (ignoring "not
+    loaded" errors) and then ``launchctl load`` on each plist.
+
+    Returns the list of installed plist paths.
+    """
+    if credential is None:
+        credential = resolve_credential_from_env()
+        # OK if it's None — render_plist will raise only on plists
+        # that need it.
+
+    if devbrain_home is None:
+        # /factory/cognify/setup_launchd.py → devbrain root is 2 levels up
+        devbrain_home = str(Path(__file__).resolve().parent.parent.parent)
+
+    if user is None:
+        user = os.environ.get("USER") or os.environ.get("LOGNAME") or ""
+        if not user:
+            raise RuntimeError("could not determine current user from env")
+
+    if target_dir is None:
+        target_dir = Path.home() / "Library" / "LaunchAgents"
+
+    installed: list[Path] = []
+    for name in ALL_PLISTS:
+        template = _TEMPLATE_DIR / name
+        if not template.exists():
+            raise FileNotFoundError(
+                f"missing cognify plist template: {template}"
+            )
+        out_path = install_one(
+            template,
+            target_dir=target_dir,
+            devbrain_home=devbrain_home,
+            user=user,
+            project_slug=project_slug,
+            credential=credential,
+        )
+        installed.append(out_path)
+
+    if reload:
+        for path in installed:
+            # `launchctl unload` errors when the job isn't loaded —
+            # swallow that case but propagate everything else.
+            runner(
+                ["launchctl", "unload", str(path)],
+                check=False,
+                capture_output=True,
+            )
+            runner(
+                ["launchctl", "load", str(path)],
+                check=True,
+                capture_output=True,
+            )
+
+    return installed

--- a/factory/tests/test_cognify_setup_launchd.py
+++ b/factory/tests/test_cognify_setup_launchd.py
@@ -1,0 +1,321 @@
+"""Tests for cognify.setup_launchd — plist renderer + installer."""
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cognify.setup_launchd import (
+    ALL_PLISTS,
+    CredentialChoice,
+    _CRED_PLISTS,
+    _NO_CRED_PLISTS,
+    _TEMPLATE_DIR,
+    install_cognify_launchd,
+    render_plist,
+    resolve_credential_from_env,
+)
+
+
+# ─── CredentialChoice ────────────────────────────────────────────────────────
+
+
+def test_credential_choice_rejects_unknown_env_name():
+    with pytest.raises(ValueError, match="unsupported credential env_name"):
+        CredentialChoice("X_API_KEY", "value")
+
+
+def test_credential_choice_rejects_empty_value():
+    with pytest.raises(ValueError, match="must be non-empty"):
+        CredentialChoice("ANTHROPIC_API_KEY", "")
+
+
+def test_credential_choice_accepts_api_key():
+    c = CredentialChoice("ANTHROPIC_API_KEY", "sk-ant-api03-FAKE")
+    assert c.env_name == "ANTHROPIC_API_KEY"
+    assert c.value == "sk-ant-api03-FAKE"
+
+
+def test_credential_choice_accepts_oauth_token():
+    c = CredentialChoice("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-FAKE")
+    assert c.env_name == "CLAUDE_CODE_OAUTH_TOKEN"
+
+
+# ─── resolve_credential_from_env ─────────────────────────────────────────────
+
+
+def _isolated_env(**vars):
+    base = {k: v for k, v in os.environ.items()
+            if k not in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN")}
+    base.update(vars)
+    return base
+
+
+def test_resolve_returns_none_when_no_env():
+    with patch.dict(os.environ, _isolated_env(), clear=True):
+        assert resolve_credential_from_env() is None
+
+
+def test_resolve_picks_console_key():
+    with patch.dict(os.environ, _isolated_env(ANTHROPIC_API_KEY="sk-ant-api03-K"), clear=True):
+        c = resolve_credential_from_env()
+        assert c == CredentialChoice("ANTHROPIC_API_KEY", "sk-ant-api03-K")
+
+
+def test_resolve_picks_oauth_when_only_oauth_set():
+    with patch.dict(os.environ, _isolated_env(CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-T"), clear=True):
+        c = resolve_credential_from_env()
+        assert c == CredentialChoice("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-T")
+
+
+def test_resolve_console_wins_over_oauth():
+    with patch.dict(
+        os.environ,
+        _isolated_env(
+            ANTHROPIC_API_KEY="sk-ant-api03-WINS",
+            CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-LOSES",
+        ),
+        clear=True,
+    ):
+        c = resolve_credential_from_env()
+        assert c.env_name == "ANTHROPIC_API_KEY"
+
+
+# ─── render_plist ────────────────────────────────────────────────────────────
+
+
+def _read_template(name: str) -> str:
+    return (_TEMPLATE_DIR / name).read_text()
+
+
+def test_render_substitutes_devbrain_home_and_user():
+    text = _read_template("com.devbrain.cognify-decay.plist")
+    out = render_plist(
+        text,
+        devbrain_home="/tmp/devbrain",
+        user="alice",
+        project_slug="ignored-for-decay",  # decay doesn't use slug
+        credential=None,
+    )
+    assert "${DEVBRAIN_HOME}" not in out
+    assert "${USER}" not in out
+    assert "/tmp/devbrain/.venv/bin/python" in out
+    assert "/Users/alice/.devbrain/logs/cognify-decay.log" in out
+
+
+def test_render_substitutes_project_slug():
+    text = _read_template("com.devbrain.cognify-strengthen.plist")
+    out = render_plist(
+        text,
+        devbrain_home="/tmp/devbrain",
+        user="alice",
+        project_slug="brightbot",
+        credential=None,
+    )
+    assert "${PROJECT_SLUG}" not in out
+    assert "--project=brightbot" in out
+
+
+def test_render_inserts_oauth_credential_block_for_extract():
+    text = _read_template("com.devbrain.cognify-extract.plist")
+    cred = CredentialChoice("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-FAKE")
+    out = render_plist(
+        text,
+        devbrain_home="/tmp/devbrain",
+        user="alice",
+        project_slug="brightbot",
+        credential=cred,
+    )
+    # The credential block is now present...
+    assert "<key>CLAUDE_CODE_OAUTH_TOKEN</key>" in out
+    assert "<string>sk-ant-oat01-FAKE</string>" in out
+    # ...and the marker is gone.
+    assert "@CREDENTIAL_ENV_BLOCK@" not in out
+    # ...and ANTHROPIC_API_KEY is NOT emitted (since we used OAuth).
+    assert "<key>ANTHROPIC_API_KEY</key>" not in out
+
+
+def test_render_inserts_api_key_credential_block_for_edges():
+    text = _read_template("com.devbrain.cognify-edges.plist")
+    cred = CredentialChoice("ANTHROPIC_API_KEY", "sk-ant-api03-CONSOLE")
+    out = render_plist(
+        text,
+        devbrain_home="/tmp/devbrain",
+        user="alice",
+        project_slug="brightbot",
+        credential=cred,
+    )
+    assert "<key>ANTHROPIC_API_KEY</key>" in out
+    assert "<string>sk-ant-api03-CONSOLE</string>" in out
+    assert "<key>CLAUDE_CODE_OAUTH_TOKEN</key>" not in out
+    assert "@CREDENTIAL_ENV_BLOCK@" not in out
+
+
+def test_render_raises_when_extract_template_has_no_credential():
+    text = _read_template("com.devbrain.cognify-extract.plist")
+    with pytest.raises(ValueError, match="require one of"):
+        render_plist(
+            text,
+            devbrain_home="/tmp/devbrain",
+            user="alice",
+            project_slug="brightbot",
+            credential=None,
+        )
+
+
+def test_render_no_credential_block_in_non_llm_templates():
+    """decay, strengthen, gc don't have the marker — credential=None must be OK."""
+    for name in _NO_CRED_PLISTS:
+        text = _read_template(name)
+        out = render_plist(
+            text,
+            devbrain_home="/tmp/devbrain",
+            user="alice",
+            project_slug="brightbot",
+            credential=None,
+        )
+        # No traces of credentials
+        assert "ANTHROPIC_API_KEY" not in out
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in out
+        # No literal placeholders left
+        assert "${DEVBRAIN_HOME}" not in out
+        assert "${USER}" not in out
+        # Indentation preserved
+        assert "<plist version=\"1.0\">" in out
+
+
+def test_render_does_not_carry_placeholder_for_project_in_no_project_plists():
+    """decay + gc don't take --project, so ${PROJECT_SLUG} shouldn't appear
+    in their templates at all (sanity check the templates themselves)."""
+    for name in ("com.devbrain.cognify-decay.plist", "com.devbrain.cognify-gc.plist"):
+        text = _read_template(name)
+        assert "${PROJECT_SLUG}" not in text, (
+            f"{name} should not have ${{PROJECT_SLUG}} — it doesn't pass --project"
+        )
+
+
+# ─── install_cognify_launchd ─────────────────────────────────────────────────
+
+
+def test_install_writes_all_five_plists(tmp_path):
+    cred = CredentialChoice("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-FAKE")
+    installed = install_cognify_launchd(
+        project_slug="brightbot",
+        credential=cred,
+        devbrain_home="/tmp/devbrain",
+        user="alice",
+        target_dir=tmp_path,
+        reload=False,
+    )
+    assert len(installed) == 5
+    assert {p.name for p in installed} == set(ALL_PLISTS)
+    for p in installed:
+        assert p.exists()
+        assert p.parent == tmp_path
+
+
+def test_install_sets_chmod_0600_on_credential_plists(tmp_path):
+    cred = CredentialChoice("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-FAKE")
+    installed = install_cognify_launchd(
+        project_slug="brightbot",
+        credential=cred,
+        devbrain_home="/tmp/devbrain",
+        user="alice",
+        target_dir=tmp_path,
+        reload=False,
+    )
+    for p in installed:
+        mode = stat.S_IMODE(p.stat().st_mode)
+        if p.name in _CRED_PLISTS:
+            assert mode == 0o600, f"{p.name} should be 0600, got {oct(mode)}"
+        else:
+            assert mode == 0o644, f"{p.name} should be 0644, got {oct(mode)}"
+
+
+def test_install_is_idempotent(tmp_path):
+    cred = CredentialChoice("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-FAKE")
+    first = install_cognify_launchd(
+        project_slug="brightbot",
+        credential=cred,
+        devbrain_home="/tmp/devbrain",
+        user="alice",
+        target_dir=tmp_path,
+        reload=False,
+    )
+    second = install_cognify_launchd(
+        project_slug="brightbot",
+        credential=cred,
+        devbrain_home="/tmp/devbrain",
+        user="alice",
+        target_dir=tmp_path,
+        reload=False,
+    )
+    assert [p.name for p in first] == [p.name for p in second]
+    # No leftover .tmp files
+    leftovers = list(tmp_path.glob("*.tmp"))
+    assert leftovers == []
+
+
+def test_install_with_reload_invokes_launchctl(tmp_path):
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(args, **kw):
+        calls.append(tuple(args))
+        class Result:
+            returncode = 0
+            stdout = b""
+            stderr = b""
+        return Result()
+
+    cred = CredentialChoice("ANTHROPIC_API_KEY", "sk-ant-api03-FAKE")
+    install_cognify_launchd(
+        project_slug="brightbot",
+        credential=cred,
+        devbrain_home="/tmp/devbrain",
+        user="alice",
+        target_dir=tmp_path,
+        reload=True,
+        runner=fake_run,
+    )
+    # Two calls per plist (unload + load) × 5 plists = 10
+    assert len(calls) == 10
+    # Each pair should be (launchctl unload <path>) then (launchctl load <path>)
+    for unload_call, load_call in zip(calls[0::2], calls[1::2]):
+        assert unload_call[0:2] == ("launchctl", "unload")
+        assert load_call[0:2] == ("launchctl", "load")
+        assert unload_call[2] == load_call[2]  # same plist
+
+
+def test_install_resolves_credential_from_env_if_not_passed(tmp_path):
+    with patch.dict(
+        os.environ,
+        _isolated_env(CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-FROM-ENV"),
+        clear=True,
+    ):
+        installed = install_cognify_launchd(
+            project_slug="brightbot",
+            devbrain_home="/tmp/devbrain",
+            user="alice",
+            target_dir=tmp_path,
+            reload=False,
+        )
+    # Inspect the extract plist to confirm the env-resolved cred was used.
+    extract = next(p for p in installed if p.name == "com.devbrain.cognify-extract.plist")
+    body = extract.read_text()
+    assert "<key>CLAUDE_CODE_OAUTH_TOKEN</key>" in body
+    assert "sk-ant-oat01-FROM-ENV" in body
+
+
+def test_install_errors_if_no_cred_in_env_and_not_passed(tmp_path):
+    with patch.dict(os.environ, _isolated_env(), clear=True):
+        with pytest.raises(ValueError, match="require one of"):
+            install_cognify_launchd(
+                project_slug="brightbot",
+                devbrain_home="/tmp/devbrain",
+                user="alice",
+                target_dir=tmp_path,
+                reload=False,
+            )


### PR DESCRIPTION
## Summary

The 2026-05-11 cognify-extract regression on Mac Studio was caused by someone copying the plist templates from `factory/cognify/launchd/` directly into `~/Library/LaunchAgents/` without substituting the shell-style `${PROJECT_SLUG}` and `${ANTHROPIC_API_KEY}` placeholders. launchd doesn't perform that substitution, so every run failed with:

```
Error: Project '${PROJECT_SLUG}' not found.
```

**Root cause:** there was no code in the repo that owned the install-and-substitute step. The templates were orphaned source files relied on being copied manually. This PR adds the missing installer.

## Changes

**New module: `factory/cognify/setup_launchd.py`**

| Function | Purpose |
|---|---|
| `render_plist()` | Pure-function substitution; testable in isolation |
| `install_one()` | Atomic write of one rendered plist with correct mode bits (0600 for credential plists, 0644 otherwise) |
| `install_cognify_launchd()` | Install all 5; optional `--reload` |
| `resolve_credential_from_env()` | Pick `ANTHROPIC_API_KEY` (Console) or `CLAUDE_CODE_OAUTH_TOKEN` (OAuth) from env |
| `CredentialChoice` | Typed wrapper, rejects unsupported env names |

**New CLI command:**

```bash
devbrain setup-cognify-launchd --project=brightbot
devbrain setup-cognify-launchd --project=brightbot --no-reload
```

Idempotent — safe to re-run with same args. With `--reload` (default), runs `launchctl unload && launchctl load` per plist.

**Template changes** (5 files):

- All file-header comments now point at `devbrain setup-cognify-launchd` as the install path, with a "Do NOT cp this file directly" warning.
- `extract` + `edges`: hardcoded `<key>ANTHROPIC_API_KEY</key>...` block replaced with `<!-- @CREDENTIAL_ENV_BLOCK@ -->` marker that the installer fills with the appropriate env var name + value based on what's in env at install time.

## Tests (21 added)

- `CredentialChoice` validation (unknown env name, empty value)
- `resolve_credential_from_env` precedence (`ANTHROPIC_API_KEY` > `CLAUDE_CODE_OAUTH_TOKEN`)
- `render_plist` for all 5 templates:
  - Substitution correctness
  - Credential block emission for both API key and OAuth paths
  - Error when extract/edges receive no credential
  - No credential leakage into decay/strengthen/gc templates
  - Sanity check: decay + gc don't carry `${PROJECT_SLUG}` (they don't take `--project`)
- `install_cognify_launchd`:
  - Writes all 5 plists
  - chmod 0600 on extract/edges, 0644 on decay/strengthen/gc
  - Idempotent re-run leaves no `.tmp` files
  - `--reload` calls `launchctl` twice per plist in the right order
  - Env-only credential resolution path
  - Errors clearly when neither env var is set

`pytest factory/tests/test_cognify_setup_launchd.py` — 21/21 pass.

## Plan after merge

Run `devbrain setup-cognify-launchd --project=brightbot --reload` on Mac Studio to replace the currently-manually-patched plists with the installer-rendered ones. Output should be byte-equivalent to what's there now; the difference is provenance — going forward, regeneration is one CLI call away.

## Test plan

- [x] `pytest factory/tests/test_cognify_setup_launchd.py` — 21/21
- [x] `pytest factory/tests/test_cognify_anthropic_auth.py` — 12/12 (unchanged)
- [x] `devbrain setup-cognify-launchd --help` registers correctly
- [ ] Reviewer: confirm template comment-block style is acceptable
- [ ] (Post-merge) Run installer on Mac Studio, diff output vs current plists

🤖 Generated with [Claude Code](https://claude.com/claude-code)