### PR TITLE
feat(cognify): --shard=N/M for parallel bulk extraction

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -3117,6 +3117,11 @@ def cognify_reextract_command(
                    "default a Ctrl+C / crash leaves a checkpoint at "
                    "~/.devbrain/cognify-bulk-<project>.json and re-running "
                    "the command picks up where it left off.")
+@click.option("--shard", default=None,
+              help="N/M — process only sessions[N::M] of the sorted session "
+                   "list. Use to parallelize across M concurrent instances "
+                   "(0/M, 1/M, ..., (M-1)/M). Each shard has its own "
+                   "checkpoint file so resumes don't collide.")
 @click.option("--dry-run", is_flag=True, default=False,
               help="Report what would be processed; make no API calls or "
                    "DB writes.")
@@ -3125,7 +3130,7 @@ def cognify_reextract_command(
                    "still goes to stderr).")
 def cognify_bulk_command(
     project_slug, target, since, max_llm_calls, recycle_every,
-    no_resume, dry_run, as_json,
+    no_resume, shard, dry_run, as_json,
 ):
     """Bulk-extract lessons/decisions from an existing chunk history.
 
@@ -3139,7 +3144,8 @@ def cognify_bulk_command(
       devbrain cognify-bulk --project=brightbot --max-llm-calls=200\n
       devbrain cognify-bulk --project=brightbot --since=2026-04-01\n
       devbrain cognify-bulk --project=brightbot --dry-run\n
-      devbrain cognify-bulk --project=brightbot --no-resume
+      devbrain cognify-bulk --project=brightbot --no-resume\n
+      devbrain cognify-bulk --project=brightbot --shard=0/10  (one of 10)
     """
     import sys
     from datetime import datetime, timezone
@@ -3164,8 +3170,24 @@ def cognify_bulk_command(
         except ValueError as exc:
             raise click.ClickException(f"Invalid --since date: {since!r}") from exc
 
+    shard_tuple: tuple[int, int] | None = None
+    if shard:
+        try:
+            n_str, m_str = shard.split("/", 1)
+            n_int, m_int = int(n_str), int(m_str)
+        except (ValueError, AttributeError) as exc:
+            raise click.ClickException(
+                f"Invalid --shard format: {shard!r}, expected N/M (e.g. 0/10)"
+            ) from exc
+        if m_int < 1 or n_int < 0 or n_int >= m_int:
+            raise click.ClickException(
+                f"Invalid --shard={shard}: need 0 <= N < M and M >= 1"
+            )
+        shard_tuple = (n_int, m_int)
+
     sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent))
     from cognify.bulk import (
+        apply_shard,
         discover_all_sessions_with_chunks,
         discover_sessions_needing_atomization,
         render_stderr_progress,
@@ -3184,10 +3206,15 @@ def cognify_bulk_command(
             )
             reextract_mode = True
 
+        total_discovered = len(sessions)
+        if shard_tuple is not None:
+            sessions = apply_shard(sessions, shard_tuple)
+
         if not sessions:
             msg = (
                 f"cognify-bulk: no sessions match target={target}"
                 + (f" since={since}" if since else "")
+                + (f" shard={shard}" if shard else "")
                 + ". Nothing to do."
             )
             if as_json:
@@ -3200,9 +3227,13 @@ def cognify_bulk_command(
                 click.echo(msg)
             return
 
+        shard_note = (
+            f"  [shard {shard} → {len(sessions)} of {total_discovered}]"
+            if shard_tuple is not None else ""
+        )
         click.echo(
-            f"cognify-bulk: discovered {len(sessions)} session(s) to process "
-            f"(target={target})",
+            f"cognify-bulk: discovered {total_discovered} session(s) "
+            f"(target={target}){shard_note}",
             err=True,
         )
         if dry_run:
@@ -3219,12 +3250,14 @@ def cognify_bulk_command(
             dry_run=dry_run,
             use_checkpoint=not no_resume,
             progress_callback=render_stderr_progress if not dry_run else None,
+            shard=shard_tuple,
         )
 
     # Final summary on stdout.
     summary = {
         "project": project_slug,
         "target": target,
+        "shard": shard,
         "sessions_targeted": result.sessions_targeted,
         "sessions_processed": result.sessions_processed,
         "sessions_skipped_resume": result.sessions_skipped_resume,

--- a/factory/cognify/bulk.py
+++ b/factory/cognify/bulk.py
@@ -45,6 +45,14 @@ Typical use:
 
     # Dry run — report what would be processed without making LLM calls:
     devbrain cognify-bulk --project=brightbot --dry-run
+
+    # Parallelize: run 10 instances concurrently, each owning a slice of
+    # the sorted session list. Each shard has its own checkpoint file so
+    # resumes don't conflict:
+    devbrain cognify-bulk --project=brightbot --shard=0/10
+    devbrain cognify-bulk --project=brightbot --shard=1/10
+    ...
+    devbrain cognify-bulk --project=brightbot --shard=9/10
 """
 from __future__ import annotations
 
@@ -169,12 +177,42 @@ def discover_all_sessions_with_chunks(
         return [r[0] for r in cur.fetchall()]
 
 
-def _checkpoint_path_for(project_slug: str) -> Path:
-    """Where the per-project checkpoint file lives."""
+def _checkpoint_path_for(
+    project_slug: str,
+    *,
+    shard: tuple[int, int] | None = None,
+) -> Path:
+    """Where the per-project checkpoint file lives.
+
+    When `shard` is provided as (N, M), the filename includes the shard
+    so parallel instances don't collide on each other's checkpoints.
+    """
     home = Path(os.environ.get("DEVBRAIN_HOME", Path.home()))
     base = home / ".devbrain"
     base.mkdir(parents=True, exist_ok=True)
+    if shard is not None:
+        n, m = shard
+        return base / f"cognify-bulk-{project_slug}-shard-{n}-of-{m}.json"
     return base / f"cognify-bulk-{project_slug}.json"
+
+
+def apply_shard(sessions: list[str], shard: tuple[int, int]) -> list[str]:
+    """Stride-slice `sessions` into shard N of M.
+
+    Given a sorted session list (discover_* already orders by
+    provenance_id), stride-slicing partitions it deterministically across
+    M workers: worker N gets sessions[N::M]. Coverage is exhaustive
+    (every session lands in exactly one shard) and stable across reruns
+    so a crashed shard's checkpoint stays valid.
+
+    Raises ValueError if (N, M) is out of range.
+    """
+    n, m = shard
+    if m < 1:
+        raise ValueError(f"shard total M must be >= 1, got M={m}")
+    if n < 0 or n >= m:
+        raise ValueError(f"shard index N={n} must satisfy 0 <= N < M={m}")
+    return sessions[n::m]
 
 
 def _load_checkpoint(path: Path) -> dict | None:
@@ -209,6 +247,7 @@ def run_bulk(
     dry_run: bool = False,
     use_checkpoint: bool = True,
     progress_callback: Callable[[int, int, dict], None] | None = None,
+    shard: tuple[int, int] | None = None,
 ) -> BulkRunResult:
     """Process `sessions` in order, with checkpoint-resume + client
     recycle + cost cap.
@@ -232,6 +271,10 @@ def run_bulk(
       progress_callback: optional fn(idx, total, last_result_dict) called
         after each session. last_result_dict has keys session_id,
         atoms, failure, llm_calls.
+      shard: when provided as (N, M), the checkpoint filename is suffixed
+        with `-shard-N-of-M` so parallel shards don't share checkpoint
+        state. The session list passed in is NOT re-sliced — callers are
+        responsible for slicing before calling run_bulk (see apply_shard).
     """
     result = BulkRunResult()
     started_at = datetime.now(timezone.utc)
@@ -240,7 +283,7 @@ def run_bulk(
     checkpoint_path: Path | None = None
     completed_set: set[str] = set()
     if use_checkpoint:
-        checkpoint_path = _checkpoint_path_for(project_slug)
+        checkpoint_path = _checkpoint_path_for(project_slug, shard=shard)
         result.checkpoint_path = checkpoint_path
         prior = _load_checkpoint(checkpoint_path)
         if prior and prior.get("project_slug") == project_slug:

--- a/factory/tests/test_cognify_bulk.py
+++ b/factory/tests/test_cognify_bulk.py
@@ -13,6 +13,7 @@ from cognify.bulk import (
     _checkpoint_path_for,
     _load_checkpoint,
     _save_checkpoint,
+    apply_shard,
     discover_all_sessions_with_chunks,
     discover_sessions_needing_atomization,
     run_bulk,
@@ -380,3 +381,96 @@ def test_run_bulk_invokes_progress_callback_per_session(tmp_path, monkeypatch):
         (2, 3, "s-2", 5),
         (3, 3, "s-3", 5),
     ]
+
+
+# ─── Sharding ────────────────────────────────────────────────────────────────
+
+
+def test_apply_shard_partitions_exhaustively_and_disjointly():
+    """Every session lands in exactly one shard; shards don't overlap."""
+    sessions = [f"s-{i:02d}" for i in range(23)]  # non-multiple of M on purpose
+    M = 4
+    shards = [apply_shard(sessions, (n, M)) for n in range(M)]
+    # Concatenation covers every input.
+    combined = sorted(s for shard in shards for s in shard)
+    assert combined == sorted(sessions)
+    # Pairwise disjoint.
+    for i in range(M):
+        for j in range(i + 1, M):
+            assert set(shards[i]).isdisjoint(set(shards[j]))
+
+
+def test_apply_shard_is_deterministic_across_calls():
+    sessions = ["a", "b", "c", "d", "e"]
+    assert apply_shard(sessions, (1, 3)) == apply_shard(sessions, (1, 3))
+
+
+def test_apply_shard_m_equals_1_returns_full_list():
+    sessions = ["a", "b", "c"]
+    assert apply_shard(sessions, (0, 1)) == sessions
+
+
+def test_apply_shard_rejects_negative_n():
+    with pytest.raises(ValueError, match="0 <= N < M"):
+        apply_shard(["a"], (-1, 3))
+
+
+def test_apply_shard_rejects_n_equal_m():
+    with pytest.raises(ValueError, match="0 <= N < M"):
+        apply_shard(["a"], (3, 3))
+
+
+def test_apply_shard_rejects_zero_m():
+    with pytest.raises(ValueError, match="M must be >= 1"):
+        apply_shard(["a"], (0, 0))
+
+
+def test_checkpoint_path_includes_shard_when_provided(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVBRAIN_HOME", str(tmp_path))
+    p = _checkpoint_path_for("brightbot", shard=(3, 10))
+    assert p == tmp_path / ".devbrain" / "cognify-bulk-brightbot-shard-3-of-10.json"
+
+
+def test_checkpoint_path_omits_shard_suffix_when_unsharded(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVBRAIN_HOME", str(tmp_path))
+    p = _checkpoint_path_for("brightbot")
+    assert p == tmp_path / ".devbrain" / "cognify-bulk-brightbot.json"
+
+
+def test_run_bulk_writes_to_shard_specific_checkpoint(tmp_path, monkeypatch):
+    """Different shards must not stomp each other's checkpoint files."""
+    monkeypatch.setenv("DEVBRAIN_HOME", str(tmp_path))
+
+    sessions = ["s-1", "s-2"]
+    with patch("cognify.extract.extract_from_session",
+               return_value=_build_extract_result(lessons=1, decisions=0, llm_calls=1)):
+        run_bulk(
+            conn=MagicMock(),
+            project_id="proj-1",
+            project_slug="brightbot",
+            sessions=sessions,
+            shard=(2, 10),
+            recycle_every=0,
+        )
+    # On clean completion the checkpoint is removed, so we instead assert
+    # that the shard checkpoint path was used during the run by patching
+    # _save_checkpoint to record calls.
+    saved: list[Path] = []
+
+    def _spy(path, data):
+        saved.append(path)
+
+    with patch("cognify.bulk._save_checkpoint", side_effect=_spy), \
+         patch("cognify.extract.extract_from_session",
+               return_value=_build_extract_result(lessons=1, decisions=0, llm_calls=1)):
+        run_bulk(
+            conn=MagicMock(),
+            project_id="proj-1",
+            project_slug="brightbot",
+            sessions=sessions,
+            shard=(2, 10),
+            recycle_every=0,
+        )
+    assert saved
+    for path in saved:
+        assert path.name == "cognify-bulk-brightbot-shard-2-of-10.json"


### PR DESCRIPTION
## Summary

- Adds `--shard=N/M` to `devbrain cognify-bulk` so the same run can be split across M parallel instances.
- Each shard owns `sessions[N::M]` of the sorted session list and writes to its own checkpoint at `~/.devbrain/cognify-bulk-<project>-shard-<N>-of-<M>.json` — resumes don't collide.
- New pure helper `apply_shard(sessions, (N, M))` validates `0 <= N < M` and `M >= 1`. CLI parses the `N/M` string and surfaces clean errors.

## Use case

The 48,806-session brightbot bulk run estimated at 7-15 days single-process. With `--shard` we can run M instances in parallel (planned: 10) — bottleneck moves from single-process throughput to Anthropic rate-limit bucket on the Max subscription.

## Test plan

- [x] `apply_shard` partitions exhaustively + disjointly (verified M=4 over 23 sessions)
- [x] `apply_shard` is deterministic across calls
- [x] `apply_shard` rejects negative N, N==M, M==0
- [x] checkpoint path includes/omits shard suffix correctly
- [x] `run_bulk` writes checkpoint to the shard-specific path
- [x] CLI `--help` shows `--shard` option with usage example
- [x] Full factory test suite: 670 passed (was 661 + 9 new shard tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)