### PR TITLE
fix(cognify): retry APIConnectionError with client recycle

### DIFF
--- a/factory/cognify/extract.py
+++ b/factory/cognify/extract.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID
@@ -46,6 +47,14 @@ logger = logging.getLogger(__name__)
 
 # Maximum LLM calls per scheduled pass invocation.
 MAX_LLM_CALLS_PER_PASS = 20
+
+# Retry configuration for transient APIConnectionError. The 2026-05-14
+# marathon-reextract incident showed that long-running cognify processes
+# accumulate stale connections in httpx's internal pool; per-call retries
+# with client recycle defeat that failure mode. Other exception classes
+# (auth, 400, JSONDecodeError) are NOT retried — they won't improve.
+_API_MAX_RETRIES = 3
+_API_BACKOFF_S = (2, 5, 15)  # exponential, applied in order
 
 # Extraction prompt/model version. Bump this integer when the extraction
 # prompt or model changes, then run `devbrain cognify-reextract --since-version=N`
@@ -466,26 +475,66 @@ def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
     #   _failure="empty"      the model returned valid JSON but with empty lists
     # All three currently degrade gracefully (return empty lists); the
     # _failure label is for telemetry/diagnostics so we can spot drift.
-    try:
-        response = client.messages.create(
-            model=_EXTRACT_MODEL,
-            max_tokens=16000,
-            system=system_blocks,
-            messages=[
-                {
-                    "role": "user",
-                    "content": f"Extract lessons and decisions from this session:\n\n{content[:200_000]}",
-                }
-            ],
+    #
+    # APIConnectionError gets per-session retry-with-backoff because we
+    # observed (2026-05-14 incident) that long-running cognify processes
+    # accumulate stale connections in the SDK's internal httpx pool;
+    # marathon `cognify-reextract --all` runs saw the failure rate climb
+    # to ~90% Connection error in the last hours of an 18h run. Recycling
+    # the client (close+new) on each retry forces a fresh httpx pool and
+    # defeats that failure mode. Other exception types are NOT retried —
+    # auth errors, 400s, JSONDecodeErrors won't get better from waiting.
+    response = None
+    api_error: Exception | None = None
+    for attempt in range(_API_MAX_RETRIES):
+        try:
+            response = client.messages.create(
+                model=_EXTRACT_MODEL,
+                max_tokens=16000,
+                system=system_blocks,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": f"Extract lessons and decisions from this session:\n\n{content[:200_000]}",
+                    }
+                ],
+            )
+            break
+        except anthropic.APIConnectionError as exc:
+            api_error = exc
+            if attempt + 1 < _API_MAX_RETRIES:
+                backoff = _API_BACKOFF_S[min(attempt, len(_API_BACKOFF_S) - 1)]
+                logger.warning(
+                    "cognify_extract: APIConnectionError (attempt %d/%d): %s; "
+                    "recycling client + retrying in %ds",
+                    attempt + 1, _API_MAX_RETRIES, exc, backoff,
+                )
+                # Drop the stale client + connection pool, then re-create.
+                try:
+                    client.close()
+                except Exception:  # noqa: BLE001
+                    pass
+                time.sleep(backoff)
+                client = anthropic.Anthropic(**auth_kwargs)
+                continue
+            # Exhausted retries — fall through to error return below.
+        except Exception as exc:  # noqa: BLE001
+            # Non-connection errors (auth, 400, model errors, etc.) —
+            # don't retry; they won't improve from waiting.
+            api_error = exc
+            break
+
+    if response is None:
+        logger.warning(
+            "cognify_extract: LLM API call failed after %d attempts: %s",
+            _API_MAX_RETRIES, api_error,
         )
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("cognify_extract: LLM API call failed: %s", exc)
         return {
             "lessons": [],
             "decisions": [],
             "_usage": _empty_usage,
             "_failure": "api",
-            "_failure_detail": str(exc)[:500],
+            "_failure_detail": str(api_error)[:500],
         }
 
     usage = response.usage

--- a/factory/tests/test_cognify_extract_observability.py
+++ b/factory/tests/test_cognify_extract_observability.py
@@ -170,3 +170,107 @@ def test_llm_extract_strips_markdown_fences_before_parsing():
     assert result["decisions"] == [{"title": "D1", "content": "x"}]
     # Fenced+valid JSON with one atom → no failure flag (decisions is non-empty)
     assert "_failure" not in result
+
+
+# ─── APIConnectionError retry-with-backoff (2026-05-14 incident fix) ─────────
+
+
+def test_llm_extract_retries_on_api_connection_error_and_succeeds(monkeypatch):
+    """If the first call raises APIConnectionError but the second
+    succeeds, we get a clean result with no _failure flag. The client
+    should have been recycled (close+new) between attempts."""
+    import anthropic
+    from cognify.extract import _llm_extract
+
+    # Bypass real time.sleep so the test runs fast.
+    monkeypatch.setattr("cognify.extract.time.sleep", lambda *_a, **_kw: None)
+
+    valid_json = json.dumps({
+        "lessons": [{"title": "L", "content": "x"}],
+        "decisions": [],
+    })
+
+    # First call raises, second returns the success response.
+    fake_client = MagicMock()
+    fake_client.messages.create.side_effect = [
+        anthropic.APIConnectionError(request=None),
+        _stub_anthropic_response(valid_json),
+    ]
+
+    auth_patch = patch(
+        "cognify.extract._resolve_auth",
+        return_value={"api_key": "sk-ant-api03-FAKE"},
+    )
+
+    construct_count = {"n": 0}
+
+    def _fake_constructor(*args, **kwargs):
+        construct_count["n"] += 1
+        return fake_client
+
+    construct_patch = patch.object(anthropic, "Anthropic", side_effect=_fake_constructor)
+
+    with auth_patch, construct_patch:
+        result = _llm_extract("content")
+
+    # Extraction succeeded
+    assert "_failure" not in result, f"got: {result}"
+    assert result["lessons"] == [{"title": "L", "content": "x"}]
+    # Two API calls attempted (1 failed + 1 succeeded)
+    assert fake_client.messages.create.call_count == 2
+    # Client should have been recycled — at least 2 constructions
+    # (initial + at least 1 retry recycle)
+    assert construct_count["n"] >= 2
+    # The stale client's close() should have been called during recycle
+    assert fake_client.close.called
+
+
+def test_llm_extract_gives_up_after_max_retries_on_persistent_connection_error(monkeypatch):
+    """If APIConnectionError persists across all retries, return
+    _failure='api'. Test that we don't retry forever."""
+    import anthropic
+    from cognify.extract import _API_MAX_RETRIES, _llm_extract
+
+    monkeypatch.setattr("cognify.extract.time.sleep", lambda *_a, **_kw: None)
+
+    fake_client = MagicMock()
+    fake_client.messages.create.side_effect = anthropic.APIConnectionError(request=None)
+
+    auth_patch = patch(
+        "cognify.extract._resolve_auth",
+        return_value={"api_key": "sk-ant-api03-FAKE"},
+    )
+    construct_patch = patch.object(anthropic, "Anthropic", return_value=fake_client)
+
+    with auth_patch, construct_patch:
+        result = _llm_extract("content")
+
+    assert result.get("_failure") == "api"
+    assert result["lessons"] == []
+    # Used all retries — call count equals _API_MAX_RETRIES exactly
+    assert fake_client.messages.create.call_count == _API_MAX_RETRIES
+
+
+def test_llm_extract_does_not_retry_non_connection_errors(monkeypatch):
+    """A 401 / 400 / random RuntimeError doesn't get retried — those
+    won't get better from waiting, and retrying just wastes time."""
+    from cognify.extract import _llm_extract
+
+    monkeypatch.setattr("cognify.extract.time.sleep", lambda *_a, **_kw: None)
+
+    fake_client = MagicMock()
+    fake_client.messages.create.side_effect = RuntimeError("401 Unauthorized")
+
+    auth_patch = patch(
+        "cognify.extract._resolve_auth",
+        return_value={"api_key": "sk-ant-api03-FAKE"},
+    )
+    import anthropic
+    construct_patch = patch.object(anthropic, "Anthropic", return_value=fake_client)
+
+    with auth_patch, construct_patch:
+        result = _llm_extract("content")
+
+    assert result.get("_failure") == "api"
+    # Single attempt only — non-connection errors don't retry
+    assert fake_client.messages.create.call_count == 1


### PR DESCRIPTION
## Summary

The 2026-05-14 marathon reextract incident (18h \`cognify-reextract --all\` on brightbot) hit a **~90% Connection error rate** in its final hours — 3,263 of 4,449 sessions failed with \`_failure='api'\` from APIConnectionError.

Root cause confirmed during incident: tokens valid (curl 200), Mac Studio network healthy (ping 0% loss). The failure was internal to the long-running Python process — most likely stale connections in the SDK's httpx pool persisting across short-lived \`Anthropic(**kw)\` instances.

## Fix

When \`client.messages.create\` raises \`anthropic.APIConnectionError\`, retry up to 3 times with exponential backoff (2s / 5s / 15s). Each retry explicitly calls \`client.close()\` + creates a fresh client — forces httpx to allocate a new connection pool.

Other exception types (auth errors, 400s, JSONDecodeError) are NOT retried — they won't improve from waiting.

## Beneficiaries

| Caller | Benefit |
|---|---|
| Scheduled launchd cognify-extract | Cheap insurance against single transient blips |
| \`cognify-reextract --session=<id>\` | One transient blip no longer fails the whole call |
| Upcoming \`cognify-bulk\` (PR B) | Will lean on this heavily |

## Tests (3 added)

- Retry succeeds on 2nd attempt after one APIConnectionError; verifies client was recycled (close called + new constructor)
- Persistent APIConnectionError exhausts \`_API_MAX_RETRIES\` then returns \`_failure='api'\` (no infinite loop)
- Non-connection errors (RuntimeError) do NOT retry — single attempt then \`_failure='api'\`

12/12 observability tests pass; full no-DB suite passes.

## Next

PR B will add \`devbrain cognify-bulk\` for resumable bulk extraction over an entire existing chunk history, built on top of this retry layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)