### PR TITLE
ci(llm-smoke): live API call defense against PR #119-class auth bugs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+Thanks for contributing to DevBrain! A short PR template — fill in what
+applies, delete what doesn't.
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what changes, why, and the user-visible effect. -->
+
+## Test plan
+
+- [ ] `pytest factory/tests/` passes locally
+- [ ] Lint clean (no new warnings)
+- [ ] If this PR touches DB schema or migrations: applied + rolled back cleanly against a scratch DB
+
+## LLM call path
+
+This section applies to any PR that touches:
+  - `factory/cognify/_anthropic_auth.py` or `factory/cognify/extract.py` or `factory/cognify/edges.py`
+  - `factory/ai_clis/` (Claude/Codex/Gemini adapters)
+  - `mcp-server/src/index.ts` if it adds or modifies API calls
+
+Pick one:
+
+- [ ] **This PR does NOT touch any LLM call path** — skip the rest of this section.
+- [ ] **This PR touches an LLM call path and I have verified end-to-end against a real Anthropic API call.** Evidence (paste one):
+  - [ ] CI `llm-smoke-test` workflow ran and passed on this PR (preferred). Workflow run: <!-- paste URL -->
+  - [ ] I ran a local smoke test. Request ID / response status: <!-- paste -->
+  - [ ] I added the `llm-smoke-test` label to this PR to opt-in to the CI smoke test (defaults to "paths-filter only" — labeling forces a run).
+
+Why this section exists: PR #119 shipped subscription OAuth support that 429'd on every real call because the system-prompt fingerprint was missing. The bug survived code review because no test exercised the live API path. This checkbox is the lightest-weight defense.

--- a/.github/workflows/llm-smoke-test.yml
+++ b/.github/workflows/llm-smoke-test.yml
@@ -1,0 +1,106 @@
+name: llm-smoke-test
+
+# Defense against the class of bug from PR #119: code that looks correct
+# in unit tests but 429s the moment it hits live /v1/messages because
+# the auth shape, system-prompt fingerprint, or beta header is subtly
+# wrong.
+#
+# Runs ONE real Anthropic API call against `_llm_extract` with a tiny
+# fixture session. Cost: ~$0.01-0.03 per run.
+#
+# Trigger conditions (ANY of):
+#   1. PR touches files under factory/cognify/, factory/ai_clis/, or
+#      mcp-server/src/ — paths where an auth/LLM regression is most likely.
+#   2. PR is explicitly labeled `llm-smoke-test`.
+#   3. Manual run via workflow_dispatch.
+#
+# Skips:
+#   * PR is from a fork (secret won't be available, would fail every run).
+#   * Repository secret CI_ANTHROPIC_OAUTH_TOKEN is not configured.
+#   * Commit message contains `[skip-llm-smoke]`.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - 'factory/cognify/**'
+      - 'factory/ai_clis/**'
+      - 'mcp-server/src/**'
+      - 'factory/tests/llm_smoke/**'
+      - '.github/workflows/llm-smoke-test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: llm-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  llm-smoke:
+    name: llm-smoke (real API call)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    # Skip on forks (no secret access) and on opt-out commit messages.
+    # The label gate ALSO runs the job even when paths-filter wouldn't,
+    # so reviewers can request a smoke test on any PR by adding the
+    # `llm-smoke-test` label.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.head_commit.message, '[skip-llm-smoke]') &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event.action == 'labeled' && github.event.label.name == 'llm-smoke-test' ||
+        github.event.action != 'labeled'
+      )
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Check secret availability
+        # If the secret isn't configured (forked repo, or admin removed it),
+        # fail clearly rather than hanging or producing a confusing
+        # pytest skip.
+        env:
+          CI_ANTHROPIC_OAUTH_TOKEN: ${{ secrets.CI_ANTHROPIC_OAUTH_TOKEN }}
+        run: |
+          if [ -z "$CI_ANTHROPIC_OAUTH_TOKEN" ]; then
+            echo "::warning::CI_ANTHROPIC_OAUTH_TOKEN secret not configured. Skipping LLM smoke test."
+            echo "Add a subscription OAuth token (sk-ant-oat01-...) to the repo's Actions secrets to enable."
+            exit 0
+          fi
+          echo "Secret is configured (first 20 chars: ${CI_ANTHROPIC_OAUTH_TOKEN:0:20}...)"
+
+      - name: Run LLM smoke test
+        # Expose the secret as CLAUDE_CODE_OAUTH_TOKEN so the existing
+        # cognify._anthropic_auth.resolve_anthropic_auth() picks it up
+        # via the documented env var rather than needing a CI-specific
+        # branch.
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CI_ANTHROPIC_OAUTH_TOKEN }}
+          PYTHONPATH: factory
+        run: |
+          python -m pytest factory/tests/llm_smoke/ -v --tb=short -p no:cacheprovider
+
+      - name: Report cost
+        if: always()
+        run: |
+          echo "::notice::LLM smoke test run complete. Each run is one Sonnet 4.6 call (~\$0.01-0.03)."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,38 @@ opening a public issue.
 - Keep PRs focused. Smaller is better — one concept per PR.
 - Include tests for new behavior and for any bug you fix.
 - Update docs if you change user-visible behavior or the install path.
+- The PR description should follow `.github/PULL_REQUEST_TEMPLATE.md`
+  (GitHub auto-fills it). In particular, **fill in the "LLM call path"
+  section** if your PR touches `factory/cognify/`, `factory/ai_clis/`,
+  or `mcp-server/src/`.
+
+### LLM call-path verification
+
+If your PR touches code that makes Anthropic API calls (cognify
+passes, AI CLI adapters, MCP server auth), the unit tests probably
+can't catch a regression — they mock the SDK, and the regressions
+that bite are usually in the auth shape or required headers (the
+`oauth-2025-04-20` beta header, the Claude Code system-prompt
+fingerprint, etc.). Two ways to verify end-to-end:
+
+1. **Preferred — let CI run the smoke test for you.** The
+   `llm-smoke-test` GitHub Actions workflow makes one real Anthropic
+   API call against a fixture session (~$0.01-0.03 per run, hits an
+   admin-owned subscription token). It auto-triggers when your PR
+   touches the watched paths. If your PR doesn't touch a watched path
+   but you want the smoke check anyway, add the `llm-smoke-test`
+   label to your PR.
+2. **Local smoke test.** Set `CLAUDE_CODE_OAUTH_TOKEN` from a
+   subscription token (via `claude setup-token`) and run:
+   ```bash
+   PYTHONPATH=factory pytest factory/tests/llm_smoke/ -v
+   ```
+   Paste the request_id or pass/fail result into the PR description.
+
+Why this exists: PR #119 shipped subscription OAuth support that
+429'd on every real call because the system-prompt fingerprint was
+missing. The bug survived code review because no test exercised the
+live API path.
 
 ### Commit messages
 

--- a/factory/tests/llm_smoke/fixtures/sample_session.txt
+++ b/factory/tests/llm_smoke/fixtures/sample_session.txt
@@ -1,0 +1,17 @@
+[Session Summary — auth migration discussion]
+
+Patrick and Claude discussed migrating the BrightBot auth layer from JWT bearer tokens to OAuth 2.0 setup-tokens for the Anthropic API integration.
+
+Key decisions:
+- Replace ANTHROPIC_API_KEY env var with CLAUDE_CODE_OAUTH_TOKEN as the primary credential
+- Console API key remains the fallback for non-subscription workloads
+- Adapter writes token to profiles/<dev>/.claude/oauth-token (atomic; chmod 0600)
+
+Lessons learned:
+- OAuth setup-token tokens have prefix sk-ant-oat\d+- (one or more digits, not fixed)
+- Bearer auth alone is insufficient; Anthropic requires anthropic-beta: oauth-2025-04-20 header
+- The system prompt's first block must be the literal Claude Code SDK fingerprint, or /v1/messages returns 429 with a terse error masquerading as a rate limit
+
+Next steps:
+- Build a rotate-token CLI for system + per-dev token rotation
+- Add CI smoke test exercising the live API path

--- a/factory/tests/llm_smoke/test_llm_smoke.py
+++ b/factory/tests/llm_smoke/test_llm_smoke.py
@@ -1,0 +1,166 @@
+"""LLM call-path smoke test.
+
+This test makes a REAL Anthropic API call. It exists to defend against
+the class of bug that bit us with PR #119: code merges that look correct
+in unit-test land but 429 the first time they hit live `/v1/messages`
+because the auth shape, system-prompt fingerprint, or beta header is
+subtly wrong.
+
+What this test verifies (end-to-end against api.anthropic.com):
+
+  1. `cognify._anthropic_auth.resolve_anthropic_auth()` returns a usable
+     credential from the env (CI sets CLAUDE_CODE_OAUTH_TOKEN from the
+     CI_ANTHROPIC_OAUTH_TOKEN secret).
+  2. `_llm_extract()` constructs the Anthropic client with the right
+     default_headers (anthropic-beta: oauth-2025-04-20).
+  3. The request body's first system block is the Claude Code SDK
+     fingerprint (PR #122).
+  4. The model returns parseable JSON with the expected `lessons` +
+     `decisions` keys.
+
+What this test does NOT verify:
+  - Correctness of the lesson/decision extraction (model output is
+    non-deterministic; we just assert the SHAPE is correct).
+  - DB writes (no DB needed — we call _llm_extract directly).
+  - End-to-end cognify_extract pass (run separately as part of pytest-db).
+
+Cost: one Sonnet 4.6 call, ~500 input tokens + ≤2K output tokens.
+Estimated $0.01-0.03 per invocation at 2026-05 pricing.
+
+The test is SKIPPED if the credential env var is not present, so the
+test file is safe to include in default pytest collection — it only
+actually fires from the dedicated CI workflow that sets the secret.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_session.txt"
+
+# Skip gracefully when no credential is available. The CI workflow that
+# owns this test sets CLAUDE_CODE_OAUTH_TOKEN from a repo secret; local
+# `pytest factory/tests/` runs without the secret and skip cleanly.
+pytestmark = pytest.mark.skipif(
+    not any(
+        os.environ.get(k)
+        for k in ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+    ),
+    reason=(
+        "no Anthropic credential in env — LLM smoke test only runs when "
+        "CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN is set"
+    ),
+)
+
+
+def test_llm_extract_against_real_api():
+    """Round-trip _llm_extract() against api.anthropic.com.
+
+    This test's job is to catch AUTH regressions specifically (the
+    PR #119 class of bug: missing header / wrong fingerprint / wrong
+    bearer shape). It is intentionally NOT a test of model output
+    quality — that's non-deterministic and would create flaky CI.
+
+    Pass conditions (any):
+      * Extraction succeeded — got lessons and/or decisions, no _failure.
+      * _failure == 'json_parse' — the API call WORKED; the model just
+        didn't return JSON this time. That's a prompt/model issue, not
+        an auth issue, and we surface it as a warning rather than a
+        hard fail.
+
+    Fail conditions:
+      * _failure == 'api' — the API call itself failed (network, auth,
+        429, wrong header, etc.). This is exactly the PR #119 class of
+        bug this test exists to catch.
+      * Missing required keys in the return dict.
+      * Token usage is zero (we never actually hit the API).
+    """
+    from cognify.extract import _llm_extract  # noqa: PLC0415
+
+    content = FIXTURE.read_text()
+    assert content.strip(), "fixture session is empty"
+
+    result = _llm_extract(content)
+
+    failure_kind = result.get("_failure")
+
+    if failure_kind == "api":
+        # This is the auth-regression case we exist to catch.
+        pytest.fail(
+            f"LLM smoke test failed (API call did not succeed): "
+            f"_failure_detail={result.get('_failure_detail', '<none>')!r}. "
+            f"This usually means an auth regression — check the OAuth "
+            f"beta header, the Claude Code system-prompt fingerprint, or "
+            f"the bearer token validity."
+        )
+
+    if failure_kind == "json_parse":
+        # Auth worked; model just didn't return JSON. Log + pass.
+        # The test's purpose is met (auth verified).
+        import warnings
+        warnings.warn(
+            f"LLM smoke test: API call succeeded but model returned "
+            f"non-JSON output. This is a prompt/model issue, not an "
+            f"auth issue. Sample: {result.get('_failure_detail', '')[:200]}"
+        )
+
+    assert "lessons" in result, f"missing 'lessons' key; got {list(result.keys())}"
+    assert "decisions" in result, f"missing 'decisions' key; got {list(result.keys())}"
+    assert isinstance(result["lessons"], list)
+    assert isinstance(result["decisions"], list)
+
+    # Token usage proves the call actually hit Anthropic. This is the
+    # invariant that DOES NOT depend on the model's output content — it
+    # depends only on the API call having gone through with valid auth.
+    usage = result.get("_usage", {})
+    assert usage.get("input_tokens", 0) > 0, (
+        f"input_tokens should be > 0 from a real call; got usage={usage!r}. "
+        f"This means the call didn't reach Anthropic or returned no token "
+        f"accounting — likely an auth or network failure."
+    )
+    # Note: output_tokens > 0 is implied by usage data existing for a
+    # successful call. We don't strictly require it because the empty-output
+    # case (output_tokens=0) could still arise if the model truly returns
+    # nothing, which is rare but not impossible.
+
+
+def test_resolved_auth_shape_is_complete_for_oauth():
+    """If we're running on an OAuth token (the CI default), the resolved
+    auth shape must include the `default_headers` with the OAuth beta
+    header. This catches the class of bug from PR #122 (auth_token alone
+    is necessary but not sufficient — the beta header gates the request).
+    """
+    from cognify._anthropic_auth import resolve_anthropic_auth  # noqa: PLC0415
+
+    auth = resolve_anthropic_auth()
+    assert auth is not None, "credential disappeared after pytest skip-gate"
+
+    if "auth_token" in auth:
+        # OAuth path — must also carry the beta header
+        headers = auth.get("default_headers", {})
+        assert "anthropic-beta" in headers, (
+            f"OAuth-path auth missing anthropic-beta header; got {auth!r}"
+        )
+        assert "oauth-2025-04-20" in headers["anthropic-beta"]
+    else:
+        # Console API key path doesn't need the beta header.
+        assert "api_key" in auth, f"unexpected auth shape: {auth!r}"
+
+
+def test_claude_code_system_prefix_returned_for_oauth():
+    """If we're running on an OAuth token, the system prefix must be
+    populated (it's what Anthropic identity-gates on at /v1/messages)."""
+    from cognify._anthropic_auth import claude_code_system_prefix  # noqa: PLC0415
+
+    prefix = claude_code_system_prefix()
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        # Console path — no prefix needed
+        assert prefix is None
+    else:
+        # OAuth path — prefix must be present
+        assert prefix is not None
+        assert "You are Claude Code" in prefix
+        assert "Claude Agent SDK" in prefix


### PR DESCRIPTION
## Summary

PR #119 shipped subscription OAuth support that 429'd on every real call because the system-prompt fingerprint was missing. Unit tests passed because they mocked the SDK. This adds a real-API smoke test that catches that class of regression before merge.

## What this PR adds

1. **`.github/workflows/llm-smoke-test.yml`** — separate workflow that:
   - Auto-triggers on PR open/sync/reopen when paths touch `factory/cognify/`, `factory/ai_clis/`, or `mcp-server/src/`
   - Also triggers when PR labeled `llm-smoke-test`
   - Skips fork PRs (no secret access)
   - Cost: ~$0.01-0.03 per run

2. **`factory/tests/llm_smoke/test_llm_smoke.py`** — 3 tests:
   - `test_llm_extract_against_real_api` — round-trips `_llm_extract()` through real `api.anthropic.com`. FAILS only on `_failure='api'` (the auth-regression case). Passes-with-warning on `_failure='json_parse'` (auth worked, model just didn't comply).
   - `test_resolved_auth_shape_is_complete_for_oauth` — confirms OAuth path includes the `anthropic-beta: oauth-2025-04-20` header (PR #122 fix).
   - `test_claude_code_system_prefix_returned_for_oauth` — confirms the fingerprint string is returned (other half of PR #122).
   - All 3 SKIP cleanly when no credential in env. Safe in default pytest collection.

3. **`factory/tests/llm_smoke/fixtures/sample_session.txt`** — bounded ~1KB fixture that looks like a real session_summary.

4. **`.github/PULL_REQUEST_TEMPLATE.md`** — new file with an "LLM call path" checklist.

5. **`CONTRIBUTING.md`** — new "LLM call-path verification" subsection.

## Operator setup required after merge

**Admin needs to add this secret to the repo:**

| Setting | Value |
|---|---|
| Name | `CI_ANTHROPIC_OAUTH_TOKEN` |
| Value | An `sk-ant-oat01-...` token from `claude setup-token` against an admin-owned Pro/Max subscription |
| Location | Settings → Secrets and variables → Actions → New repository secret |

Without the secret, the workflow logs a `::warning::` and exits 0 — silently no-op. With it, every triggering PR gets a real-API verification.

## Verification

Ran the smoke test locally with a known-good token. All 3 cases pass in ~13s. The fixture extraction returns valid JSON with lessons + decisions on first try.

```
PYTHONPATH=factory CLAUDE_CODE_OAUTH_TOKEN=$TOKEN \
  pytest factory/tests/llm_smoke/ -v
============================== 3 passed in 13.49s ==============================
```

Full `pytest factory/tests/` suite: 605 passed, 451 skipped (including the 3 LLM smoke tests in default collection), 0 failed.

## Test plan

- [x] Local: 3/3 pass with real token in ~13s
- [x] Local: 3/3 skip cleanly with no credential
- [x] Local: full `factory/tests/` suite still 605/451/0
- [ ] After merge: admin adds `CI_ANTHROPIC_OAUTH_TOKEN` secret
- [ ] After secret added: this PR's own workflow run can be re-triggered to confirm CI integration works (re-trigger via "Re-run all jobs" in Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)