### PR TITLE
feat(cognify): extract nomenclature + JSON-parse failure telemetry

### DIFF
--- a/factory/cognify/extract.py
+++ b/factory/cognify/extract.py
@@ -58,7 +58,16 @@ _EXTRACT_MODEL = "claude-sonnet-4-6"
 
 @dataclass
 class ExtractResult:
-    """Result of extracting lessons/decisions from a single session."""
+    """Result of extracting lessons/decisions from a single session.
+
+    `lessons_created` is the LLM-facing nomenclature — the prompt asks
+    the model to produce "lessons" and we count what it returned. In
+    DB storage these rows land with `kind='pattern'` (the storage-layer
+    naming); see `_upsert_memory(..., kind='pattern', ...)` below. The
+    `patterns_created` attribute is an alias for the same int, exposed
+    so SQL-side code can use the storage name without remembering the
+    LLM-side rename.
+    """
 
     session_id: str
     lessons_created: int = 0
@@ -66,6 +75,12 @@ class ExtractResult:
     skipped_duplicates: int = 0
     llm_calls: int = 0
     memory_ids: list[str] = field(default_factory=list)
+    failure: str | None = None  # None | "api" | "json_parse" | "empty"
+
+    @property
+    def patterns_created(self) -> int:
+        """Alias for lessons_created — matches DB storage kind ('pattern')."""
+        return self.lessons_created
 
 
 @register_pass
@@ -123,6 +138,7 @@ class ExtractPass(CognifyPass):
         total_decisions = 0
         total_llm = 0
         sessions_processed = 0
+        failure_counts: dict[str, int] = {}
 
         for session_id in candidate_sessions:
             if total_llm >= cap:
@@ -142,6 +158,8 @@ class ExtractPass(CognifyPass):
             total_decisions += result.decisions_created
             total_llm += result.llm_calls
             sessions_processed += 1
+            if result.failure:
+                failure_counts[result.failure] = failure_counts.get(result.failure, 0) + 1
 
         rows = total_lessons + total_decisions
         return PassResult(
@@ -150,8 +168,14 @@ class ExtractPass(CognifyPass):
             metadata={
                 "pass": "extract",
                 "sessions_processed": sessions_processed,
+                # LLM-side naming (what the model produces); DB stores these
+                # under `kind='pattern'`, so `patterns_created` is an alias.
                 "lessons_created": total_lessons,
+                "patterns_created": total_lessons,
                 "decisions_created": total_decisions,
+                # A4: surface per-failure-kind counts so silent JSON parse
+                # errors and API failures are visible in the run log.
+                "failure_counts": failure_counts,
                 "since": since.isoformat() if since else None,
             },
         )
@@ -281,6 +305,7 @@ def extract_from_session(
         skipped_duplicates=skipped,
         llm_calls=llm_calls,
         memory_ids=memory_ids,
+        failure=extracted.get("_failure"),
     )
 
 
@@ -434,6 +459,13 @@ def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
     # Input cap of 200_000 chars (~50K tokens) — Sonnet 4.6 has a 1M context
     # window, but real session_summaries top out well below 200K chars. The
     # previous 8K cap silently discarded 95%+ of any non-trivial summary.
+    # Make the LLM call. Distinguish three failure modes so callers can
+    # tell whether a session produced 0 atoms because:
+    #   _failure="api"        the API call itself errored (network/auth/429)
+    #   _failure="json_parse" the model returned non-JSON output
+    #   _failure="empty"      the model returned valid JSON but with empty lists
+    # All three currently degrade gracefully (return empty lists); the
+    # _failure label is for telemetry/diagnostics so we can spot drift.
     try:
         response = client.messages.create(
             model=_EXTRACT_MODEL,
@@ -446,24 +478,50 @@ def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
                 }
             ],
         )
-        usage = response.usage
-        token_usage = {
-            "input_tokens": getattr(usage, "input_tokens", 0),
-            "output_tokens": getattr(usage, "output_tokens", 0),
-            "cache_read_tokens": getattr(usage, "cache_read_input_tokens", 0) or 0,
-            "cache_write_tokens": getattr(usage, "cache_creation_input_tokens", 0) or 0,
-        }
-        text = response.content[0].text.strip()
-        # Strip markdown code fences if present.
-        if text.startswith("```"):
-            text = "\n".join(text.split("\n")[1:])
-            text = text.rsplit("```", 1)[0].strip()
-        result = json.loads(text)
-        result["_usage"] = token_usage
-        return result
     except Exception as exc:  # noqa: BLE001
-        logger.warning("cognify_extract: LLM call failed: %s", exc)
-        return {"lessons": [], "decisions": [], "_usage": _empty_usage}
+        logger.warning("cognify_extract: LLM API call failed: %s", exc)
+        return {
+            "lessons": [],
+            "decisions": [],
+            "_usage": _empty_usage,
+            "_failure": "api",
+            "_failure_detail": str(exc)[:500],
+        }
+
+    usage = response.usage
+    token_usage = {
+        "input_tokens": getattr(usage, "input_tokens", 0),
+        "output_tokens": getattr(usage, "output_tokens", 0),
+        "cache_read_tokens": getattr(usage, "cache_read_input_tokens", 0) or 0,
+        "cache_write_tokens": getattr(usage, "cache_creation_input_tokens", 0) or 0,
+    }
+    text = response.content[0].text.strip()
+    # Strip markdown code fences if present.
+    if text.startswith("```"):
+        text = "\n".join(text.split("\n")[1:])
+        text = text.rsplit("```", 1)[0].strip()
+    try:
+        result = json.loads(text)
+    except json.JSONDecodeError as exc:
+        # Log a sample of the offending payload so we can spot patterns
+        # (e.g. model returning a refusal, hitting max_tokens mid-string,
+        # wrapping in extra preamble). Keep it short to avoid flooding logs.
+        payload_sample = text[:400] if text else "<empty>"
+        logger.warning(
+            "cognify_extract: JSON parse failed (%s); model output sample: %r",
+            exc, payload_sample,
+        )
+        return {
+            "lessons": [],
+            "decisions": [],
+            "_usage": token_usage,  # the API call DID succeed; preserve spend
+            "_failure": "json_parse",
+            "_failure_detail": f"{exc.__class__.__name__}: {exc}; sample={payload_sample!r}",
+        }
+    result["_usage"] = token_usage
+    if not result.get("lessons") and not result.get("decisions"):
+        result["_failure"] = "empty"
+    return result
 
 
 def _resolve_auth() -> dict[str, Any] | None:

--- a/factory/cognify/reextract_cli.py
+++ b/factory/cognify/reextract_cli.py
@@ -102,6 +102,7 @@ def run_reextract(
 
     total_lessons = 0
     total_decisions = 0
+    failure_counts: dict[str, int] = {}
 
     for sid in sessions:
         result = extract_from_session(
@@ -112,12 +113,19 @@ def run_reextract(
         )
         total_lessons += result.lessons_created
         total_decisions += result.decisions_created
+        if result.failure:
+            failure_counts[result.failure] = failure_counts.get(result.failure, 0) + 1
         # archived count is recorded internally via _archive_prior_extracts.
 
     return {
         "sessions_targeted": len(sessions),
+        # LLM-side naming (what the model produces); DB stores these under
+        # `kind='pattern'`, so `patterns_created` is an alias.
         "lessons_created": total_lessons,
+        "patterns_created": total_lessons,
         "decisions_created": total_decisions,
+        # A4: visibility into silent JSON parse / API failures during reextract.
+        "failure_counts": failure_counts,
     }
 
 

--- a/factory/tests/test_cognify_extract_observability.py
+++ b/factory/tests/test_cognify_extract_observability.py
@@ -1,0 +1,172 @@
+"""Tests for cognify_extract observability changes (A3 + A4):
+
+  A3 — nomenclature: ExtractResult exposes `patterns_created` as an
+       alias for `lessons_created` (matching DB `kind='pattern'` storage).
+       PassResult.metadata emits both keys.
+
+  A4 — error telemetry: _llm_extract distinguishes "api" failure (the
+       API call itself errored) from "json_parse" failure (model returned
+       non-JSON) and "empty" (valid JSON but no atoms). Counts surface
+       in PassResult.metadata.failure_counts.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ─── A3: ExtractResult.patterns_created alias ────────────────────────────────
+
+
+def test_extract_result_patterns_alias_matches_lessons():
+    from cognify.extract import ExtractResult
+
+    r = ExtractResult(session_id="s1", lessons_created=7, decisions_created=4)
+    assert r.lessons_created == 7
+    assert r.patterns_created == 7  # alias
+    assert r.decisions_created == 4
+
+
+def test_extract_result_patterns_alias_when_zero():
+    from cognify.extract import ExtractResult
+
+    r = ExtractResult(session_id="s1")
+    assert r.lessons_created == 0
+    assert r.patterns_created == 0
+
+
+# ─── A4: ExtractResult.failure field ─────────────────────────────────────────
+
+
+def test_extract_result_failure_defaults_to_none():
+    from cognify.extract import ExtractResult
+
+    r = ExtractResult(session_id="s1")
+    assert r.failure is None
+
+
+def test_extract_result_failure_can_be_set():
+    from cognify.extract import ExtractResult
+
+    r = ExtractResult(session_id="s1", failure="json_parse")
+    assert r.failure == "json_parse"
+
+
+# ─── A4: _llm_extract failure categorization ─────────────────────────────────
+
+
+def _stub_anthropic_response(text: str):
+    """Build a fake response object shaped like anthropic.types.Message."""
+    response = MagicMock()
+    response.content = [MagicMock(text=text)]
+    response.usage = MagicMock(
+        input_tokens=10,
+        output_tokens=5,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+    return response
+
+
+def _patch_auth_and_client(response_or_exc):
+    """Returns context managers that stub auth + Anthropic client to
+    return `response_or_exc`. If exc, the client.messages.create raises;
+    otherwise it returns the response."""
+    auth_patch = patch(
+        "cognify.extract._resolve_auth",
+        return_value={"api_key": "sk-ant-api03-FAKE"},
+    )
+
+    fake_client = MagicMock()
+    if isinstance(response_or_exc, Exception):
+        fake_client.messages.create.side_effect = response_or_exc
+    else:
+        fake_client.messages.create.return_value = response_or_exc
+
+    # Patch the Anthropic constructor where _llm_extract imports it
+    # (`import anthropic` inside the function).
+    import anthropic
+    client_patch = patch.object(anthropic, "Anthropic", return_value=fake_client)
+    return auth_patch, client_patch
+
+
+def test_llm_extract_returns_clean_result_on_valid_json():
+    from cognify.extract import _llm_extract
+
+    valid_json = json.dumps({
+        "lessons": [{"title": "L1", "content": "body"}],
+        "decisions": [{"title": "D1", "content": "body"}],
+    })
+    auth_p, client_p = _patch_auth_and_client(_stub_anthropic_response(valid_json))
+    with auth_p, client_p:
+        result = _llm_extract("some content")
+    assert result["lessons"] == [{"title": "L1", "content": "body"}]
+    assert result["decisions"] == [{"title": "D1", "content": "body"}]
+    assert "_failure" not in result  # success path doesn't set _failure
+
+
+def test_llm_extract_flags_empty_extraction():
+    """Valid JSON but no atoms — `_failure='empty'` signals 'LLM succeeded
+    but the model didn't find anything worth recording.'"""
+    from cognify.extract import _llm_extract
+
+    valid_empty_json = json.dumps({"lessons": [], "decisions": []})
+    auth_p, client_p = _patch_auth_and_client(_stub_anthropic_response(valid_empty_json))
+    with auth_p, client_p:
+        result = _llm_extract("some content")
+    assert result["lessons"] == []
+    assert result["decisions"] == []
+    assert result["_failure"] == "empty"
+
+
+def test_llm_extract_categorizes_json_parse_failure(caplog):
+    """Model returns non-JSON output — categorize as 'json_parse'.
+    Usage tokens are preserved (the API call DID succeed, just the
+    parsing of its output failed)."""
+    from cognify.extract import _llm_extract
+
+    auth_p, client_p = _patch_auth_and_client(_stub_anthropic_response("Not JSON at all!"))
+    with caplog.at_level(logging.WARNING, logger="cognify.extract"):
+        with auth_p, client_p:
+            result = _llm_extract("content")
+
+    assert result["lessons"] == []
+    assert result["decisions"] == []
+    assert result["_failure"] == "json_parse"
+    assert "_failure_detail" in result
+    # Token usage from the (successful) API call is preserved
+    assert result["_usage"]["input_tokens"] == 10
+    assert result["_usage"]["output_tokens"] == 5
+    # The payload sample is logged for diagnostics
+    assert any("JSON parse failed" in rec.message for rec in caplog.records)
+
+
+def test_llm_extract_categorizes_api_call_failure():
+    """API call itself raises — categorize as 'api'. No usage to preserve."""
+    from cognify.extract import _llm_extract
+
+    auth_p, client_p = _patch_auth_and_client(RuntimeError("connection refused"))
+    with auth_p, client_p:
+        result = _llm_extract("content")
+
+    assert result["lessons"] == []
+    assert result["decisions"] == []
+    assert result["_failure"] == "api"
+    assert "connection refused" in result["_failure_detail"]
+    assert result["_usage"]["input_tokens"] == 0  # _empty_usage
+
+
+def test_llm_extract_strips_markdown_fences_before_parsing():
+    """Some models wrap JSON in ```json ... ``` fences; we strip them."""
+    from cognify.extract import _llm_extract
+
+    fenced = "```json\n" + json.dumps({"lessons": [], "decisions": [{"title": "D1", "content": "x"}]}) + "\n```"
+    auth_p, client_p = _patch_auth_and_client(_stub_anthropic_response(fenced))
+    with auth_p, client_p:
+        result = _llm_extract("content")
+    assert result["decisions"] == [{"title": "D1", "content": "x"}]
+    # Fenced+valid JSON with one atom → no failure flag (decisions is non-empty)
+    assert "_failure" not in result


### PR DESCRIPTION
## Summary

Two changes to cognify_extract observability discovered during today's debug session:

### A3 — Nomenclature alignment

The CLI/JSON output emits `lessons_created`, but the DB stores those rows under `kind='pattern'`. `SELECT count(*) WHERE kind='lesson'` returns 0 even when the CLI just reported N lessons created.

**Fix (additive, non-breaking)**: `ExtractResult` gains `patterns_created` as a `@property` alias for `lessons_created`. `PassResult.metadata` emits both keys. `reextract_cli` result dict emits both keys.

### A4 — JSON parse failure visibility

Previously `_llm_extract` wrapped the entire LLM call + JSON parse + return in one `try: ... except Exception: ...` block. **Three distinct failure modes were lumped together**:

1. API call itself failed (network / 429 / auth)
2. API succeeded but model returned non-JSON output
3. API succeeded with valid JSON but empty lists

All three returned identical zero-row results with no signal. This morning's `cognify-reextract --all` log filled with `Expecting value: line 1 column 1 (char 0)` (parse failures) with no count of affected sessions or sample of bad payloads.

**Fix**: split the `try/except` so each failure mode is caught + categorized separately. The returned dict gets a `_failure ∈ {"api", "json_parse", "empty"}` tag. `ExtractResult.failure` propagates it. `ExtractPass.run` aggregates per-kind counts into `metadata.failure_counts`. JSON parse failures now log a 400-char payload sample for diagnostics. API failures preserve `_failure_detail` (truncated exception message). Parse failures preserve `_usage` tokens since the API call did succeed — spend should still record.

## Tests (9 added)

- patterns_created alias correctness (with and without lessons_created set)
- ExtractResult.failure default / settable
- _llm_extract clean result on valid JSON
- _llm_extract flags `_failure='empty'` when valid JSON has no atoms
- _llm_extract flags `_failure='json_parse'` when model returns non-JSON, preserves usage tokens, logs payload sample
- _llm_extract flags `_failure='api'` when the API call raises
- _llm_extract strips markdown ` ```json ` fences before parsing

All 65 cognify tests pass (was 56 before; +9 new).

## Test plan

- [x] `pytest factory/tests/test_cognify_extract_observability.py` — 9/9
- [x] `pytest factory/tests/ -k cognify` — 65 pass, 56 skipped, 0 fail
- [ ] Reviewer: confirm `lessons_created`/`patterns_created` dual-key emission won't confuse any downstream consumer (I greped — only the orchestrator + reextract_cli consume the metadata dict, both updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)