### PR TITLE
fix(env): honor documented env > .env precedence (don't clobber caller env)

### DIFF
--- a/bin/devbrain
+++ b/bin/devbrain
@@ -58,16 +58,37 @@ if [[ "${1:-}" == "setup" ]] && [[ "${DEVBRAIN_NO_UPDATE:-}" != "1" ]]; then
     _auto_update
 fi
 
-# Load .env if present. `set -a` auto-exports all variables, so API keys
-# (ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY) and other secrets
-# become environment variables visible to Python + every child process
-# the factory spawns. Without this, keys saved to .env during setup
-# wouldn't be picked up by subprocesses.
-if [[ -f "$DEVBRAIN_DIR/.env" ]]; then
-    set -a
-    # shellcheck disable=SC1091
-    source "$DEVBRAIN_DIR/.env"
-    set +a
-fi
+# Load .env if present. Each KEY=VALUE pair is exported so it's visible
+# to Python and any subprocess the factory spawns. Honors the precedence
+# documented in .env.example: env > .env > config/devbrain.yaml > defaults.
+# A var already set in the caller's environment is preserved; .env only
+# fills in keys that aren't already set.
+#
+# (Previously this was `set -a; source .env; set +a`, which silently
+# clobbered caller-passed env. That broke ops scripts that try to override
+# values inline — e.g., `CLAUDE_CODE_OAUTH_TOKEN=newtok devbrain ...`.)
+_load_dotenv_no_override() {
+    local envfile="$1"
+    [[ -f "$envfile" ]] || return 0
+    local line key value
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        [[ -z "$line" || "$line" =~ ^# ]] && continue
+        line="${line#export }"
+        key="${line%%=*}"
+        value="${line#*=}"
+        [[ "$key" == "$line" ]] && continue
+        key="${key%%[[:space:]]*}"
+        if [[ "$value" =~ ^\".*\"$ ]]; then
+            value="${value#\"}"; value="${value%\"}"
+        elif [[ "$value" =~ ^\'.*\'$ ]]; then
+            value="${value#\'}"; value="${value%\'}"
+        fi
+        [[ -n "${!key+x}" ]] && continue
+        export "$key=$value"
+    done < "$envfile"
+}
+_load_dotenv_no_override "$DEVBRAIN_DIR/.env"
 
 exec "$DEVBRAIN_DIR/.venv/bin/python" "$DEVBRAIN_DIR/factory/cli.py" "$@"

--- a/bin/devbrain-onboard
+++ b/bin/devbrain-onboard
@@ -21,13 +21,32 @@ while [[ -L "$_target" ]]; do
 done
 DEVBRAIN_DIR="$(cd "$(dirname "$_target")/.." && pwd)"
 
-# Load .env so PGPASSWORD etc. propagate to the Python service.
-if [[ -f "$DEVBRAIN_DIR/.env" ]]; then
-    set -a
-    # shellcheck disable=SC1091
-    source "$DEVBRAIN_DIR/.env"
-    set +a
-fi
+# Load .env so PGPASSWORD etc. propagate to the Python service. Honors
+# documented precedence (env > .env > defaults): vars already set in the
+# caller's environment are preserved. See bin/devbrain for the rationale.
+_load_dotenv_no_override() {
+    local envfile="$1"
+    [[ -f "$envfile" ]] || return 0
+    local line key value
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        [[ -z "$line" || "$line" =~ ^# ]] && continue
+        line="${line#export }"
+        key="${line%%=*}"
+        value="${line#*=}"
+        [[ "$key" == "$line" ]] && continue
+        key="${key%%[[:space:]]*}"
+        if [[ "$value" =~ ^\".*\"$ ]]; then
+            value="${value#\"}"; value="${value%\"}"
+        elif [[ "$value" =~ ^\'.*\'$ ]]; then
+            value="${value#\'}"; value="${value%\'}"
+        fi
+        [[ -n "${!key+x}" ]] && continue
+        export "$key=$value"
+    done < "$envfile"
+}
+_load_dotenv_no_override "$DEVBRAIN_DIR/.env"
 
 # Map .env's DEVBRAIN_DB_* names to the standard PG* names that the
 # webhook script reads (matches libpq conventions, simpler test).

--- a/factory/tests/test_dotenv_loader.py
+++ b/factory/tests/test_dotenv_loader.py
@@ -1,0 +1,239 @@
+"""Tests for the bash `_load_dotenv_no_override` function shared across
+bin/devbrain, bin/devbrain-onboard, and mcp-server/run.sh.
+
+These three scripts each carry their own copy of the function (kept in
+sync by hand). We test by extracting the function from bin/devbrain
+and exercising it in a bash subprocess against a controlled .env file
+and pre-set caller env.
+
+The contract under test:
+  * Vars already set in env are preserved (env > .env precedence,
+    matching the .env.example doc comment).
+  * Quoted values have their surrounding quotes stripped (both " and ').
+  * `export FOO=bar` lines are accepted.
+  * Comment lines (#) and blank lines are ignored.
+  * Values containing `=` are preserved verbatim past the first `=`.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEVBRAIN_SCRIPT = REPO_ROOT / "bin" / "devbrain"
+
+
+def _extract_function() -> str:
+    """Pull the _load_dotenv_no_override function definition out of
+    bin/devbrain. Fails the test if the function name isn't found there,
+    which is also a useful failsafe for future renames.
+    """
+    text = DEVBRAIN_SCRIPT.read_text()
+    start = text.find("_load_dotenv_no_override() {")
+    if start < 0:
+        pytest.fail(
+            f"_load_dotenv_no_override() not found in {DEVBRAIN_SCRIPT} — "
+            "did the function get renamed?"
+        )
+    # Find the matching closing brace at column 0
+    end = text.find("\n}\n", start)
+    if end < 0:
+        pytest.fail("could not locate end of _load_dotenv_no_override()")
+    return text[start : end + 3]
+
+
+def _run_bash_with_dotenv(
+    envfile_contents: str,
+    *,
+    preset_env: dict[str, str] | None = None,
+    probe_keys: list[str],
+    tmp_path: Path,
+) -> dict[str, str]:
+    """Run a bash subprocess that sources the loader, applies it to a
+    written .env, and prints each probe_key on its own line.
+
+    Returns a dict of the values bash saw post-load. Empty strings are
+    preserved; truly unset variables come back as `<UNSET>`.
+    """
+    envfile = tmp_path / ".env"
+    envfile.write_text(envfile_contents)
+
+    fn = _extract_function()
+
+    # Compose the bash script: load the function, run it, dump probes.
+    # We use `${VAR-<UNSET>}` so a truly-unset var is distinguishable
+    # from one set to empty string.
+    probes = "\n".join(
+        f'echo "{k}=${{{k}-<UNSET>}}"' for k in probe_keys
+    )
+    script = textwrap.dedent(f"""
+        set -u
+        {fn}
+        _load_dotenv_no_override {envfile!s}
+        {probes}
+    """)
+
+    env = os.environ.copy()
+    # Strip any leftover test pollution
+    for k in probe_keys:
+        env.pop(k, None)
+    if preset_env:
+        env.update(preset_env)
+
+    result = subprocess.run(
+        ["bash", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = {}
+    for line in result.stdout.splitlines():
+        if "=" in line:
+            k, _, v = line.partition("=")
+            out[k] = v
+    return out
+
+
+def test_caller_env_wins_over_dotenv(tmp_path):
+    """env > .env: a var pre-set in env is preserved verbatim."""
+    contents = "ALREADY_SET=from_dotenv\n"
+    out = _run_bash_with_dotenv(
+        contents,
+        preset_env={"ALREADY_SET": "from_caller"},
+        probe_keys=["ALREADY_SET"],
+        tmp_path=tmp_path,
+    )
+    assert out["ALREADY_SET"] == "from_caller"
+
+
+def test_dotenv_fills_in_missing(tmp_path):
+    """.env fills in vars that weren't already set in env."""
+    contents = "KEY_FROM_FILE=from_env_file\n"
+    out = _run_bash_with_dotenv(
+        contents,
+        probe_keys=["KEY_FROM_FILE"],
+        tmp_path=tmp_path,
+    )
+    assert out["KEY_FROM_FILE"] == "from_env_file"
+
+
+def test_comments_and_blanks_ignored(tmp_path):
+    """Lines starting with # and blank lines are skipped silently."""
+    contents = textwrap.dedent("""
+        # a comment
+
+           # indented comment
+        REAL_KEY=real_value
+    """)
+    out = _run_bash_with_dotenv(
+        contents,
+        probe_keys=["REAL_KEY"],
+        tmp_path=tmp_path,
+    )
+    assert out["REAL_KEY"] == "real_value"
+
+
+def test_double_quoted_value_has_quotes_stripped(tmp_path):
+    contents = 'KEY_WITH_QUOTES="quoted_value"\n'
+    out = _run_bash_with_dotenv(
+        contents,
+        probe_keys=["KEY_WITH_QUOTES"],
+        tmp_path=tmp_path,
+    )
+    assert out["KEY_WITH_QUOTES"] == "quoted_value"
+
+
+def test_single_quoted_value_has_quotes_stripped(tmp_path):
+    contents = "KEY_WITH_SQUOTES='squoted_value'\n"
+    out = _run_bash_with_dotenv(
+        contents,
+        probe_keys=["KEY_WITH_SQUOTES"],
+        tmp_path=tmp_path,
+    )
+    assert out["KEY_WITH_SQUOTES"] == "squoted_value"
+
+
+def test_export_prefix_stripped(tmp_path):
+    """Bash-style `export KEY=value` lines work too."""
+    contents = "export PREFIXED=prefixed_value\n"
+    out = _run_bash_with_dotenv(
+        contents,
+        probe_keys=["PREFIXED"],
+        tmp_path=tmp_path,
+    )
+    assert out["PREFIXED"] == "prefixed_value"
+
+
+def test_value_with_equals_preserved(tmp_path):
+    """A value containing `=` (e.g. a URL with a query) keeps everything
+    after the first `=`."""
+    contents = "URL=postgres://user:pass=word@host/db?ssl=true\n"
+    out = _run_bash_with_dotenv(
+        contents,
+        probe_keys=["URL"],
+        tmp_path=tmp_path,
+    )
+    assert out["URL"] == "postgres://user:pass=word@host/db?ssl=true"
+
+
+def test_empty_value_allowed(tmp_path):
+    """KEY= with nothing after is a valid empty string, not a syntax
+    error and not skipped."""
+    contents = "EMPTY_KEY=\nOTHER=non_empty\n"
+    out = _run_bash_with_dotenv(
+        contents,
+        probe_keys=["EMPTY_KEY", "OTHER"],
+        tmp_path=tmp_path,
+    )
+    assert out["EMPTY_KEY"] == ""
+    assert out["OTHER"] == "non_empty"
+
+
+def test_caller_empty_string_wins(tmp_path):
+    """If caller pre-set a var to empty string, .env should NOT overwrite
+    it. (Empty string is a deliberate value; "" != "unset".)"""
+    contents = "DELIBERATELY_EMPTY=from_dotenv\n"
+    out = _run_bash_with_dotenv(
+        contents,
+        preset_env={"DELIBERATELY_EMPTY": ""},
+        probe_keys=["DELIBERATELY_EMPTY"],
+        tmp_path=tmp_path,
+    )
+    assert out["DELIBERATELY_EMPTY"] == ""
+
+
+def test_missing_dotenv_is_silent_noop(tmp_path):
+    """No .env at all — loader returns 0, no error, no vars set."""
+    out = _run_bash_with_dotenv(
+        "",  # we'll write empty, then delete it
+        probe_keys=["ANYTHING"],
+        tmp_path=tmp_path,
+    )
+    (tmp_path / ".env").unlink(missing_ok=True)
+    # Re-run after the unlink
+    fn = _extract_function()
+    result = subprocess.run(
+        ["bash", "-c", f"set -u\n{fn}\n_load_dotenv_no_override {tmp_path}/.env\necho ok"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "ok" in result.stdout
+
+
+def test_function_present_in_all_three_scripts():
+    """All three entry-point scripts must carry the same loader function
+    (kept in sync by hand). Catches drift."""
+    for rel in ("bin/devbrain", "bin/devbrain-onboard", "mcp-server/run.sh"):
+        script = REPO_ROOT / rel
+        assert script.exists(), f"missing entry-point: {rel}"
+        text = script.read_text()
+        assert "_load_dotenv_no_override() {" in text, (
+            f"{rel} missing the shared _load_dotenv_no_override loader — "
+            f"its .env behavior will drift from the other entrypoints"
+        )

--- a/mcp-server/run.sh
+++ b/mcp-server/run.sh
@@ -5,13 +5,31 @@ DEVBRAIN_HOME="${DEVBRAIN_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 # Load .env so API keys and config overrides are available to the MCP
 # server and any subprocesses it spawns (factory orchestrator, ingest
-# scripts, spawned AI CLIs). Without this, keys saved to .env wouldn't
-# be in the environment of processes launched by the MCP server.
-if [[ -f "$DEVBRAIN_HOME/.env" ]]; then
-    set -a
-    # shellcheck disable=SC1091
-    source "$DEVBRAIN_HOME/.env"
-    set +a
-fi
+# scripts, spawned AI CLIs). Honors documented precedence (env > .env >
+# defaults): vars already set in the caller's environment are preserved.
+# See bin/devbrain for the rationale.
+_load_dotenv_no_override() {
+    local envfile="$1"
+    [[ -f "$envfile" ]] || return 0
+    local line key value
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        [[ -z "$line" || "$line" =~ ^# ]] && continue
+        line="${line#export }"
+        key="${line%%=*}"
+        value="${line#*=}"
+        [[ "$key" == "$line" ]] && continue
+        key="${key%%[[:space:]]*}"
+        if [[ "$value" =~ ^\".*\"$ ]]; then
+            value="${value#\"}"; value="${value%\"}"
+        elif [[ "$value" =~ ^\'.*\'$ ]]; then
+            value="${value#\'}"; value="${value%\'}"
+        fi
+        [[ -n "${!key+x}" ]] && continue
+        export "$key=$value"
+    done < "$envfile"
+}
+_load_dotenv_no_override "$DEVBRAIN_HOME/.env"
 
 exec node "$DEVBRAIN_HOME/mcp-server/dist/index.js"


### PR DESCRIPTION
## Summary

`.env.example` line 4 documents: **"Precedence: env > config/devbrain.yaml > built-in defaults"**. But the three bash entry-points (`bin/devbrain`, `bin/devbrain-onboard`, `mcp-server/run.sh`) all used `set -a; source .env; set +a`, which **clobbers** caller-passed env with `.env` values — the opposite of the documented behavior.

## Bug example

```bash
# Expected by docs: my passed token wins.
CLAUDE_CODE_OAUTH_TOKEN=newtok devbrain cognify-reextract --all ...

# Actual: .env's `CLAUDE_CODE_OAUTH_TOKEN=oldtok` silently overrides mine.
```

Discovered today (2026-05-13) while testing the new `setup-cognify-launchd` installer (#125): I passed an OAuth token via SSH env, but `.env` had a different token, and the wrapper's `source .env` silently overrode mine. The plist ended up with the .env value, not the one I'd passed.

## Fix

Replaces `set -a; source .env; set +a` in all three scripts with `_load_dotenv_no_override()`:

```bash
_load_dotenv_no_override() {
    local envfile="$1"
    [[ -f "$envfile" ]] || return 0
    local line key value
    while IFS= read -r line || [[ -n "$line" ]]; do
        line="${line%$'\r'}"
        line="${line#"${line%%[![:space:]]*}"}"
        [[ -z "$line" || "$line" =~ ^# ]] && continue
        line="${line#export }"
        key="${line%%=*}"
        value="${line#*=}"
        [[ "$key" == "$line" ]] && continue
        key="${key%%[[:space:]]*}"
        if [[ "$value" =~ ^\".*\"$ ]]; then
            value="${value#\"}"; value="${value%\"}"
        elif [[ "$value" =~ ^\'.*\'$ ]]; then
            value="${value#\'}"; value="${value%\'}"
        fi
        [[ -n "${!key+x}" ]] && continue   # caller env wins
        export "$key=$value"
    done < "$envfile"
}
```

Behavior:

| Input | Handling |
|---|---|
| Comments + blank lines | Skipped |
| `export FOO=bar` | Treated as `FOO=bar` |
| `KEY="val"` / `KEY='val'` | Surrounding quotes stripped |
| `URL=postgres://u:p=w@h/db?ssl=true` | First `=` splits; rest of value preserved verbatim |
| `KEY=` (empty value) | Allowed |
| Key already set in caller env | **Preserved — .env does not override** ✓ |

The function is duplicated verbatim across the three scripts (rather than sourced from a shared helper) to keep each script self-contained.

## Why a doc-precedence violation is a bug, not a behavior preference

Anyone reading `.env.example` and writing ops scripts based on the documented precedence is in for a silent breakage today. Two examples I found searching the codebase:

- `bin/devbrain-onboard` lines 34-41 use `${VAR:-default}` patterns *after* `source .env`. The author clearly expected env > defaults, but `source .env` having already clobbered env defeats the pattern unless `.env` has that key absent.
- `setup-cognify-launchd` installer (#125) reads env at install time. With the buggy loader, you can't override what gets baked into plists by passing inline env — you have to edit `.env` first, which is awkward for one-off ops.

## Test plan

- [x] `pytest factory/tests/test_dotenv_loader.py` — **11 new tests, all pass**
  - caller env > .env (the headline change)
  - .env fills in missing
  - comments + blanks ignored
  - double + single quote stripping
  - export prefix stripping
  - `=` in values preserved
  - empty values allowed
  - caller's empty string wins
  - missing .env is silent noop
  - function present in all 3 scripts (drift-catcher)
- [x] Test extracts the function from `bin/devbrain` and runs it in a bash subprocess — so it tests the actual code shipped, not a copy
- [ ] Reviewer: confirm no operational flow you maintain relied on `.env`-wins behavior (I searched the codebase and found none; the only places sourcing .env are these three scripts and they all use the same pattern that this PR fixes)

## Deploy note

Mac Studio's `/opt/homebrew/bin/devbrain` is a symlink to `/Users/lhtdev/devbrain/bin/devbrain` (confirmed today), so `git pull` on Mac Studio is sufficient to deploy this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)