### PR TITLE
ci(llm-smoke): allow workflow_dispatch + tighten event matching

### DIFF
--- a/.github/workflows/llm-smoke-test.yml
+++ b/.github/workflows/llm-smoke-test.yml
@@ -44,13 +44,22 @@ jobs:
     # The label gate ALSO runs the job even when paths-filter wouldn't,
     # so reviewers can request a smoke test on any PR by adding the
     # `llm-smoke-test` label.
+    #
+    # The fork check only applies to pull_request events — workflow_dispatch
+    # is always trusted (only repo members can trigger it), and head.repo
+    # is empty for non-PR events which would otherwise spuriously skip.
     if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.event.head_commit.message, '[skip-llm-smoke]') &&
       (
         github.event_name == 'workflow_dispatch' ||
-        github.event.action == 'labeled' && github.event.label.name == 'llm-smoke-test' ||
-        github.event.action != 'labeled'
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          (
+            github.event.action != 'labeled' ||
+            github.event.label.name == 'llm-smoke-test'
+          )
+        )
       )
 
     steps:

--- a/.github/workflows/llm-smoke-test.yml
+++ b/.github/workflows/llm-smoke-test.yml
@@ -96,7 +96,27 @@ jobs:
             echo "Add a subscription OAuth token (sk-ant-oat01-...) to the repo's Actions secrets to enable."
             exit 0
           fi
-          echo "Secret is configured (first 20 chars: ${CI_ANTHROPIC_OAUTH_TOKEN:0:20}...)"
+          # Diagnostics — GitHub masks the full secret value in logs, so we
+          # print indirect signals that don't leak the token but DO catch the
+          # common copy-paste hazards (truncation, embedded whitespace, wrong
+          # prefix). Length + start-marker + end-marker are enough to confirm
+          # the secret is intact without revealing it.
+          TOKEN_LEN=${#CI_ANTHROPIC_OAUTH_TOKEN}
+          echo "Secret length: $TOKEN_LEN chars"
+          echo "Starts with 'sk-ant-oat01-': $(case "$CI_ANTHROPIC_OAUTH_TOKEN" in sk-ant-oat01-*) echo yes;; *) echo no;; esac)"
+          echo "Starts with 'sk-ant-oat1-': $(case "$CI_ANTHROPIC_OAUTH_TOKEN" in sk-ant-oat1-*) echo yes;; *) echo no;; esac)"
+          echo "Starts with 'sk-ant-':      $(case "$CI_ANTHROPIC_OAUTH_TOKEN" in sk-ant-*) echo yes;; *) echo no;; esac)"
+          # Check for leading whitespace (most common paste bug)
+          TRIMMED="$(echo -n "$CI_ANTHROPIC_OAUTH_TOKEN" | sed 's/^[[:space:]]*//' | head -c 1)"
+          FIRST="$(echo -n "$CI_ANTHROPIC_OAUTH_TOKEN" | head -c 1)"
+          if [ "$TRIMMED" != "$FIRST" ]; then
+            echo "::warning::Secret starts with whitespace — strip it from the GitHub Actions secret value."
+          fi
+          # Check for trailing newline (also common)
+          LAST="$(echo -n "$CI_ANTHROPIC_OAUTH_TOKEN" | tail -c 1)"
+          case "$LAST" in
+            [[:space:]]) echo "::warning::Secret ends with whitespace.";;
+          esac
 
       - name: Run LLM smoke test
         # Expose the secret as CLAUDE_CODE_OAUTH_TOKEN so the existing

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,12 @@ pyyaml>=6.0
 textual>=0.80
 google-auth>=2.0
 google-api-python-client>=2.0
+# Anthropic SDK used by cognify_extract + cognify_edges (LLM-cost passes).
+# Cognify's code path degrades gracefully on ImportError (logs a warning and
+# skips the LLM call), so the package is technically optional for non-LLM
+# usage. But: any cognify-touching install — including CI's llm-smoke-test
+# workflow — needs it. Pinning here so it lands in every install.
+anthropic>=0.40
 pytest>=8.0
 pytest-asyncio>=0.23
 pytest-cov>=4.0


### PR DESCRIPTION
## Summary

The original if-condition required `pull_request.head.repo.full_name == github.repository` as a top-level gate. That correctly rejected fork PRs (no secret access) but **also rejected workflow_dispatch** — `head.repo` is empty for non-PR events, so the comparison always fails.

Caught when verifying the PR #132 setup post-secret-add: a manual `gh workflow run llm-smoke-test.yml` showed *completed skipped* in 2s, which traced to this gate failing for workflow_dispatch.

## Fix

Rewrite the gate so:
- `workflow_dispatch` always runs (only repo members can trigger it, so fork concern doesn't apply)
- `pull_request` runs when from the same repo AND (not a label event, or the label is exactly `llm-smoke-test`)
- `[skip-llm-smoke]` in commit message bypasses either path

## Test plan

- [x] Local: workflow YAML still parses cleanly
- [ ] This PR's own workflow run should now actually fire the smoke test (since the path is also in the path-filter for `.github/workflows/llm-smoke-test.yml`), and with the new `CI_ANTHROPIC_OAUTH_TOKEN` secret configured we should see a real ~13s smoke run instead of a 2s skip
- [ ] After merge: `gh workflow run llm-smoke-test.yml --repo nooma-stack/devbrain --ref main` should also succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)