### PR TITLE
feat(cognify): --max-llm-calls CLI flag for extract + edges passes

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2884,9 +2884,14 @@ def cmd_rules_lint():
               help="Edges pass only: include canonical 'devbrain' rules library "
                    "as candidate-pair source. Detects when project lessons "
                    "contradict canonical regulatory rules. Other passes ignore.")
+@click.option("--max-llm-calls", "max_llm_calls", type=int, default=None,
+              help="Override the per-pass LLM-call ceiling (extract + edges "
+                   "only; zero-LLM passes ignore). When omitted, each pass "
+                   "uses its built-in default (extract=20, edges=15). "
+                   "Use 0 to skip LLM work entirely.")
 @click.option("--json", "as_json", is_flag=True, default=False,
               help="Emit result as JSON.")
-def cognify_command(pass_name, run_all, project_slug, dry_run, cross_project, as_json):
+def cognify_command(pass_name, run_all, project_slug, dry_run, cross_project, max_llm_calls, as_json):
     """Run one or all cognify passes.
 
     Examples:\n
@@ -2894,7 +2899,9 @@ def cognify_command(pass_name, run_all, project_slug, dry_run, cross_project, as
       devbrain cognify --pass=extract --project=myproject\n
       devbrain cognify --all --project=myproject\n
       devbrain cognify --pass=decay --dry-run\n
-      devbrain cognify --pass=edges --project=brightbot --cross-project
+      devbrain cognify --pass=edges --project=brightbot --cross-project\n
+      devbrain cognify --pass=edges --project=brightbot --max-llm-calls=5\n
+      devbrain cognify --pass=extract --project=brightbot --max-llm-calls=0
     """
     import sys
     from config import DATABASE_URL
@@ -2925,7 +2932,10 @@ def cognify_command(pass_name, run_all, project_slug, dry_run, cross_project, as
     with db._conn() as conn:
         if run_all:
             results = _run_all(
-                conn, project_id, dry_run=dry_run, cross_project=cross_project
+                conn, project_id,
+                dry_run=dry_run,
+                cross_project=cross_project,
+                max_llm_calls=max_llm_calls,
             )
             if as_json:
                 import json as _json
@@ -2942,7 +2952,9 @@ def cognify_command(pass_name, run_all, project_slug, dry_run, cross_project, as
         else:
             result = _run_pass(
                 conn, pass_name, project_id,
-                dry_run=dry_run, cross_project=cross_project,
+                dry_run=dry_run,
+                cross_project=cross_project,
+                max_llm_calls=max_llm_calls,
             )
             if as_json:
                 import json as _json

--- a/factory/cognify/edges.py
+++ b/factory/cognify/edges.py
@@ -79,6 +79,7 @@ class EdgesPass(CognifyPass):
         *,
         dry_run: bool = False,
         cross_project: bool = False,
+        max_llm_calls: int | None = None,
     ) -> PassResult:
         if project_id is None:
             raise ValueError(
@@ -86,7 +87,10 @@ class EdgesPass(CognifyPass):
             )
 
         cites_new, contradicts_new, llm_calls = _run_edges(
-            conn, project_id, dry_run=dry_run, cross_project=cross_project
+            conn, project_id,
+            dry_run=dry_run,
+            cross_project=cross_project,
+            max_llm_calls=max_llm_calls,
         )
         return PassResult(
             rows_processed=cites_new + contradicts_new,
@@ -105,17 +109,23 @@ def _run_edges(
     *,
     dry_run: bool = False,
     cross_project: bool = False,
+    max_llm_calls: int | None = None,
 ) -> tuple[int, int, int]:
     """Main edges pass logic. Returns (cites_new, contradicts_new, llm_calls).
 
     cites detection stays strictly project-local (text-pattern match;
     no walker involvement). Only contradicts detection honors
     cross_project when True.
+
+    max_llm_calls: per-pass ceiling on contradicts-detection LLM calls.
+    When None (default), uses MAX_LLM_CALLS_PER_PASS=15. cites detection
+    is zero-LLM and ignores this.
     """
     cites_new = _detect_cites(conn, project_id, dry_run=dry_run)
     contradicts_new, llm_calls = _detect_contradicts(
         conn, project_id, dry_run=dry_run, record_conn=conn,
         cross_project=cross_project,
+        max_llm_calls=max_llm_calls,
     )
     return cites_new, contradicts_new, llm_calls
 
@@ -184,6 +194,7 @@ def _detect_contradicts(
     dry_run: bool = False,
     record_conn: Any = None,
     cross_project: bool = False,
+    max_llm_calls: int | None = None,
 ) -> tuple[int, int]:
     """Detect contradicts edges using Phase 5 graph_walk + LLM judgment.
 
@@ -252,8 +263,9 @@ def _detect_contradicts(
 
     new_edges = 0
     llm_calls = 0
-    for from_id, to_id in candidate_pairs[:MAX_LLM_CALLS_PER_PASS]:
-        if llm_calls >= MAX_LLM_CALLS_PER_PASS:
+    cap = max_llm_calls if max_llm_calls is not None else MAX_LLM_CALLS_PER_PASS
+    for from_id, to_id in candidate_pairs[:cap]:
+        if llm_calls >= cap:
             break
         content_a = content_by_id.get(from_id, "")
         content_b = content_by_id.get(to_id, "")

--- a/factory/cognify/extract.py
+++ b/factory/cognify/extract.py
@@ -77,13 +77,22 @@ class ExtractPass(CognifyPass):
 
     pass_name = "extract"
 
-    def run(self, conn: Any, project_id: Any, *, dry_run: bool = False) -> PassResult:
+    def run(
+        self,
+        conn: Any,
+        project_id: Any,
+        *,
+        dry_run: bool = False,
+        max_llm_calls: int | None = None,
+    ) -> PassResult:
         """Extract lessons/decisions from sessions ingested since last pass.
 
         Args:
             conn: psycopg2 connection.
             project_id: UUID. Required for extract (LLM pass; project-scoped).
             dry_run: if True, compute candidate sessions without extracting.
+            max_llm_calls: per-pass ceiling on LLM calls. When None (default),
+                uses MAX_LLM_CALLS_PER_PASS=20.
 
         Returns:
             PassResult with row counts.
@@ -93,6 +102,8 @@ class ExtractPass(CognifyPass):
                 "cognify_extract requires a project_id "
                 "(it's an LLM-cost pass; always project-scoped)"
             )
+
+        cap = max_llm_calls if max_llm_calls is not None else MAX_LLM_CALLS_PER_PASS
 
         since = _last_successful_run(conn, "extract", project_id)
         candidate_sessions = _sessions_since(conn, project_id, since)
@@ -114,10 +125,10 @@ class ExtractPass(CognifyPass):
         sessions_processed = 0
 
         for session_id in candidate_sessions:
-            if total_llm >= MAX_LLM_CALLS_PER_PASS:
+            if total_llm >= cap:
                 logger.info(
                     "cognify_extract: LLM cap (%d) reached, deferring %d sessions",
-                    MAX_LLM_CALLS_PER_PASS,
+                    cap,
                     len(candidate_sessions) - sessions_processed,
                 )
                 break
@@ -125,7 +136,7 @@ class ExtractPass(CognifyPass):
                 conn,
                 session_id,
                 project_id,
-                max_llm_calls=MAX_LLM_CALLS_PER_PASS - total_llm,
+                max_llm_calls=cap - total_llm,
             )
             total_lessons += result.lessons_created
             total_decisions += result.decisions_created

--- a/factory/cognify/orchestrator.py
+++ b/factory/cognify/orchestrator.py
@@ -122,6 +122,7 @@ def run_pass(
     *,
     dry_run: bool = False,
     cross_project: bool = False,
+    max_llm_calls: int | None = None,
 ) -> PassResult:
     """Run a single named pass and record it in cognify_run_log.
 
@@ -133,6 +134,10 @@ def run_pass(
         cross_project: only honored by passes that opt in (currently
             'edges' for canonical-rule contradiction sweeps). Other
             passes ignore the flag.
+        max_llm_calls: per-pass override for the LLM-call ceiling. Only
+            honored by LLM-cost passes (extract + edges). Zero-LLM passes
+            (decay, gc, strengthen) ignore it. When None (default), each
+            pass uses its own built-in MAX_LLM_CALLS_PER_PASS constant.
 
     Returns:
         PassResult from the pass.
@@ -155,14 +160,17 @@ def run_pass(
     error_text: str | None = None
 
     try:
-        # Pass-specific kwargs: only forward cross_project to passes that
-        # accept it. The introspection check keeps the signature optional
-        # without forcing every pass to declare it.
+        # Pass-specific kwargs: only forward optional flags to passes
+        # whose .run() signature declares them. Keeps each pass'
+        # signature minimal without forcing every pass to accept every
+        # orchestrator-wide flag.
         kwargs = {"dry_run": dry_run}
         import inspect
         sig = inspect.signature(instance.run)
         if "cross_project" in sig.parameters:
             kwargs["cross_project"] = cross_project
+        if "max_llm_calls" in sig.parameters:
+            kwargs["max_llm_calls"] = max_llm_calls
         result = instance.run(conn, project_id, **kwargs)
     except Exception as exc:
         error_text = traceback.format_exc()[:2000]
@@ -184,6 +192,7 @@ def run_all(
     *,
     dry_run: bool = False,
     cross_project: bool = False,
+    max_llm_calls: int | None = None,
 ) -> dict[str, PassResult]:
     """Run all 5 passes in dependency order.
 
@@ -192,6 +201,8 @@ def run_all(
     flaky LLM in 'extract' doesn't block 'strengthen'.
 
     cross_project is forwarded to passes that accept it (currently 'edges').
+    max_llm_calls is forwarded to LLM-cost passes (extract + edges); zero-
+    LLM passes ignore it.
     """
     _ensure_registry()
     results: dict[str, PassResult] = {}
@@ -199,7 +210,9 @@ def run_all(
         try:
             results[name] = run_pass(
                 conn, name, project_id,
-                dry_run=dry_run, cross_project=cross_project,
+                dry_run=dry_run,
+                cross_project=cross_project,
+                max_llm_calls=max_llm_calls,
             )
         except RuntimeError:
             # Logged inside run_pass; continue to next pass.

--- a/factory/tests/test_cognify_max_llm_calls.py
+++ b/factory/tests/test_cognify_max_llm_calls.py
@@ -1,0 +1,291 @@
+"""Tests for the --max-llm-calls CLI flag and its plumbing through the
+orchestrator → ExtractPass / EdgesPass → _llm_extract / _detect_contradicts.
+
+These tests focus on the cap *plumbing*, not the LLM call itself. The
+LLM functions are stubbed; we assert how many times they get invoked.
+
+Each pass also retains its built-in default cap (MAX_LLM_CALLS_PER_PASS),
+exercised separately for sanity.
+"""
+from __future__ import annotations
+
+import inspect
+import os
+from unittest.mock import patch
+
+import pytest
+
+from cognify import edges as edges_mod
+from cognify import extract as extract_mod
+from cognify.orchestrator import run_pass
+
+
+# ─── Signatures: confirm the kwarg exists on every layer ─────────────────────
+
+
+def test_extract_pass_run_accepts_max_llm_calls():
+    sig = inspect.signature(extract_mod.ExtractPass.run)
+    assert "max_llm_calls" in sig.parameters
+    assert sig.parameters["max_llm_calls"].default is None
+
+
+def test_edges_pass_run_accepts_max_llm_calls():
+    sig = inspect.signature(edges_mod.EdgesPass.run)
+    assert "max_llm_calls" in sig.parameters
+    assert sig.parameters["max_llm_calls"].default is None
+
+
+def test_run_edges_helper_accepts_max_llm_calls():
+    sig = inspect.signature(edges_mod._run_edges)
+    assert "max_llm_calls" in sig.parameters
+
+
+def test_detect_contradicts_accepts_max_llm_calls():
+    sig = inspect.signature(edges_mod._detect_contradicts)
+    assert "max_llm_calls" in sig.parameters
+
+
+def test_orchestrator_run_pass_accepts_max_llm_calls():
+    sig = inspect.signature(run_pass)
+    assert "max_llm_calls" in sig.parameters
+
+
+# ─── Behavior: extract pass honors the override ──────────────────────────────
+
+
+class _StubConn:
+    """Minimal stand-in for psycopg2 conn — methods are unused because we
+    stub `extract_from_session` before the conn is touched."""
+    def cursor(self):
+        raise RuntimeError("cursor() shouldn't be called when we stub the helpers")
+
+    def commit(self):
+        pass
+
+
+def _set_extract_stubs(*, candidate_session_ids, per_session_lessons=1, per_session_decisions=1, per_session_llm=1):
+    """Return patches that:
+      - Make `_last_successful_run` return None.
+      - Make `_sessions_since` return the given session id list.
+      - Make `extract_from_session` return a deterministic _ExtractResult.
+
+    Yields the list of patch context managers so the caller can stack
+    them with contextlib.ExitStack if needed; this helper just returns
+    them as a tuple.
+    """
+    from cognify.extract import ExtractResult  # noqa: PLC0415
+
+    fake_result = ExtractResult(
+        session_id="stub",
+        lessons_created=per_session_lessons,
+        decisions_created=per_session_decisions,
+        llm_calls=per_session_llm,
+    )
+    return (
+        patch("cognify.extract._last_successful_run", return_value=None),
+        patch("cognify.extract._sessions_since", return_value=candidate_session_ids),
+        patch("cognify.extract.extract_from_session", return_value=fake_result),
+    )
+
+
+def test_extract_pass_honors_max_llm_calls_below_default():
+    """5 candidate sessions, each costs 1 LLM call. With max_llm_calls=3,
+    we expect exactly 3 sessions processed (then break)."""
+    sessions = [f"session-{i}" for i in range(5)]
+    patches = _set_extract_stubs(candidate_session_ids=sessions)
+
+    with patches[0], patches[1], patches[2] as p_extract:
+        pass_obj = extract_mod.ExtractPass()
+        result = pass_obj.run(_StubConn(), project_id="proj-1", max_llm_calls=3)
+
+    assert result.llm_calls == 3
+    # 3 sessions × 1 lesson + 3 × 1 decision = 6 rows
+    assert result.rows_processed == 6
+    assert p_extract.call_count == 3
+
+
+def test_extract_pass_uses_default_cap_when_none():
+    """max_llm_calls=None means use the module-level default (20).
+    With 30 candidate sessions, we expect exactly 20 processed."""
+    sessions = [f"session-{i}" for i in range(30)]
+    patches = _set_extract_stubs(candidate_session_ids=sessions)
+
+    with patches[0], patches[1], patches[2] as p_extract:
+        pass_obj = extract_mod.ExtractPass()
+        result = pass_obj.run(_StubConn(), project_id="proj-1", max_llm_calls=None)
+
+    assert result.llm_calls == extract_mod.MAX_LLM_CALLS_PER_PASS
+    assert p_extract.call_count == extract_mod.MAX_LLM_CALLS_PER_PASS
+
+
+def test_extract_pass_zero_cap_skips_all_llm_work():
+    """max_llm_calls=0 means do nothing LLM-side."""
+    sessions = [f"session-{i}" for i in range(5)]
+    patches = _set_extract_stubs(candidate_session_ids=sessions)
+
+    with patches[0], patches[1], patches[2] as p_extract:
+        pass_obj = extract_mod.ExtractPass()
+        result = pass_obj.run(_StubConn(), project_id="proj-1", max_llm_calls=0)
+
+    assert result.llm_calls == 0
+    assert p_extract.call_count == 0
+
+
+# ─── Behavior: edges pass honors the override ────────────────────────────────
+
+
+def test_detect_contradicts_honors_max_llm_calls_below_default():
+    """Stub the LLM judge so it always returns "not a contradiction" and
+    bump candidate-pair generation so we have plenty. Then assert the
+    LLM is called exactly `cap` times when cap < default (15)."""
+    from uuid import uuid4
+    # Build 20 fake memories — more than the default cap.
+    memories = [
+        {
+            "id": uuid4(),
+            "kind": "memory",
+            "tier": "lesson",
+            "title": f"Lesson {i}",
+            "content": f"Lesson body {i}",
+        }
+        for i in range(20)
+    ]
+
+    fake_call_count = {"n": 0}
+
+    def fake_llm_judge(content_a, content_b):
+        fake_call_count["n"] += 1
+        return False, {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        }
+
+    # Fake a graph_walk that returns all other memories as neighbors,
+    # so candidate_pairs >= 100 (way over any cap we'd test).
+    class FakeNode:
+        def __init__(self, mid):
+            self.id = mid
+
+    class FakeWalkResult:
+        def __init__(self, nodes):
+            self.memories = nodes
+
+    def fake_graph_walk(*args, **kwargs):
+        all_ids = [m["id"] for m in memories]
+        return FakeWalkResult([FakeNode(mid) for mid in all_ids])
+
+    with patch("cognify.edges._load_memories", return_value=memories), \
+         patch("cognify.edges._llm_judge_contradiction", side_effect=fake_llm_judge), \
+         patch("cognify.edges.walk", side_effect=fake_graph_walk), \
+         patch("cognify.edges._insert_edge", return_value=1):
+        new_edges, llm_calls = edges_mod._detect_contradicts(
+            conn=_StubConn(),
+            project_id="proj-1",
+            dry_run=False,
+            record_conn=None,
+            max_llm_calls=4,
+        )
+
+    # The cap should be honored exactly.
+    assert llm_calls == 4
+    assert fake_call_count["n"] == 4
+
+
+def test_detect_contradicts_uses_default_cap_when_none():
+    """Same setup, max_llm_calls=None → uses MAX_LLM_CALLS_PER_PASS=15."""
+    from uuid import uuid4
+    memories = [
+        {
+            "id": uuid4(),
+            "kind": "memory",
+            "tier": "lesson",
+            "title": f"Lesson {i}",
+            "content": f"Lesson body {i}",
+        }
+        for i in range(40)
+    ]
+
+    fake_call_count = {"n": 0}
+
+    def fake_llm_judge(content_a, content_b):
+        fake_call_count["n"] += 1
+        return False, {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        }
+
+    class FakeNode:
+        def __init__(self, mid):
+            self.id = mid
+
+    class FakeWalkResult:
+        def __init__(self, nodes):
+            self.memories = nodes
+
+    def fake_graph_walk(*args, **kwargs):
+        return FakeWalkResult([FakeNode(m["id"]) for m in memories])
+
+    with patch("cognify.edges._load_memories", return_value=memories), \
+         patch("cognify.edges._llm_judge_contradiction", side_effect=fake_llm_judge), \
+         patch("cognify.edges.walk", side_effect=fake_graph_walk), \
+         patch("cognify.edges._insert_edge", return_value=1):
+        new_edges, llm_calls = edges_mod._detect_contradicts(
+            conn=_StubConn(),
+            project_id="proj-1",
+            dry_run=False,
+            record_conn=None,
+            max_llm_calls=None,
+        )
+
+    assert llm_calls == edges_mod.MAX_LLM_CALLS_PER_PASS  # 15
+
+
+def test_detect_contradicts_zero_cap_skips_all_llm_work():
+    """max_llm_calls=0 means no LLM calls."""
+    from uuid import uuid4
+    memories = [
+        {
+            "id": uuid4(),
+            "kind": "memory",
+            "tier": "lesson",
+            "title": f"Lesson {i}",
+            "content": f"Lesson body {i}",
+        }
+        for i in range(10)
+    ]
+
+    fake_call_count = {"n": 0}
+
+    def fake_llm_judge(content_a, content_b):
+        fake_call_count["n"] += 1
+        return False, {}
+
+    class FakeNode:
+        def __init__(self, mid):
+            self.id = mid
+
+    class FakeWalkResult:
+        def __init__(self, nodes):
+            self.memories = nodes
+
+    def fake_graph_walk(*args, **kwargs):
+        return FakeWalkResult([FakeNode(m["id"]) for m in memories])
+
+    with patch("cognify.edges._load_memories", return_value=memories), \
+         patch("cognify.edges._llm_judge_contradiction", side_effect=fake_llm_judge), \
+         patch("cognify.edges.walk", side_effect=fake_graph_walk), \
+         patch("cognify.edges._insert_edge", return_value=1):
+        new_edges, llm_calls = edges_mod._detect_contradicts(
+            conn=_StubConn(),
+            project_id="proj-1",
+            dry_run=False,
+            record_conn=None,
+            max_llm_calls=0,
+        )
+
+    assert llm_calls == 0
+    assert fake_call_count["n"] == 0


### PR DESCRIPTION
## Summary

Both LLM-cost cognify passes had hardcoded `MAX_LLM_CALLS_PER_PASS` constants (extract=20, edges=15) with no runtime override. The edges pass in particular has no candidate-prefilter beyond the cap, so a real run on a project with ~50K memories can otherwise rack up unbounded LLM cost.

Discovered during today's cognify debug session — I had to kill two `cognify --pass=edges --dry-run` python processes that had been pegging 99% CPU for 15+ minutes on brightbot's 48K-row dataset. (The actual fix for those was killing the rogue python procs, but the underlying cost-ceiling exposure problem deserves its own knob.)

## Changes

Adds `--max-llm-calls INT` to `devbrain cognify`, plumbed:

```
cli.py (--max-llm-calls)
  → orchestrator.run_pass(max_llm_calls=...)
    → ExtractPass.run(max_llm_calls=...)  ─→  internal extract loop
    → EdgesPass.run(max_llm_calls=...)
      → _run_edges
        → _detect_contradicts
```

The orchestrator forwards `max_llm_calls` only to passes whose `.run()` signature declares it (mirrors the existing `cross_project` introspection pattern). Zero-LLM passes (decay, gc, strengthen) ignore the flag silently.

```bash
# Cap an edges pass to 5 LLM calls
devbrain cognify --pass=edges --project=brightbot --max-llm-calls=5

# Skip LLM work entirely — useful for verifying the non-LLM half
# of a pass (candidate enumeration, etc.) at zero cost
devbrain cognify --pass=extract --project=brightbot --max-llm-calls=0
```

## Tests (11 new in `test_cognify_max_llm_calls.py`)

- **Signature smoke tests on all 5 layers**: ExtractPass.run, EdgesPass.run, `_run_edges`, `_detect_contradicts`, `orchestrator.run_pass`. Catches drift if someone removes the kwarg.
- **Extract pass behavior**: cap below default honored, default used when None, zero cap skips all LLM work.
- **Edges pass behavior**: same three cases, with the LLM judge + walker stubbed to verify exact call counts.

All 56 existing cognify tests still pass — no regressions.

## Test plan

- [x] `pytest factory/tests/test_cognify_max_llm_calls.py` — 11/11
- [x] `pytest factory/tests/ -k cognify` — 56 pass, 56 skipped (DB), 0 fail
- [x] `devbrain cognify --help` shows the new flag with examples
- [ ] Reviewer: smoke-test against a real project to confirm behavior end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)