### PR TITLE
feat(auth): DEVBRAIN_COGNIFY_OAUTH_TOKEN system fallback + rotate-token CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,30 @@
 # Summarization / NL-query model.
 # DEVBRAIN_SUMMARY_MODEL=qwen2.5:7b
 
+# ─── Anthropic credentials (cognify LLM-cost passes) ─────────────────────────
+
+# Cognify (extract + edges) calls the Anthropic Messages API to derive
+# lessons / decisions / contradictions from session content. Four slots
+# are accepted, with the documented precedence:
+#
+#   1. ANTHROPIC_API_KEY              — Console key (sk-ant-api03-...).
+#                                       Per-call billing.
+#   2. CLAUDE_CODE_OAUTH_TOKEN        — triggering dev's session token.
+#                                       Burns the dev's Max budget for
+#                                       work they triggered (e.g.,
+#                                       end_session-driven cognify).
+#                                       Per-dev attribution.
+#   3. DEVBRAIN_COGNIFY_OAUTH_TOKEN   — system fallback. Patrick/admin's
+#                                       token. Burns when no dev is
+#                                       present (scheduled launchd
+#                                       cognify-extract runs). Set here.
+#   4. ANTHROPIC_AUTH_TOKEN           — legacy SDK-docs name. Lowest
+#                                       precedence; avoid for new setups.
+#
+# Rotate the system token with: devbrain rotate-token --system
+# Rotate a dev's token with:    devbrain rotate-token --dev=<dev_id>
+# DEVBRAIN_COGNIFY_OAUTH_TOKEN=
+
 # ─── Hooks ────────────────────────────────────────────────────────────────────
 
 # Project slug used by hooks/session-start.sh when generating context.

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -452,6 +452,64 @@ def setup_cognify_launchd_cmd(project_slug, reload):
         click.echo(f"reloaded {len(installed)} launchd job(s)")
 
 
+@cli.command(name="rotate-token")
+@click.option(
+    "--system", "is_system", is_flag=True, default=False,
+    help="Rotate the system DEVBRAIN_COGNIFY_OAUTH_TOKEN in .env. "
+         "Used by scheduled launchd cognify passes when no dev is "
+         "present. Reloads cognify launchd jobs after replacement.",
+)
+@click.option(
+    "--dev", "dev_id", default=None,
+    help="Rotate the named dev's personal OAuth token at "
+         "profiles/<dev_id>/.claude/oauth-token. Used by that dev's "
+         "interactive sessions and by cognify when triggered from their "
+         "end_session.",
+)
+@click.option(
+    "--no-reload-launchd", "no_reload", is_flag=True, default=False,
+    help="(--system only) Skip the launchctl unload+load step. The "
+         "next plist firing will pick up the new token on its own.",
+)
+def rotate_token_cmd(is_system, dev_id, no_reload):
+    """Mint a fresh OAuth token and atomically replace the target.
+
+    Exactly one of `--system` or `--dev=<id>` must be supplied.
+
+    The rotation runs `claude setup-token` interactively — you'll need
+    to open the printed URL in your browser, sign in, and paste the
+    verification code back. The captured token replaces the target
+    atomically. Prior value is backed up to `<target>.pre-rotate.<ts>`.
+
+    Examples:\n
+      devbrain rotate-token --system\n
+      devbrain rotate-token --dev=mike_courtney\n
+      devbrain rotate-token --system --no-reload-launchd
+    """
+    if is_system == bool(dev_id):
+        raise click.UsageError(
+            "Specify exactly one of --system or --dev=<id>."
+        )
+
+    from rotate_token import rotate_system_token, rotate_dev_token
+
+    if is_system:
+        result = rotate_system_token(reload_launchd=not no_reload)
+    else:
+        result = rotate_dev_token(dev_id)
+
+    if not result.success:
+        click.echo(f"error: {result.error}", err=True)
+        if result.hint:
+            click.echo(f"  hint: {result.hint}", err=True)
+        sys.exit(1)
+
+    click.echo(f"✅ rotated: {result.target_path}")
+    click.echo(f"   new token: {result.token_preview}")
+    if result.backup_path is not None:
+        click.echo(f"   backup:    {result.backup_path}")
+
+
 @cli.command(name="add-channel")
 @click.option("--dev-id", default=None)
 @click.option("--channel", "channel_spec", required=True, help="TYPE:ADDRESS")

--- a/factory/cognify/_anthropic_auth.py
+++ b/factory/cognify/_anthropic_auth.py
@@ -1,19 +1,31 @@
 """Anthropic credential resolution for cognify's LLM passes.
 
 The cognify pipeline's extract + edges passes call the Anthropic API
-to derive lessons / contradictions from session content. Two credential
+to derive lessons / contradictions from session content. Three credential
 shapes are accepted:
 
   1. Console API key — `sk-ant-api03-...`. Created at
      console.anthropic.com → Settings → API keys. Sent by the SDK as
      the `X-Api-Key` header. Set via env var `ANTHROPIC_API_KEY`.
 
-  2. Subscription OAuth token — `sk-ant-oat<N>-...`. Created by
-     `claude setup-token` against a Pro/Max/Team/Enterprise account.
-     Sent by the SDK as `Authorization: Bearer`. Set via env var
-     `CLAUDE_CODE_OAUTH_TOKEN` (the name Claude Code's docs use) or
-     `ANTHROPIC_AUTH_TOKEN` (the name the SDK's auth-precedence docs
-     use). Either works — both resolve to the same SDK kwarg.
+  2. Subscription OAuth token (dev's, per-session) — `sk-ant-oat<N>-...`.
+     Created by `claude setup-token` against a Pro/Max/Team/Enterprise
+     account. Sent by the SDK as `Authorization: Bearer`. Set via env
+     var `CLAUDE_CODE_OAUTH_TOKEN` (the name Claude Code's docs use).
+     This is the slot that carries the triggering dev's token when
+     cognify is invoked from `end_session` — the dev's session env has
+     their personal token, so cognify burns the dev's Max budget for
+     work they triggered. Per-dev attribution.
+
+  3. Subscription OAuth token (system fallback) —
+     `DEVBRAIN_COGNIFY_OAUTH_TOKEN`. The admin's token. Used when no
+     dev is present (e.g., scheduled launchd cognify-extract runs),
+     where the system token should pay. Lower precedence than the
+     dev's token in (2), so dev-triggered runs still attribute to
+     the dev — this only kicks in when (2) is unset.
+
+  Legacy: `ANTHROPIC_AUTH_TOKEN` is also accepted (the name the
+  Anthropic SDK's auth-precedence docs use). Lowest precedence.
 
 Returns the kwargs to pass into `anthropic.Anthropic(...)`. Returns
 None when no credential is available; callers should skip the LLM
@@ -50,11 +62,33 @@ _CLAUDE_CODE_SYSTEM_PREFIX = (
 )
 
 
+def _resolve_oauth_token() -> str | None:
+    """Pick the OAuth token from env with the documented precedence.
+
+    Order (each one wins over later entries):
+      1. ``CLAUDE_CODE_OAUTH_TOKEN``         — dev's session token
+      2. ``DEVBRAIN_COGNIFY_OAUTH_TOKEN``    — admin/system fallback
+      3. ``ANTHROPIC_AUTH_TOKEN``            — legacy SDK-docs name
+
+    The split between (1) and (2) is the per-dev attribution lever: a
+    dev-triggered cognify run (from `end_session`) finds the dev's token
+    in slot (1) and burns the dev's Max budget. A launchd-scheduled run
+    has no dev present, so (1) is unset and (2) kicks in — Patrick's
+    system token pays.
+    """
+    return (
+        os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+        or os.environ.get("DEVBRAIN_COGNIFY_OAUTH_TOKEN")
+        or os.environ.get("ANTHROPIC_AUTH_TOKEN")
+    )
+
+
 def resolve_anthropic_auth() -> dict[str, Any] | None:
     """Return SDK kwargs dict, or None if no credential present.
 
     Precedence: ANTHROPIC_API_KEY (Console) wins if set, since it gives
-    deterministic per-call billing; OAuth bearer tokens are the fallback.
+    deterministic per-call billing; OAuth bearer tokens are the fallback,
+    with their own internal precedence (see `_resolve_oauth_token`).
 
     Console path returns: ``{"api_key": "<value>"}``.
     OAuth path returns: ``{"auth_token": "<value>", "default_headers":
@@ -65,10 +99,7 @@ def resolve_anthropic_auth() -> dict[str, Any] | None:
     if api_key:
         return {"api_key": api_key}
 
-    bearer = (
-        os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
-        or os.environ.get("ANTHROPIC_AUTH_TOKEN")
-    )
+    bearer = _resolve_oauth_token()
     if bearer:
         return {
             "auth_token": bearer,
@@ -94,8 +125,6 @@ def claude_code_system_prefix() -> str | None:
     """
     if os.environ.get("ANTHROPIC_API_KEY"):
         return None
-    if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get(
-        "ANTHROPIC_AUTH_TOKEN"
-    ):
+    if _resolve_oauth_token():
         return _CLAUDE_CODE_SYSTEM_PREFIX
     return None

--- a/factory/rotate_token.py
+++ b/factory/rotate_token.py
@@ -1,0 +1,359 @@
+"""Token rotation: mint a fresh Anthropic OAuth token and atomically
+replace either the system-wide token in .env or a single dev's profile
+file.
+
+Two flavors:
+
+  * **System token** (`rotate_system_token`) — writes to
+    `<DEVBRAIN_HOME>/.env`'s `DEVBRAIN_COGNIFY_OAUTH_TOKEN=` line. This
+    is the system fallback used by scheduled cognify-extract /
+    cognify-edges launchd jobs.
+
+  * **Dev token** (`rotate_dev_token`) — writes to
+    `<DEVBRAIN_HOME>/profiles/<dev_id>/.claude/oauth-token`. This is
+    the dev's personal token used by their interactive Claude sessions
+    AND by cognify when triggered from their `end_session`.
+
+Both flavors:
+
+  1. Back up the existing token file (.env or oauth-token) to
+     `<path>.pre-rotate.<timestamp>` for one-step rollback.
+  2. Run `claude setup-token` interactively. The operator (you)
+     authenticates in a browser. The setup-token output (captured via
+     `script(1)`) is scraped for the new token.
+  3. Atomically replace the target file with the new value (temp
+     file + rename, chmod 0600).
+  4. Optionally reload cognify launchd jobs (system flavor only) so the
+     new token takes effect immediately rather than at next plist load.
+
+The setup-token capture machinery is shared with `ai_clis.claude` —
+see `_run_setup_token_and_extract()` below, which factors the
+script(1)+regex pattern out of `ClaudeAdapter.login()`.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RotationResult:
+    """Outcome of a token rotation. ``success`` flags whether the new
+    token landed on disk; ``backup_path`` is where the old file was
+    moved (None on first-ever provisioning). ``token_preview`` is the
+    new token's first 25 chars (safe to log)."""
+
+    success: bool
+    target_path: Path
+    backup_path: Path | None
+    token_preview: str | None
+    error: str | None = None
+    hint: str | None = None
+
+
+def rotate_system_token(
+    devbrain_home: Path | None = None,
+    *,
+    reload_launchd: bool = True,
+    runner: callable = subprocess.run,
+    setup_token_fn: callable | None = None,
+) -> RotationResult:
+    """Rotate the system DEVBRAIN_COGNIFY_OAUTH_TOKEN in `.env`.
+
+    Args:
+      devbrain_home: defaults to the repo root inferred from this file.
+      reload_launchd: after rotation, run `launchctl unload && load`
+        on the cognify-extract + cognify-edges plists so the new token
+        takes effect immediately. Set False for tests / when launchd
+        isn't relevant.
+      runner: dependency-injected subprocess.run for tests.
+      setup_token_fn: dependency-injected callable to mint a token; takes
+        a runner callable, returns the new token string or raises. Defaults
+        to a real `claude setup-token` invocation. Tests pass a stub.
+    """
+    if devbrain_home is None:
+        devbrain_home = Path(__file__).resolve().parent.parent
+    env_path = devbrain_home / ".env"
+
+    if setup_token_fn is None:
+        setup_token_fn = _run_setup_token_and_extract
+
+    try:
+        new_token = setup_token_fn(runner=runner)
+    except RotationError as exc:
+        return RotationResult(
+            success=False,
+            target_path=env_path,
+            backup_path=None,
+            token_preview=None,
+            error=exc.error,
+            hint=exc.hint,
+        )
+
+    backup_path = _backup_file(env_path)
+    _replace_env_var(env_path, "DEVBRAIN_COGNIFY_OAUTH_TOKEN", new_token)
+
+    if reload_launchd:
+        _reload_cognify_launchd(runner=runner)
+
+    return RotationResult(
+        success=True,
+        target_path=env_path,
+        backup_path=backup_path,
+        token_preview=_safe_preview(new_token),
+    )
+
+
+def rotate_dev_token(
+    dev_id: str,
+    devbrain_home: Path | None = None,
+    *,
+    runner: callable = subprocess.run,
+    setup_token_fn: callable | None = None,
+) -> RotationResult:
+    """Rotate a single dev's `profiles/<dev_id>/.claude/oauth-token`."""
+    if devbrain_home is None:
+        devbrain_home = Path(__file__).resolve().parent.parent
+
+    profile_dir = devbrain_home / "profiles" / dev_id
+    token_path = profile_dir / ".claude" / "oauth-token"
+
+    if not profile_dir.exists():
+        return RotationResult(
+            success=False,
+            target_path=token_path,
+            backup_path=None,
+            token_preview=None,
+            error=f"profile directory not found: {profile_dir}",
+            hint=(
+                f"Run `devbrain setup add-dev` to onboard {dev_id} first, "
+                "or check the dev_id spelling."
+            ),
+        )
+
+    if setup_token_fn is None:
+        setup_token_fn = _run_setup_token_and_extract
+
+    try:
+        new_token = setup_token_fn(runner=runner)
+    except RotationError as exc:
+        return RotationResult(
+            success=False,
+            target_path=token_path,
+            backup_path=None,
+            token_preview=None,
+            error=exc.error,
+            hint=exc.hint,
+        )
+
+    backup_path = _backup_file(token_path) if token_path.exists() else None
+    _atomic_write(token_path, new_token, mode=0o600)
+
+    return RotationResult(
+        success=True,
+        target_path=token_path,
+        backup_path=backup_path,
+        token_preview=_safe_preview(new_token),
+    )
+
+
+# ─── Internals ───────────────────────────────────────────────────────────────
+
+
+class RotationError(Exception):
+    """Raised when the setup-token flow fails. Carries operator-friendly
+    `error` + `hint` strings so the CLI can print actionable guidance."""
+
+    def __init__(self, error: str, hint: str = ""):
+        super().__init__(error)
+        self.error = error
+        self.hint = hint
+
+
+# Token-capture regex: matches sk-ant-oatN-... where N is one or more
+# digits. Mirrors ai_clis/claude.py's _extract_oauth_token; replicated
+# here to avoid a circular import when ai_clis depends on rotate_token.
+_TOKEN_RE = re.compile(
+    r"sk-ant-oat\d+-[A-Za-z0-9_-]+(?:-[A-Za-z0-9_-]+)*"
+)
+# Intra-token TTY escapes that need stripping before regex match.
+_INTRA_TOKEN_ESCAPE_RE = re.compile(r"(?:\x1b\[1C|\r\x1b\[1B)")
+
+
+def _run_setup_token_and_extract(*, runner: callable) -> str:
+    """Run `claude setup-token` via script(1) and scrape the issued token.
+
+    Raises `RotationError` on any failure path with operator guidance.
+    """
+    log_fd, log_path_str = tempfile.mkstemp(prefix=".setup-token-", suffix=".log")
+    os.close(log_fd)
+    log_path = Path(log_path_str)
+    os.chmod(log_path, 0o600)
+
+    try:
+        try:
+            result = runner(
+                ["script", "-q", str(log_path), "claude", "setup-token"],
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RotationError(
+                error=f"binary not found: {exc.filename or 'script or claude'}",
+                hint=(
+                    "Both `script` (system-provided on macOS) and `claude` "
+                    "must be on PATH for token rotation to work."
+                ),
+            ) from exc
+
+        if result.returncode != 0:
+            raise RotationError(
+                error=f"claude setup-token exited with code {result.returncode}",
+                hint=(
+                    "Complete the OAuth flow: open the printed URL in your "
+                    "browser, sign in, copy the verification code from the "
+                    "post-signin page, and paste it back into this session."
+                ),
+            )
+
+        log_text = log_path.read_bytes().decode("utf-8", "replace")
+    finally:
+        try:
+            log_path.unlink()
+        except OSError:
+            pass
+
+    cleaned = _INTRA_TOKEN_ESCAPE_RE.sub("", log_text)
+    match = _TOKEN_RE.search(cleaned)
+    if match is None:
+        raise RotationError(
+            error="claude setup-token completed but no sk-ant-oatN-... token was found in the captured output",
+            hint=(
+                "The OAuth flow may not have completed — verify you signed "
+                "in and pasted the verification code."
+            ),
+        )
+    return match.group(0)
+
+
+def _backup_file(path: Path) -> Path | None:
+    """Copy `path` to `path.pre-rotate.<unix_ts>`. Returns the backup
+    path, or None if the original didn't exist."""
+    if not path.exists():
+        return None
+    import time
+    ts = int(time.time())
+    backup = path.with_suffix(path.suffix + f".pre-rotate.{ts}")
+    shutil.copy2(path, backup)
+    os.chmod(backup, 0o600)
+    return backup
+
+
+def _replace_env_var(env_path: Path, key: str, value: str) -> None:
+    """Update `key=value` in the .env at `env_path`, preserving every
+    other line. If the file doesn't exist, create it. If the key isn't
+    present, append it. Atomic via temp file + rename.
+
+    Preserves blank lines + comment lines verbatim.
+    """
+    if env_path.exists():
+        original = env_path.read_text().splitlines(keepends=False)
+    else:
+        original = []
+
+    new_lines: list[str] = []
+    found = False
+    for line in original:
+        stripped = line.lstrip()
+        if stripped.startswith("#") or not stripped:
+            new_lines.append(line)
+            continue
+        # Match `KEY=...` (allow leading `export `)
+        bare = stripped[len("export "):] if stripped.startswith("export ") else stripped
+        if bare.startswith(f"{key}="):
+            new_lines.append(f"{key}={value}")
+            found = True
+        else:
+            new_lines.append(line)
+
+    if not found:
+        # Append (after a comment header for discoverability)
+        if new_lines and new_lines[-1] != "":
+            new_lines.append("")
+        new_lines.append(f"# DevBrain cognify system token (see config/devbrain.yaml).")
+        new_lines.append(f"{key}={value}")
+
+    # Atomic write
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=env_path.name + ".", suffix=".tmp", dir=str(env_path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write("\n".join(new_lines))
+            f.write("\n")
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, env_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _atomic_write(target: Path, content: str, *, mode: int = 0o600) -> None:
+    """Write `content` to `target` atomically, set mode."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=target.name + ".", suffix=".tmp", dir=str(target.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, target)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _reload_cognify_launchd(*, runner: callable) -> None:
+    """Reload the two cognify LLM-cost launchd plists so they pick up
+    the new env var values. Errors are logged-and-ignored — rotation
+    succeeded DB-side; the operator can manually `launchctl load` if
+    this fails.
+    """
+    home = Path.home()
+    plists = [
+        home / "Library" / "LaunchAgents" / "com.devbrain.cognify-extract.plist",
+        home / "Library" / "LaunchAgents" / "com.devbrain.cognify-edges.plist",
+    ]
+    for plist in plists:
+        if not plist.exists():
+            continue
+        runner(
+            ["launchctl", "unload", str(plist)],
+            check=False,
+            capture_output=True,
+        )
+        runner(
+            ["launchctl", "load", str(plist)],
+            check=False,
+            capture_output=True,
+        )
+
+
+def _safe_preview(token: str) -> str:
+    """Return a token preview safe to print: prefix + ellipsis + last 4."""
+    if len(token) < 30:
+        return token[:8] + "…"
+    return token[:25] + "…" + token[-4:]

--- a/factory/tests/test_cognify_anthropic_auth.py
+++ b/factory/tests/test_cognify_anthropic_auth.py
@@ -30,7 +30,12 @@ _OAUTH_PREFIX = (
 def _isolated_env(**vars):
     """Strip the target env vars to start clean, then layer in `vars`."""
     base = {k: v for k, v in os.environ.items()
-            if k not in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN")}
+            if k not in (
+                "ANTHROPIC_API_KEY",
+                "CLAUDE_CODE_OAUTH_TOKEN",
+                "DEVBRAIN_COGNIFY_OAUTH_TOKEN",
+                "ANTHROPIC_AUTH_TOKEN",
+            )}
     base.update(vars)
     return base
 
@@ -100,6 +105,69 @@ def test_empty_string_env_treated_as_unset():
             "auth_token": "sk-ant-oat1-USE-ME",
             "default_headers": _OAUTH_BETA,
         }
+
+
+# ── DEVBRAIN_COGNIFY_OAUTH_TOKEN (system fallback) ───────────────────────────
+
+
+def test_devbrain_cognify_token_used_when_only_system_token_set():
+    """Launchd / system-only case: no dev token in env. The system
+    fallback DEVBRAIN_COGNIFY_OAUTH_TOKEN wins."""
+    env = _isolated_env(DEVBRAIN_COGNIFY_OAUTH_TOKEN="sk-ant-oat1-SYSTEM")
+    with patch.dict(os.environ, env, clear=True):
+        assert resolve_anthropic_auth() == {
+            "auth_token": "sk-ant-oat1-SYSTEM",
+            "default_headers": _OAUTH_BETA,
+        }
+
+
+def test_dev_token_wins_over_system_token():
+    """End_session case: both dev's session token AND system token are
+    in env (system from .env, dev from session). Dev wins — that's the
+    per-dev attribution feature."""
+    env = _isolated_env(
+        CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat1-DEV-WINS",
+        DEVBRAIN_COGNIFY_OAUTH_TOKEN="sk-ant-oat1-SYSTEM-LOSES",
+    )
+    with patch.dict(os.environ, env, clear=True):
+        assert resolve_anthropic_auth() == {
+            "auth_token": "sk-ant-oat1-DEV-WINS",
+            "default_headers": _OAUTH_BETA,
+        }
+
+
+def test_console_key_still_wins_over_both_oauth_tokens():
+    """Explicit Console key beats any OAuth precedence."""
+    env = _isolated_env(
+        ANTHROPIC_API_KEY="sk-ant-api03-CONSOLE-WINS",
+        CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat1-DEV-LOSES",
+        DEVBRAIN_COGNIFY_OAUTH_TOKEN="sk-ant-oat1-SYSTEM-LOSES",
+    )
+    with patch.dict(os.environ, env, clear=True):
+        assert resolve_anthropic_auth() == {"api_key": "sk-ant-api03-CONSOLE-WINS"}
+
+
+def test_system_token_wins_over_legacy_anthropic_auth_token():
+    """DEVBRAIN_COGNIFY_OAUTH_TOKEN beats the legacy ANTHROPIC_AUTH_TOKEN
+    name, since it's the more specific (cognify-purpose-built) slot."""
+    env = _isolated_env(
+        DEVBRAIN_COGNIFY_OAUTH_TOKEN="sk-ant-oat1-NEW-SYSTEM",
+        ANTHROPIC_AUTH_TOKEN="sk-ant-oat1-OLD-LEGACY",
+    )
+    with patch.dict(os.environ, env, clear=True):
+        assert resolve_anthropic_auth() == {
+            "auth_token": "sk-ant-oat1-NEW-SYSTEM",
+            "default_headers": _OAUTH_BETA,
+        }
+
+
+def test_system_prefix_present_for_system_token_only():
+    """When only DEVBRAIN_COGNIFY_OAUTH_TOKEN is set (launchd case),
+    the system prefix must still be returned — Anthropic gates on the
+    prefix regardless of which OAuth slot the token came from."""
+    env = _isolated_env(DEVBRAIN_COGNIFY_OAUTH_TOKEN="sk-ant-oat1-SYSTEM")
+    with patch.dict(os.environ, env, clear=True):
+        assert claude_code_system_prefix() == _OAUTH_PREFIX
 
 
 # ── claude_code_system_prefix ────────────────────────────────────────────────

--- a/factory/tests/test_rotate_token.py
+++ b/factory/tests/test_rotate_token.py
@@ -1,0 +1,312 @@
+"""Tests for factory.rotate_token — system + dev OAuth token rotation."""
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from rotate_token import (
+    RotationError,
+    RotationResult,
+    _atomic_write,
+    _backup_file,
+    _replace_env_var,
+    _safe_preview,
+    rotate_dev_token,
+    rotate_system_token,
+)
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _stub_setup_token_success(token: str = "sk-ant-oat01-NEWLY-MINTED-FROM-STUB-1234567890ABCDEF"):
+    """Build a `setup_token_fn` stub that returns a fixed token."""
+    def _fn(*, runner):
+        return token
+    return _fn
+
+
+def _stub_setup_token_failure(error: str = "claude setup-token exited with code 1", hint: str = "hint here"):
+    def _fn(*, runner):
+        raise RotationError(error=error, hint=hint)
+    return _fn
+
+
+def _fake_runner_success():
+    """Build a runner that always returns returncode=0."""
+    def _run(*args, **kwargs):
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = b""
+        r.stderr = b""
+        return r
+    return _run
+
+
+# ─── _safe_preview ───────────────────────────────────────────────────────────
+
+
+def test_safe_preview_long_token():
+    token = "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"
+    preview = _safe_preview(token)
+    # 25-char prefix
+    assert preview.startswith(token[:25])
+    # Last 4 chars present
+    assert preview.endswith(token[-4:])
+    assert "…" in preview
+    # Critically, the middle of the token must NOT be in the preview.
+    assert "9JdHIfY9qf6i" not in preview
+
+
+def test_safe_preview_short_token():
+    """Pathologically short tokens get truncated at 8 chars."""
+    preview = _safe_preview("sk-ant-oat01-X")
+    assert preview == "sk-ant-o…"
+
+
+# ─── _replace_env_var ────────────────────────────────────────────────────────
+
+
+def test_replace_env_var_creates_new_file(tmp_path):
+    env_path = tmp_path / ".env"
+    _replace_env_var(env_path, "DEVBRAIN_COGNIFY_OAUTH_TOKEN", "newval")
+    body = env_path.read_text()
+    assert "DEVBRAIN_COGNIFY_OAUTH_TOKEN=newval" in body
+    assert os.stat(env_path).st_mode & 0o777 == 0o600
+
+
+def test_replace_env_var_updates_existing_key(tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "# Comment\n"
+        "OTHER_VAR=untouched\n"
+        "DEVBRAIN_COGNIFY_OAUTH_TOKEN=oldval\n"
+        "ANOTHER_VAR=stays\n"
+    )
+    _replace_env_var(env_path, "DEVBRAIN_COGNIFY_OAUTH_TOKEN", "newval")
+    body = env_path.read_text()
+    assert "DEVBRAIN_COGNIFY_OAUTH_TOKEN=newval" in body
+    assert "DEVBRAIN_COGNIFY_OAUTH_TOKEN=oldval" not in body
+    assert "OTHER_VAR=untouched" in body
+    assert "ANOTHER_VAR=stays" in body
+    assert "# Comment" in body  # comments preserved
+
+
+def test_replace_env_var_appends_missing_key(tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text("OTHER_VAR=v\n")
+    _replace_env_var(env_path, "DEVBRAIN_COGNIFY_OAUTH_TOKEN", "newval")
+    body = env_path.read_text()
+    assert "OTHER_VAR=v" in body
+    assert "DEVBRAIN_COGNIFY_OAUTH_TOKEN=newval" in body
+
+
+def test_replace_env_var_handles_export_prefix(tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text("export DEVBRAIN_COGNIFY_OAUTH_TOKEN=oldval\n")
+    _replace_env_var(env_path, "DEVBRAIN_COGNIFY_OAUTH_TOKEN", "newval")
+    body = env_path.read_text()
+    # The export prefix gets stripped on rewrite (consistent format).
+    assert "DEVBRAIN_COGNIFY_OAUTH_TOKEN=newval" in body
+    assert "oldval" not in body
+
+
+def test_replace_env_var_is_atomic(tmp_path):
+    """No .tmp files left behind on success."""
+    env_path = tmp_path / ".env"
+    _replace_env_var(env_path, "K", "v")
+    leftovers = list(tmp_path.glob("*.tmp"))
+    assert leftovers == []
+
+
+# ─── _backup_file ────────────────────────────────────────────────────────────
+
+
+def test_backup_file_creates_versioned_copy(tmp_path):
+    src = tmp_path / "oauth-token"
+    src.write_text("ORIGINAL")
+    backup = _backup_file(src)
+    assert backup is not None
+    assert backup.exists()
+    assert backup.read_text() == "ORIGINAL"
+    assert ".pre-rotate." in backup.name
+    assert stat.S_IMODE(backup.stat().st_mode) == 0o600
+
+
+def test_backup_file_returns_none_when_missing(tmp_path):
+    src = tmp_path / "does-not-exist"
+    assert _backup_file(src) is None
+
+
+# ─── rotate_system_token ─────────────────────────────────────────────────────
+
+
+def test_rotate_system_token_writes_new_token_to_env(tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text("DEVBRAIN_COGNIFY_OAUTH_TOKEN=OLD\n")
+
+    result = rotate_system_token(
+        devbrain_home=tmp_path,
+        reload_launchd=False,
+        runner=_fake_runner_success(),
+        setup_token_fn=_stub_setup_token_success("sk-ant-oat01-NEW-TOKEN-FROM-TEST"),
+    )
+
+    assert result.success is True
+    assert result.target_path == env_path
+    assert result.backup_path is not None
+    assert result.backup_path.read_text() == "DEVBRAIN_COGNIFY_OAUTH_TOKEN=OLD\n"
+    new_body = env_path.read_text()
+    assert "DEVBRAIN_COGNIFY_OAUTH_TOKEN=sk-ant-oat01-NEW-TOKEN-FROM-TEST" in new_body
+    assert "OLD" not in new_body
+    assert result.token_preview.startswith("sk-ant-oat01-NEW")
+
+
+def test_rotate_system_token_creates_env_if_missing(tmp_path):
+    result = rotate_system_token(
+        devbrain_home=tmp_path,
+        reload_launchd=False,
+        runner=_fake_runner_success(),
+        setup_token_fn=_stub_setup_token_success(),
+    )
+    assert result.success is True
+    assert result.backup_path is None  # no original to back up
+    assert (tmp_path / ".env").exists()
+
+
+def test_rotate_system_token_preserves_other_env_vars(tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "# Devbrain env\n"
+        "TELEGRAM_BOT_TOKEN=secret123\n"
+        "DEVBRAIN_COGNIFY_OAUTH_TOKEN=OLD\n"
+        "DEVBRAIN_DB_PASSWORD=dbpw\n"
+    )
+
+    rotate_system_token(
+        devbrain_home=tmp_path,
+        reload_launchd=False,
+        runner=_fake_runner_success(),
+        setup_token_fn=_stub_setup_token_success("sk-ant-oat01-NEW"),
+    )
+
+    body = env_path.read_text()
+    assert "TELEGRAM_BOT_TOKEN=secret123" in body
+    assert "DEVBRAIN_DB_PASSWORD=dbpw" in body
+    assert "DEVBRAIN_COGNIFY_OAUTH_TOKEN=sk-ant-oat01-NEW" in body
+    assert "# Devbrain env" in body  # comment preserved
+
+
+def test_rotate_system_token_returns_error_when_setup_fails(tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text("DEVBRAIN_COGNIFY_OAUTH_TOKEN=UNCHANGED\n")
+
+    result = rotate_system_token(
+        devbrain_home=tmp_path,
+        reload_launchd=False,
+        runner=_fake_runner_success(),
+        setup_token_fn=_stub_setup_token_failure("setup-token failed"),
+    )
+
+    assert result.success is False
+    assert result.error == "setup-token failed"
+    # Critically, the .env was NOT modified on failure.
+    assert env_path.read_text() == "DEVBRAIN_COGNIFY_OAUTH_TOKEN=UNCHANGED\n"
+
+
+def test_rotate_system_token_reload_launchd_calls_launchctl(tmp_path):
+    """When reload_launchd=True, expect launchctl unload+load calls per plist
+    (only for plists that exist on disk; in tests neither does, so 0 calls)."""
+    calls: list[tuple] = []
+
+    def _record_runner(*args, **kwargs):
+        calls.append(tuple(args[0]) if args else ())
+        r = MagicMock()
+        r.returncode = 0
+        return r
+
+    rotate_system_token(
+        devbrain_home=tmp_path,
+        reload_launchd=True,
+        runner=_record_runner,
+        setup_token_fn=_stub_setup_token_success(),
+    )
+    # In test env the plists won't exist at ~/Library/LaunchAgents,
+    # so we just confirm rotate_system_token didn't fail.
+    # Real-machine integration is covered by manual smoke test.
+
+
+# ─── rotate_dev_token ────────────────────────────────────────────────────────
+
+
+def test_rotate_dev_token_writes_to_profile_dir(tmp_path):
+    # Set up a fake profile
+    profile_dir = tmp_path / "profiles" / "mike_courtney"
+    (profile_dir / ".claude").mkdir(parents=True)
+    token_path = profile_dir / ".claude" / "oauth-token"
+    token_path.write_text("sk-ant-oat01-OLD-TOKEN")
+    token_path.chmod(0o600)
+
+    result = rotate_dev_token(
+        "mike_courtney",
+        devbrain_home=tmp_path,
+        runner=_fake_runner_success(),
+        setup_token_fn=_stub_setup_token_success("sk-ant-oat01-NEW-TOKEN"),
+    )
+
+    assert result.success is True
+    assert result.target_path == token_path
+    assert result.backup_path is not None
+    assert result.backup_path.read_text() == "sk-ant-oat01-OLD-TOKEN"
+    assert token_path.read_text() == "sk-ant-oat01-NEW-TOKEN"
+    assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+
+
+def test_rotate_dev_token_errors_when_profile_dir_missing(tmp_path):
+    result = rotate_dev_token(
+        "nonexistent_dev",
+        devbrain_home=tmp_path,
+        runner=_fake_runner_success(),
+        setup_token_fn=_stub_setup_token_success(),
+    )
+    assert result.success is False
+    assert "profile directory not found" in result.error
+
+
+def test_rotate_dev_token_creates_token_file_if_missing(tmp_path):
+    """If profile dir exists but no prior oauth-token, that's fine — just write."""
+    profile_dir = tmp_path / "profiles" / "new_dev"
+    profile_dir.mkdir(parents=True)
+    # Don't create .claude/oauth-token
+
+    result = rotate_dev_token(
+        "new_dev",
+        devbrain_home=tmp_path,
+        runner=_fake_runner_success(),
+        setup_token_fn=_stub_setup_token_success("sk-ant-oat01-FIRST-TOKEN"),
+    )
+    assert result.success is True
+    assert result.backup_path is None  # nothing to back up
+    assert (profile_dir / ".claude" / "oauth-token").read_text() == "sk-ant-oat01-FIRST-TOKEN"
+
+
+def test_rotate_dev_token_returns_error_when_setup_fails(tmp_path):
+    profile_dir = tmp_path / "profiles" / "mike_courtney"
+    (profile_dir / ".claude").mkdir(parents=True)
+    token_path = profile_dir / ".claude" / "oauth-token"
+    token_path.write_text("UNCHANGED")
+
+    result = rotate_dev_token(
+        "mike_courtney",
+        devbrain_home=tmp_path,
+        runner=_fake_runner_success(),
+        setup_token_fn=_stub_setup_token_failure("flow timed out"),
+    )
+
+    assert result.success is False
+    assert result.error == "flow timed out"
+    assert token_path.read_text() == "UNCHANGED"  # original preserved


### PR DESCRIPTION
## Summary

Two related changes for cognify auth precedence + token lifecycle:

### 1. `DEVBRAIN_COGNIFY_OAUTH_TOKEN` (new env-var slot)

Per Patrick's design call: cognify should be authenticated as the **triggering dev** (per-dev attribution from PR #120) with a **system token as fallback** for cases when no dev is present (scheduled launchd cognify-extract runs).

New precedence ladder in `cognify._anthropic_auth.resolve_anthropic_auth()`:

| Slot | Used when |
|---|---|
| `ANTHROPIC_API_KEY` | Console key (explicit, deterministic billing) |
| `CLAUDE_CODE_OAUTH_TOKEN` | Dev's session token (PR #120 per-dev attribution) |
| `DEVBRAIN_COGNIFY_OAUTH_TOKEN` | **System fallback (new)** — Patrick's token, for launchd runs |
| `ANTHROPIC_AUTH_TOKEN` | Legacy SDK-docs name |

end_session-triggered cognify → dev's token wins → dev's Max budget pays.
Launchd-scheduled cognify-extract → no dev → system token kicks in → Patrick's token pays.

`.env.example` documents the full precedence ladder.

### 2. `devbrain rotate-token` CLI

Mints a fresh OAuth token via `claude setup-token` and atomically replaces either the system slot or a dev's profile file:

```bash
devbrain rotate-token --system               # → .env's DEVBRAIN_COGNIFY_OAUTH_TOKEN
devbrain rotate-token --dev=<id>             # → profiles/<id>/.claude/oauth-token
devbrain rotate-token --system --no-reload-launchd
```

Both flavors:
- Back up prior value to `<target>.pre-rotate.<unix_ts>` (one-step rollback).
- Run `claude setup-token` interactively via the same `script(1)` pattern `ai_clis/claude.py::login()` uses.
- Atomic replace (temp file + `os.replace`, chmod 0600).
- (System only, default on) Reload cognify launchd jobs via `launchctl unload && load`.

`_replace_env_var` preserves every other line in `.env` verbatim — comments, blanks, other vars stay; only the target key is updated.

## Tests (23 new)

**`test_rotate_token.py` (18 tests):**
- `_safe_preview` mid-string truncation
- `_replace_env_var`: creates, updates, appends, handles `export ` prefix, atomic
- `_backup_file`: versioned copy with 0600; None when src missing
- `rotate_system_token`: writes new, preserves other vars, errors+leaves-untouched on failure, optional launchd reload
- `rotate_dev_token`: writes to profile, backs up, errors when profile missing, creates first-time, preserves on failure

**`test_cognify_anthropic_auth.py` (5 added):**
- System token used when only system slot set
- Dev token wins over system token
- Console key wins over both
- System slot wins over legacy `ANTHROPIC_AUTH_TOKEN`
- System prefix returned when only system slot set

## Test plan

- [x] `pytest factory/tests/test_rotate_token.py factory/tests/test_cognify_anthropic_auth.py` — 35/35 pass
- [x] Full `factory/tests/` suite: 628 pass, 451 skip, 0 fail
- [x] `devbrain rotate-token --help` renders correctly
- [ ] Reviewer: confirm precedence ladder matches your mental model (`ANTHROPIC_API_KEY` > dev > system > legacy)
- [ ] After merge: add `DEVBRAIN_COGNIFY_OAUTH_TOKEN=<your token>` to Mac Studio's `.env`, then `devbrain rotate-token --system` to verify the rotation flow works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)