### PR TITLE
fix(mcp): fail fast at startup when DB is unreachable

### DIFF
--- a/factory/tests/test_mcp_server_db_probe.py
+++ b/factory/tests/test_mcp_server_db_probe.py
@@ -1,0 +1,148 @@
+"""Integration test for the MCP server's startup DB probe (D2 fix).
+
+When the DB is unreachable, the MCP server should exit fast (within
+~6s) with a clear stderr message, rather than coming up and letting
+the first tool call hang or return opaquely.
+
+This test:
+  1. Spawns `node mcp-server/dist/index.js` pointing at a port that's
+     never listening (port 1).
+  2. Asserts the process exits non-zero within the timeout window.
+  3. Asserts stderr contains the actionable DB-down message.
+  4. Verifies the DEVBRAIN_MCP_SKIP_DB_PROBE=1 escape hatch lets it
+     start (smoke test of the bypass).
+
+The MCP server reads database config from `config/devbrain.yaml`. We
+patch the host/port via a tmp config + DEVBRAIN_CONFIG env var to keep
+the test hermetic.
+
+Marked `skipif` when the MCP server hasn't been built or when node
+isn't available — both required for this test.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MCP_BUNDLE = REPO_ROOT / "mcp-server" / "dist" / "index.js"
+CONFIG_TEMPLATE_PATH = REPO_ROOT / "config" / "devbrain.yaml"
+
+_node_path = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(
+    not MCP_BUNDLE.exists() or _node_path is None,
+    reason="MCP server dist/index.js not built or node not on PATH",
+)
+
+
+def _write_temp_config_with_dead_db(tmp_path: Path) -> Path:
+    """Copy config/devbrain.yaml and rewrite the database host+port to
+    something that's guaranteed to refuse connections."""
+    src = CONFIG_TEMPLATE_PATH.read_text()
+    # Point at port 1 on localhost — kernel will RST every SYN.
+    # Use a simple regex-ish replacement; keep the rest of the config
+    # intact (chunking + embedding + summarization stay valid).
+    out = []
+    for line in src.splitlines():
+        stripped = line.lstrip()
+        # YAML format: "  host: <value>" inside the database: block.
+        # Naive matching is fine here because devbrain.yaml has only one
+        # "host:" key under database.
+        if stripped.startswith("host:") and "127.0.0.1" not in line and "localhost" not in line:
+            out.append(line)
+            continue
+        if stripped.startswith("host:"):
+            indent = line[: len(line) - len(stripped)]
+            out.append(f"{indent}host: 127.0.0.1")
+        elif stripped.startswith("port:") and " 543" in line:
+            indent = line[: len(line) - len(stripped)]
+            out.append(f"{indent}port: 1")
+        else:
+            out.append(line)
+    out_path = tmp_path / "devbrain.yaml"
+    out_path.write_text("\n".join(out) + "\n")
+    return out_path
+
+
+def test_mcp_server_exits_fast_when_db_unreachable(tmp_path):
+    """With Postgres unreachable, the MCP server should exit non-zero
+    within ~7 seconds and surface a useful error message on stderr."""
+    config_path = _write_temp_config_with_dead_db(tmp_path)
+    env = os.environ.copy()
+    env["DEVBRAIN_CONFIG"] = str(config_path)
+    # Make sure the bypass isn't accidentally set in the test env.
+    env.pop("DEVBRAIN_MCP_SKIP_DB_PROBE", None)
+
+    proc = subprocess.Popen(
+        [_node_path, str(MCP_BUNDLE)],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        # Wait up to 10s for the process to exit on its own.
+        stdout, stderr = proc.communicate(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate()
+        pytest.fail(
+            "MCP server did not exit within 10s — startup DB probe "
+            "appears not to fail fast. stderr so far:\n"
+            f"{stderr.decode('utf-8', 'replace')}"
+        )
+
+    err = stderr.decode("utf-8", "replace")
+    assert proc.returncode != 0, (
+        f"MCP server exited 0 with DB unreachable — expected non-zero. "
+        f"stderr:\n{err}"
+    )
+    # The friendly message should mention DB unreachable + Docker hint.
+    assert "[devbrain-mcp]" in err
+    assert "DB unreachable" in err or "cannot reach Postgres" in err
+    assert "DEVBRAIN_MCP_SKIP_DB_PROBE" in err  # mentions the escape hatch
+
+
+def test_mcp_server_skip_probe_env_var_bypasses_check(tmp_path):
+    """With DEVBRAIN_MCP_SKIP_DB_PROBE=1 set, the server should NOT
+    exit on startup just because the DB is unreachable. It should
+    proceed to the StdioServerTransport setup.
+
+    We verify by setting up a dead DB config + the skip flag, starting
+    the process, then asserting it's still alive after 3 seconds and
+    killing it.
+    """
+    config_path = _write_temp_config_with_dead_db(tmp_path)
+    env = os.environ.copy()
+    env["DEVBRAIN_CONFIG"] = str(config_path)
+    env["DEVBRAIN_MCP_SKIP_DB_PROBE"] = "1"
+
+    proc = subprocess.Popen(
+        [_node_path, str(MCP_BUNDLE)],
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        # The server should still be running after 3s because the probe
+        # was bypassed. We don't send any MCP frames — just keep stdin
+        # held open.
+        time.sleep(3)
+        assert proc.poll() is None, (
+            "MCP server exited unexpectedly with DEVBRAIN_MCP_SKIP_DB_PROBE=1; "
+            f"stderr: {proc.stderr.read().decode('utf-8', 'replace') if proc.stderr else ''}"
+        )
+    finally:
+        proc.terminate()
+        try:
+            proc.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()

--- a/mcp-server/src/db.ts
+++ b/mcp-server/src/db.ts
@@ -7,7 +7,11 @@ import { resolve } from 'path'
 // narrow accessors below so consumers get only the fields they need and
 // credentials don't propagate into every file that happens to need a
 // chunking limit or Ollama URL.
-const configPath = resolve(import.meta.dirname, '../../config/devbrain.yaml')
+// DEVBRAIN_CONFIG env var (documented in .env.example) overrides the
+// default location. Without this honored, tests can't point the MCP at
+// a controlled config and the documented escape hatch is a no-op.
+const configPath = process.env.DEVBRAIN_CONFIG ||
+  resolve(import.meta.dirname, '../../config/devbrain.yaml')
 const _config = parse(readFileSync(configPath, 'utf-8'))
 
 let _pool: pg.Pool | null = null
@@ -63,5 +67,117 @@ export async function query<T extends pg.QueryResultRow = Record<string, unknown
   text: string,
   params?: unknown[],
 ): Promise<pg.QueryResult<T>> {
-  return getPool().query<T>(text, params)
+  try {
+    return await getPool().query<T>(text, params)
+  } catch (err) {
+    // Rewrap connection-time failures with an actionable hint so the
+    // user sees "DB unreachable, start Docker" rather than a bare
+    // "ECONNREFUSED 127.0.0.1:5433" that doesn't say what to do.
+    throw _friendlyDbError(err)
+  }
+}
+
+// ─── Connection diagnostics ──────────────────────────────────────────────────
+
+
+/**
+ * Map low-level pg / network errors to a single actionable message.
+ * The original error is preserved as `.cause`.
+ *
+ * Recognised low-level codes:
+ *   * `ECONNREFUSED`  — port not listening (Docker stopped, container down)
+ *   * `ETIMEDOUT`     — packet dropped (firewall, host down)
+ *   * `ENOTFOUND`     — DNS / hostname unresolvable
+ *   * `28P01`         — pg auth: wrong password
+ *   * `3D000`         — pg auth: database does not exist
+ */
+function _friendlyDbError(err: unknown): Error {
+  if (!(err instanceof Error)) {
+    return new Error(String(err))
+  }
+  // pg's code shape: ECONNREFUSED for network, SQLSTATE strings for auth.
+  const code = (err as NodeJS.ErrnoException & { code?: string }).code
+  const host = _config.database.host
+  const port = _config.database.port
+  let hint = err.message
+  switch (code) {
+    case 'ECONNREFUSED':
+    case 'ETIMEDOUT':
+      hint =
+        `DevBrain MCP: cannot reach Postgres at ${host}:${port} (${code}). ` +
+        `If you're on the laptop, start Docker Desktop and run ` +
+        `\`cd /Users/$(whoami)/devbrain && docker compose up -d\` to bring ` +
+        `the DB up. If you're on Mac Studio, check \`docker ps\` for the ` +
+        `\`devbrain-db\` container.`
+      break
+    case 'ENOTFOUND':
+      hint =
+        `DevBrain MCP: hostname ${host} does not resolve. Check the ` +
+        `database.host setting in config/devbrain.yaml.`
+      break
+    case '28P01':
+      hint =
+        `DevBrain MCP: Postgres rejected the credentials for user ` +
+        `${_config.database.user}. Check the password in your .env.`
+      break
+    case '3D000':
+      hint =
+        `DevBrain MCP: database ${_config.database.database} does not exist ` +
+        `on ${host}:${port}. Check the database.database setting in config/devbrain.yaml.`
+      break
+    default:
+      // Other errors flow through unchanged.
+      return err
+  }
+  const wrapped = new Error(hint)
+  ;(wrapped as Error & { cause?: unknown }).cause = err
+  return wrapped
+}
+
+/**
+ * Probe the DB pool with a fast `SELECT 1`. Used at MCP server startup
+ * to fail fast (and loudly) if the DB is unreachable, rather than letting
+ * the first tool call hang or return an opaque error.
+ *
+ * `timeoutMs` bounds the probe; matches the pool's connectionTimeoutMillis
+ * by default.
+ *
+ * Throws the same friendly-wrapped error that `query()` would, so the
+ * caller can log it and exit.
+ */
+export async function waitForDb(timeoutMs: number = 5000): Promise<void> {
+  const pool = getPool()
+  // We need a hard wall-clock cap. The pool's connectionTimeoutMillis
+  // bounds individual connection-acquire attempts but not the full
+  // pool.query() retry behavior, so use Promise.race.
+  let timeoutId: NodeJS.Timeout | null = null
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error(`DB probe timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    )
+  })
+  try {
+    await Promise.race([pool.query('SELECT 1'), timeout])
+  } catch (err) {
+    throw _friendlyDbError(err)
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId)
+  }
+}
+
+// Test-only: lets the test suite swap the config without touching the
+// module-private singleton. Not exposed to runtime callers.
+export function _testOnlyOverrideConfig(overrides: {
+  host?: string
+  port?: number
+  user?: string
+  database?: string
+}): void {
+  Object.assign(_config.database, overrides)
+  // Force pool re-init on next getPool() call so the override takes effect.
+  if (_pool) {
+    _pool.end().catch(() => {})
+    _pool = null
+  }
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -7,7 +7,7 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs'
 import { homedir, tmpdir } from 'os'
 import { join, resolve } from 'path'
 import { z } from 'zod'
-import { query } from './db.js'
+import { query, waitForDb } from './db.js'
 import { embed, toSqlVector } from './embeddings.js'
 import { enqueueCascades, recordMemory, recordMemoryDependency, resolveMemoryId } from './memory.js'
 import {
@@ -2197,6 +2197,31 @@ server.tool(
 // ─── Start server ────────────────────────────────────────────────────────────
 
 async function main() {
+  // Probe the DB before we tell the MCP client we're ready. If the DB
+  // is unreachable (Docker not running, container down, wrong creds),
+  // exit fast with a clear stderr message rather than coming up, letting
+  // the client connect, and then having every tool call hang/return
+  // opaquely on the first query.
+  //
+  // The check can be skipped with DEVBRAIN_MCP_SKIP_DB_PROBE=1 for tests
+  // and recovery scenarios where you genuinely want to start the MCP
+  // without a working DB (e.g. to use tools that don't touch the DB,
+  // or to keep stdio open while you fix Docker in another shell).
+  if (process.env.DEVBRAIN_MCP_SKIP_DB_PROBE !== '1') {
+    try {
+      await waitForDb(5000)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error('\n[devbrain-mcp] DB unreachable — refusing to start.')
+      console.error(`[devbrain-mcp] ${msg}`)
+      console.error(
+        '[devbrain-mcp] Set DEVBRAIN_MCP_SKIP_DB_PROBE=1 to bypass this ' +
+        'check (tool calls that touch the DB will fail with the same ' +
+        'error message at call time).\n',
+      )
+      process.exit(1)
+    }
+  }
   const transport = new StdioServerTransport()
   await server.connect(transport)
 }


### PR DESCRIPTION
## Summary

When the laptop's Docker Desktop was off this morning, every `mcp__devbrain__*` tool call returned silently — no output, no error. The MCP server was coming up cleanly (Docker isn't checked at startup), and each tool call's underlying `query()` would eventually throw ECONNREFUSED. But the error never surfaced to the client clearly — the user just saw "no output."

## Three changes

### 1. Friendly errors in `db.query()`

Wraps low-level pg / network errors with actionable messages:

| Code | Mapped message |
|---|---|
| `ECONNREFUSED` / `ETIMEDOUT` | "cannot reach Postgres at `host:port`, start Docker Desktop / `docker compose up -d`" |
| `ENOTFOUND` | "hostname does not resolve, check `database.host`" |
| `28P01` (pg auth) | "Postgres rejected credentials for user X" |
| `3D000` (no such db) | "database X does not exist on host:port" |

Other errors flow through unchanged. Original error preserved as `.cause`.

### 2. Startup health probe → fail fast

New `waitForDb(timeoutMs)` runs `SELECT 1` with a hard wall-clock timeout (5s default). Called at MCP startup in `main()` before `server.connect(transport)`. If the probe fails, the server logs the friendly message to stderr and `process.exit(1)` — so the MCP client sees the stdio pipe close with a clear reason, rather than the server "succeeding" and then having every subsequent tool call hang or return opaquely.

Escape hatch: `DEVBRAIN_MCP_SKIP_DB_PROBE=1` bypasses the check (for tests + recovery scenarios where you want stdio open while bringing the DB up in another shell).

### 3. Honor `DEVBRAIN_CONFIG` env var

`db.ts` previously had a hardcoded `import.meta.dirname, '../../config/devbrain.yaml'` config path, making the `DEVBRAIN_CONFIG` override documented in `.env.example` a silent no-op. Now reads the env var first, falls back to default. This is independently a real bug (doc/code drift) and was a prerequisite for the integration test.

## Tests (2 added)

- `test_mcp_server_exits_fast_when_db_unreachable`: spawns the built bundle pointing at port 1 (never listening), asserts non-zero exit within 10s and friendly stderr message contains "DB unreachable", `[devbrain-mcp]`, and the escape-hatch name.
- `test_mcp_server_skip_probe_env_var_bypasses_check`: with the skip flag, server stays running after 3s with DB unreachable.

Both pass in ~3.2s.

## Test plan

- [x] `pytest factory/tests/test_mcp_server_db_probe.py` — 2/2 pass
- [x] `npm run build` in mcp-server — TypeScript clean, no errors
- [ ] Reviewer: confirm DEVBRAIN_MCP_SKIP_DB_PROBE escape hatch name is acceptable (or suggest alternative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)