### PR TITLE
feat(dashboard): cognify pass status panel

### DIFF
--- a/factory/dashboard/app.py
+++ b/factory/dashboard/app.py
@@ -26,6 +26,7 @@ from dashboard.widgets.jobs_panel import ActiveJobsPanel
 from dashboard.widgets.events_panel import RecentEventsPanel
 from dashboard.widgets.locks_panel import FileLocksPanel
 from dashboard.widgets.completed_panel import RecentCompletedPanel
+from dashboard.widgets.cognify_panel import CognifyPanel
 from dashboard.widgets.job_detail import JobDetailScreen
 
 REFRESH_INTERVAL = 2.0  # seconds
@@ -72,6 +73,7 @@ class DashboardApp(App):
             yield ActiveJobsPanel(id="jobs-panel", classes="panel")
             yield RecentEventsPanel(id="events-panel", classes="panel")
             yield FileLocksPanel(id="locks-panel", classes="panel")
+            yield CognifyPanel(id="cognify-panel", classes="panel")
             yield RecentCompletedPanel(id="completed-panel", classes="panel")
         yield Footer()
 
@@ -87,10 +89,12 @@ class DashboardApp(App):
             events = self.data.get_recent_events(project=self.current_project)
             locks = self.data.get_active_locks(project=self.current_project)
             completed = self.data.get_recent_completed(project=self.current_project)
+            cognify_passes = self.data.get_cognify_pass_status(project=self.current_project)
 
             self.query_one("#jobs-panel", ActiveJobsPanel).update_jobs(jobs)
             self.query_one("#events-panel", RecentEventsPanel).update_events(events)
             self.query_one("#locks-panel", FileLocksPanel).update_locks(locks)
+            self.query_one("#cognify-panel", CognifyPanel).update_passes(cognify_passes)
             self.query_one("#completed-panel", RecentCompletedPanel).update_completed(completed)
         except Exception as e:
             self.notify(f"Refresh error: {e}", severity="error")

--- a/factory/dashboard/data.py
+++ b/factory/dashboard/data.py
@@ -252,3 +252,128 @@ class DashboardData:
                 for r in reports
             ],
         }
+
+    # Pass schedule (seconds between runs). Used to derive `down` state
+    # — if no run has happened within `expected_interval * DOWN_FACTOR`,
+    # we consider the launchd job stopped. Matches the StartInterval
+    # values in factory/cognify/launchd/com.devbrain.cognify-*.plist.
+    _COGNIFY_PASS_SCHEDULE: dict[str, int] = {
+        "extract":    3_600,   # hourly
+        "edges":      21_600,  # every 6h
+        "decay":      3_600,   # hourly
+        "strengthen": 86_400,  # daily
+        "gc":         604_800, # weekly
+    }
+    _DOWN_FACTOR = 3  # >3× expected interval since last run = consider down
+
+    def get_cognify_pass_status(self, project: str | None = None) -> list[dict]:
+        """Return per-pass status rows for the cognify dashboard panel.
+
+        Pulls the most-recent row per pass_name from cognify_run_log and
+        derives a state from its timing + completion + error fields:
+
+          * `running`   — most recent row has started_at but no completed_at
+                          (the pass is currently in flight).
+          * `errored`   — most recent COMPLETED row has a non-null error.
+          * `idle`      — last successful run is within expected_interval;
+                          launchd is firing as expected.
+          * `down`      — last run is older than expected_interval * DOWN_FACTOR.
+                          Suggests launchd isn't firing (plist unloaded, etc.).
+          * `never_run` — no row in cognify_run_log for this pass.
+
+        Returns one dict per pass with keys: pass_name, state, last_run,
+        last_completed, last_rows_processed, last_llm_calls, last_error
+        (truncated), project (slug or None for global passes).
+
+        `project` filter scopes to a specific project_id. Global passes
+        (decay, gc — project_id IS NULL) are always included.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc)
+        rows = []
+
+        # Project filter resolves to project_id (or None if not given).
+        project_id = None
+        if project:
+            with self.db._conn() as conn, conn.cursor() as cur:
+                cur.execute(
+                    "SELECT id FROM devbrain.projects WHERE slug = %s",
+                    (project,),
+                )
+                row = cur.fetchone()
+                project_id = row[0] if row else None
+
+        with self.db._conn() as conn, conn.cursor() as cur:
+            # For each known pass, fetch the most recent row.
+            for pass_name in self._COGNIFY_PASS_SCHEDULE:
+                if project_id is not None:
+                    # Project-scoped passes (extract, edges, strengthen)
+                    # filter to project_id; global passes (decay, gc)
+                    # have project_id IS NULL.
+                    cur.execute(
+                        """
+                        SELECT started_at, completed_at, rows_processed,
+                               llm_calls, error
+                        FROM devbrain.cognify_run_log
+                        WHERE pass_name = %s
+                          AND (project_id = %s OR project_id IS NULL)
+                        ORDER BY started_at DESC
+                        LIMIT 1
+                        """,
+                        (pass_name, project_id),
+                    )
+                else:
+                    cur.execute(
+                        """
+                        SELECT started_at, completed_at, rows_processed,
+                               llm_calls, error
+                        FROM devbrain.cognify_run_log
+                        WHERE pass_name = %s
+                        ORDER BY started_at DESC
+                        LIMIT 1
+                        """,
+                        (pass_name,),
+                    )
+                last = cur.fetchone()
+                expected = self._COGNIFY_PASS_SCHEDULE[pass_name]
+
+                if last is None:
+                    rows.append({
+                        "pass_name": pass_name,
+                        "state": "never_run",
+                        "last_run": None,
+                        "last_completed": None,
+                        "last_rows_processed": 0,
+                        "last_llm_calls": 0,
+                        "last_error": None,
+                        "expected_interval_s": expected,
+                    })
+                    continue
+
+                started_at, completed_at, rows_processed, llm_calls, error = last
+
+                # State derivation
+                if completed_at is None:
+                    state = "running"
+                elif error is not None:
+                    state = "errored"
+                else:
+                    age = (now - completed_at).total_seconds()
+                    if age > expected * self._DOWN_FACTOR:
+                        state = "down"
+                    else:
+                        state = "idle"
+
+                rows.append({
+                    "pass_name": pass_name,
+                    "state": state,
+                    "last_run": started_at,
+                    "last_completed": completed_at,
+                    "last_rows_processed": rows_processed or 0,
+                    "last_llm_calls": llm_calls or 0,
+                    "last_error": (error[:200] if error else None),
+                    "expected_interval_s": expected,
+                })
+
+        return rows

--- a/factory/dashboard/widgets/cognify_panel.py
+++ b/factory/dashboard/widgets/cognify_panel.py
@@ -1,0 +1,109 @@
+"""Cognify pass status panel.
+
+Shows the 5 cognify passes (extract, edges, decay, strengthen, gc)
+with their current state (running / idle / errored / down / never_run),
+last completion time, and recent activity counters.
+
+State semantics (see `DashboardData.get_cognify_pass_status`):
+
+  ╔═══════════╤══════════════════════════════════════════════════════╗
+  ║ running   │ Started_at exists, completed_at not yet recorded.    ║
+  ║ idle      │ Most recent run completed cleanly within the         ║
+  ║           │ pass's expected interval. Healthy.                   ║
+  ║ errored   │ Most recent completed run has a non-null error.      ║
+  ║ down      │ No run within 3× expected interval. Suggests the     ║
+  ║           │ launchd job stopped firing (plist unloaded, etc.).   ║
+  ║ never_run │ No cognify_run_log row for this pass yet.            ║
+  ╚═══════════╧══════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from textual.containers import Vertical
+from textual.widgets import DataTable, Static
+
+
+_STATE_INDICATOR = {
+    "running":   "🟢 running",
+    "idle":      "⚪ idle",
+    "errored":   "🔴 errored",
+    "down":      "⛔ down",
+    "never_run": "○ never run",
+}
+
+
+class CognifyPanel(Vertical):
+    """Panel showing per-pass cognify run state + recent activity."""
+
+    DEFAULT_CSS = """
+    CognifyPanel {
+        height: auto;
+        max-height: 12;
+    }
+    """
+
+    def compose(self):
+        yield Static("━━━ Cognify ━━━", classes="panel-title")
+        table = DataTable(id="cognify-table", zebra_stripes=True)
+        table.add_columns("Pass", "State", "Last completed", "Rows", "LLM calls", "Note")
+        yield table
+
+    def update_passes(self, passes: list[dict]) -> None:
+        """Re-populate the table from `DashboardData.get_cognify_pass_status`."""
+        table = self.query_one(DataTable)
+        table.clear()
+
+        if not passes:
+            table.add_row("No cognify passes registered", "", "", "", "", "")
+            return
+
+        for p in passes:
+            pass_name = p["pass_name"]
+            state = _STATE_INDICATOR.get(p["state"], p["state"])
+            completed = _format_relative(p.get("last_completed"))
+            rows_n = str(p.get("last_rows_processed") or 0)
+            llm_n = str(p.get("last_llm_calls") or 0)
+
+            # Note column: error message for `errored`, schedule hint
+            # for `down`/`never_run`, blank otherwise.
+            note = ""
+            if p["state"] == "errored" and p.get("last_error"):
+                note = (p["last_error"] or "").splitlines()[0][:50]
+            elif p["state"] == "down":
+                expected = p.get("expected_interval_s", 0)
+                note = f"expected every {_format_interval(expected)}"
+            elif p["state"] == "never_run":
+                note = "no runs recorded"
+
+            table.add_row(pass_name, state, completed, rows_n, llm_n, note)
+
+
+def _format_relative(ts) -> str:
+    """Human-friendly age. e.g. '2m ago', '4h ago', '3d ago'."""
+    if ts is None:
+        return "—"
+    if isinstance(ts, str):
+        ts = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    sec = int((now - ts).total_seconds())
+    if sec < 60:
+        return f"{sec}s ago"
+    if sec < 3600:
+        return f"{sec // 60}m ago"
+    if sec < 86_400:
+        return f"{sec // 3600}h ago"
+    return f"{sec // 86_400}d ago"
+
+
+def _format_interval(seconds: int) -> str:
+    if seconds <= 0:
+        return "?"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86_400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86_400}d"

--- a/factory/tests/test_dashboard_cognify_panel.py
+++ b/factory/tests/test_dashboard_cognify_panel.py
@@ -1,0 +1,259 @@
+"""Tests for the cognify status panel (data layer + widget).
+
+The data-layer method `get_cognify_pass_status` is exercised against a
+mock DB so we can control timing edge cases without spinning up a real
+cognify_run_log. The widget tests are pure rendering — no DB.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+
+# ─── widget rendering ────────────────────────────────────────────────────────
+
+
+def test_format_relative_seconds():
+    from dashboard.widgets.cognify_panel import _format_relative
+    now = datetime.now(timezone.utc)
+    assert _format_relative(now - timedelta(seconds=5)) == "5s ago"
+    assert _format_relative(now - timedelta(seconds=59)) == "59s ago"
+
+
+def test_format_relative_minutes():
+    from dashboard.widgets.cognify_panel import _format_relative
+    now = datetime.now(timezone.utc)
+    assert _format_relative(now - timedelta(minutes=2)) == "2m ago"
+
+
+def test_format_relative_hours():
+    from dashboard.widgets.cognify_panel import _format_relative
+    now = datetime.now(timezone.utc)
+    assert _format_relative(now - timedelta(hours=4)) == "4h ago"
+
+
+def test_format_relative_days():
+    from dashboard.widgets.cognify_panel import _format_relative
+    now = datetime.now(timezone.utc)
+    assert _format_relative(now - timedelta(days=3)) == "3d ago"
+
+
+def test_format_relative_none():
+    from dashboard.widgets.cognify_panel import _format_relative
+    assert _format_relative(None) == "—"
+
+
+def test_format_relative_naive_datetime_treated_as_utc():
+    from dashboard.widgets.cognify_panel import _format_relative
+    now_naive = datetime.utcnow() - timedelta(seconds=12)
+    result = _format_relative(now_naive)
+    # Don't pin the exact number (clock skew); just confirm it parses
+    # as a recent past time, not raising on tz comparison.
+    assert "s ago" in result or "m ago" in result
+
+
+def test_format_interval():
+    from dashboard.widgets.cognify_panel import _format_interval
+    assert _format_interval(0) == "?"
+    assert _format_interval(60) == "1m"
+    assert _format_interval(3600) == "1h"
+    assert _format_interval(86_400) == "1d"
+    assert _format_interval(604_800) == "7d"
+
+
+# ─── data layer state derivation ─────────────────────────────────────────────
+
+
+class _MockCursor:
+    """Lightweight stand-in for psycopg2 cursor — yields canned results
+    from a list, one per execute() call."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self._current = None
+
+    def execute(self, query, params=None):
+        self._current = self._results.pop(0) if self._results else None
+
+    def fetchone(self):
+        return self._current
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+class _MockConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def _build_data_with_canned(results: list):
+    """Return a DashboardData instance whose `db._conn()` yields a
+    connection that produces `results` in order, one per execute()."""
+    from dashboard.data import DashboardData
+
+    db = MagicMock()
+    cursor = _MockCursor(results)
+    conn = _MockConn(cursor)
+    db._conn.return_value = conn
+    return DashboardData(db=db)
+
+
+def test_state_never_run_when_no_log_rows():
+    """All 5 passes return rows even when cognify_run_log is empty."""
+    data = _build_data_with_canned([None] * 5)
+    rows = data.get_cognify_pass_status()
+    assert len(rows) == 5
+    assert all(r["state"] == "never_run" for r in rows)
+    assert {r["pass_name"] for r in rows} == {
+        "extract", "edges", "decay", "strengthen", "gc"
+    }
+
+
+def test_state_running_when_started_no_complete():
+    """started_at present, completed_at NULL → state='running'."""
+    now = datetime.now(timezone.utc)
+    running_row = (now - timedelta(seconds=10), None, None, None, None)
+    data = _build_data_with_canned([running_row, None, None, None, None])
+    rows = data.get_cognify_pass_status()
+    extract = next(r for r in rows if r["pass_name"] == "extract")
+    assert extract["state"] == "running"
+
+
+def test_state_idle_when_recent_completion():
+    """Completed within expected interval → state='idle'."""
+    now = datetime.now(timezone.utc)
+    # extract expected hourly; 5 minutes ago counts as idle
+    idle_row = (
+        now - timedelta(minutes=10),  # started_at
+        now - timedelta(minutes=5),   # completed_at
+        12,                            # rows_processed
+        3,                             # llm_calls
+        None,                          # error
+    )
+    data = _build_data_with_canned([idle_row, None, None, None, None])
+    rows = data.get_cognify_pass_status()
+    extract = next(r for r in rows if r["pass_name"] == "extract")
+    assert extract["state"] == "idle"
+    assert extract["last_rows_processed"] == 12
+    assert extract["last_llm_calls"] == 3
+
+
+def test_state_errored_when_error_set():
+    """Most recent completed run has error → state='errored'."""
+    now = datetime.now(timezone.utc)
+    err_row = (
+        now - timedelta(minutes=10),
+        now - timedelta(minutes=5),
+        0,
+        0,
+        "ConnectionRefusedError: connect ECONNREFUSED 127.0.0.1:5432\nstack...",
+    )
+    data = _build_data_with_canned([err_row, None, None, None, None])
+    rows = data.get_cognify_pass_status()
+    extract = next(r for r in rows if r["pass_name"] == "extract")
+    assert extract["state"] == "errored"
+    assert extract["last_error"].startswith("ConnectionRefusedError")
+    # Error is truncated to 200 chars
+    assert len(extract["last_error"]) <= 200
+
+
+def test_state_down_when_well_past_expected_interval():
+    """No completion within 3× expected interval → state='down'."""
+    now = datetime.now(timezone.utc)
+    # extract expected hourly; 5 hours ago is past 3× = down
+    stale_row = (
+        now - timedelta(hours=5, minutes=1),
+        now - timedelta(hours=5),
+        5,
+        1,
+        None,  # success but old
+    )
+    data = _build_data_with_canned([stale_row, None, None, None, None])
+    rows = data.get_cognify_pass_status()
+    extract = next(r for r in rows if r["pass_name"] == "extract")
+    assert extract["state"] == "down"
+
+
+def test_state_idle_at_2x_interval_not_yet_down():
+    """A run 2× expected_interval old is still 'idle', not 'down' (down
+    threshold is 3×). This documents the boundary."""
+    now = datetime.now(timezone.utc)
+    # extract expected hourly; 2 hours ago is past 1× but not past 3×
+    row = (
+        now - timedelta(hours=2, minutes=1),
+        now - timedelta(hours=2),
+        5,
+        1,
+        None,
+    )
+    data = _build_data_with_canned([row, None, None, None, None])
+    rows = data.get_cognify_pass_status()
+    extract = next(r for r in rows if r["pass_name"] == "extract")
+    assert extract["state"] == "idle"
+
+
+def test_widget_renders_all_states(monkeypatch):
+    """Sanity: CognifyPanel.update_passes handles every defined state
+    without raising. Uses a stub DataTable so we don't need a running
+    textual app."""
+    from dashboard.widgets.cognify_panel import CognifyPanel
+
+    # Build a fake panel — bypass textual's compose lifecycle.
+    panel = CognifyPanel.__new__(CognifyPanel)
+
+    rows_logged: list[tuple] = []
+
+    class _FakeTable:
+        def clear(self):
+            rows_logged.clear()
+
+        def add_row(self, *cols):
+            rows_logged.append(cols)
+
+    fake_table = _FakeTable()
+    monkeypatch.setattr(panel, "query_one", lambda _cls: fake_table)
+
+    now = datetime.now(timezone.utc)
+    panel.update_passes([
+        {"pass_name": "extract",    "state": "running",   "last_completed": None,
+         "last_rows_processed": 0,  "last_llm_calls": 0, "last_error": None,
+         "expected_interval_s": 3600},
+        {"pass_name": "edges",      "state": "idle",      "last_completed": now - timedelta(minutes=30),
+         "last_rows_processed": 5,  "last_llm_calls": 2, "last_error": None,
+         "expected_interval_s": 21_600},
+        {"pass_name": "decay",      "state": "errored",   "last_completed": now - timedelta(hours=1),
+         "last_rows_processed": 0,  "last_llm_calls": 0, "last_error": "Boom\nfull stack here",
+         "expected_interval_s": 3600},
+        {"pass_name": "strengthen", "state": "down",      "last_completed": now - timedelta(days=5),
+         "last_rows_processed": 0,  "last_llm_calls": 0, "last_error": None,
+         "expected_interval_s": 86_400},
+        {"pass_name": "gc",         "state": "never_run", "last_completed": None,
+         "last_rows_processed": 0,  "last_llm_calls": 0, "last_error": None,
+         "expected_interval_s": 604_800},
+    ])
+
+    assert len(rows_logged) == 5
+    states_rendered = [row[1] for row in rows_logged]  # state column
+    assert "running" in states_rendered[0]
+    assert "idle" in states_rendered[1]
+    assert "errored" in states_rendered[2]
+    assert "down" in states_rendered[3]
+    assert "never" in states_rendered[4]
+
+    # The error note for `errored` is the first line of the error message,
+    # truncated to 50 chars.
+    assert "Boom" in rows_logged[2][5]
+    assert "full stack here" not in rows_logged[2][5]


### PR DESCRIPTION
## Summary

Adds a TUI panel showing live state of the 5 cognify passes. Discovered the need this morning when cognify ran in dry-run mode for ~5 days unnoticed — there was no operational visibility.

## What you'll see in the dashboard

```
━━━ Cognify ━━━
Pass        State           Last completed   Rows   LLM calls   Note
extract     🟢 running       —                0      0
edges       ⚪ idle          30m ago          5      2
decay       🔴 errored       1h ago           0      0          ConnectionRefusedError: connect ECONNREFUSED
strengthen  ⛔ down          5d ago           0      0          expected every 1d
gc          ○ never run     —                0      0          no runs recorded
```

## State derivation (`dashboard.data.get_cognify_pass_status`)

| State | Meaning |
|---|---|
| `running` | started_at present, completed_at NULL |
| `idle` | Completed cleanly within expected interval |
| `errored` | Most recent completed run has non-null error |
| `down` | No run within 3× expected interval — launchd probably stopped firing |
| `never_run` | No cognify_run_log row for this pass |

Expected intervals come from the plist `StartInterval` values: extract=hourly, edges=6h, decay=hourly, strengthen=daily, gc=weekly.

## Out of scope — active-dev-sessions panel

User's B2 ask included a second panel showing "Dev session attribution: Session ID, CLI/app, dev name". Investigation showed:

- `raw_sessions` table has no `dev_id` or `cli` columns
- `end_session_log` similarly lacks dev attribution
- Implementing this properly needs a schema change (add `dev_id` + `cli` to one of those tables, or a new sessions tracker)

Filing as a separate follow-up issue rather than half-shipping. This PR is just the cognify panel.

## Tests (14 new)

- `_format_relative`: seconds / minutes / hours / days / None / naive-datetime
- `_format_interval`: 0 / minutes / hours / days
- State derivation: never_run, running, idle, errored, down
- Boundary case: 2× expected_interval is idle (down threshold is 3×)
- Widget renders all 5 states without raising; error note truncation

All 38 dashboard tests pass; full 642-test no-DB suite passes.

## Test plan

- [x] `pytest factory/tests/test_dashboard_cognify_panel.py` — 14/14
- [x] `pytest factory/tests/ -k dashboard` — 38/38
- [x] Full no-DB suite: 642 pass, 451 skip, 0 fail
- [ ] Reviewer: run `devbrain dashboard` locally and confirm the new panel renders correctly and the state derivation matches your mental model
- [ ] Follow-up: I'll file a separate issue for active-dev-sessions tracking (needs schema work first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)