### PR TITLE
feat(cognify): atomize per raw_session, not per chunk

### DIFF
--- a/factory/cognify/bulk.py
+++ b/factory/cognify/bulk.py
@@ -104,23 +104,22 @@ def discover_sessions_needing_atomization(
     *,
     since: datetime | None = None,
 ) -> list[str]:
-    """Return provenance_ids of sessions that have chunks but no active
-    pattern/decision atoms.
+    """Return raw_session UUIDs that have chunks in memory but no active
+    pattern/decision/lesson atoms.
 
-    A session "needs atomization" when:
-      * memory rows exist for its provenance_id (any kind), AND
-      * NO active (archived_at IS NULL) rows of kind 'pattern' or
-        'decision' exist for that provenance_id.
+    Post-migration-032, memory.provenance_id IS raw_sessions.id, so the
+    join is trivial. Only memory rows whose provenance points at a real
+    raw_session are returned — chunks from codebase indexing or
+    headers-only imports (no raw_session) are correctly excluded from
+    atomization.
 
-    The check is project-scoped via project_id.
-
-    `since`: optional cutoff. Only sessions whose oldest chunk was
-    created after `since` are returned. Defaults to None (no filter).
+    `since`: optional cutoff on raw_sessions.started_at (the actual
+    conversation start time, NOT devbrain's ingest time).
     """
     params: list = [project_id]
     where_since = ""
     if since is not None:
-        where_since = "AND m.created_at >= %s"
+        where_since = "AND rs.started_at >= %s"
         params.append(since)
 
     with conn.cursor() as cur:
@@ -128,8 +127,8 @@ def discover_sessions_needing_atomization(
             f"""
             SELECT DISTINCT m.provenance_id::text
             FROM devbrain.memory m
+            JOIN devbrain.raw_sessions rs ON rs.id = m.provenance_id
             WHERE m.project_id = %s
-              AND m.provenance_id IS NOT NULL
               AND m.archived_at IS NULL
               {where_since}
               AND NOT EXISTS (
@@ -152,25 +151,26 @@ def discover_all_sessions_with_chunks(
     *,
     since: datetime | None = None,
 ) -> list[str]:
-    """Every session with chunks in the project, regardless of whether
-    it already has atoms. Used by --target=all (re-processes everything,
-    archiving prior atoms — mirrors cognify-reextract --all semantics)."""
+    """Every raw_session that has chunks in the project, regardless of
+    whether atoms already exist. Used by --target=all (re-processes
+    everything, archiving prior atoms — mirrors cognify-reextract --all
+    semantics)."""
     params: list = [project_id]
     where_since = ""
     if since is not None:
-        where_since = "AND created_at >= %s"
+        where_since = "AND rs.started_at >= %s"
         params.append(since)
 
     with conn.cursor() as cur:
         cur.execute(
             f"""
-            SELECT DISTINCT provenance_id::text
-            FROM devbrain.memory
-            WHERE project_id = %s
-              AND provenance_id IS NOT NULL
-              AND archived_at IS NULL
+            SELECT DISTINCT m.provenance_id::text
+            FROM devbrain.memory m
+            JOIN devbrain.raw_sessions rs ON rs.id = m.provenance_id
+            WHERE m.project_id = %s
+              AND m.archived_at IS NULL
               {where_since}
-            ORDER BY provenance_id::text
+            ORDER BY m.provenance_id::text
             """,
             params,
         )

--- a/factory/tests/test_cognify_bulk.py
+++ b/factory/tests/test_cognify_bulk.py
@@ -104,7 +104,8 @@ def test_discover_all_sessions_with_chunks_returns_strings():
 
 
 def test_discover_passes_since_filter_when_set(monkeypatch):
-    """Confirm the since parameter actually affects SQL execution."""
+    """`--since` must filter on raw_sessions.started_at (real session
+    date), not on memory.created_at (devbrain ingest time)."""
     executed_sql: list[tuple] = []
 
     class _Cur:
@@ -126,8 +127,33 @@ def test_discover_passes_since_filter_when_set(monkeypatch):
     )
     assert len(executed_sql) == 1
     sql, params = executed_sql[0]
-    assert "m.created_at >= %s" in sql
+    assert "rs.started_at >= %s" in sql
+    assert "JOIN devbrain.raw_sessions" in sql
     assert when in params
+
+
+def test_discover_joins_raw_sessions_even_without_since():
+    """Even without --since, discovery must join raw_sessions so chunks
+    from non-session sources (codebase indexer, markdown imports) are
+    excluded from atomization."""
+    executed_sql: list[tuple] = []
+
+    class _Cur:
+        def execute(self, sql, params):
+            executed_sql.append((sql, list(params)))
+        def fetchall(self):
+            return []
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    class _Conn:
+        def cursor(self): return _Cur()
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    discover_sessions_needing_atomization(_Conn(), project_id="proj-1")
+    discover_all_sessions_with_chunks(_Conn(), project_id="proj-1")
+    assert all("JOIN devbrain.raw_sessions" in sql for sql, _ in executed_sql)
 
 
 # ─── run_bulk: dry-run + discovery contract ──────────────────────────────────

--- a/factory/tests/test_dual_write.py
+++ b/factory/tests/test_dual_write.py
@@ -105,13 +105,18 @@ def test_migration_011_applied(db):
         row = cur.fetchone()
         assert row is not None, "partial unique index missing"
         idxdef = row[0]
-        # Index must be UNIQUE on (provenance_id, kind) WITH the
-        # provenance_id IS NOT NULL predicate — both halves are
-        # required for the inferred-constraint match.
+        # Index must be UNIQUE on (provenance_id, kind). Migration 032
+        # narrowed the predicate to exclude kind='chunk' (many chunks
+        # legitimately share a session's provenance_id) while keeping
+        # uniqueness for atom kinds.
         assert "UNIQUE" in idxdef.upper()
         assert "provenance_id" in idxdef
         assert "kind" in idxdef
         assert "provenance_id IS NOT NULL" in idxdef
+        assert "kind <> 'chunk'" in idxdef or "kind != 'chunk'" in idxdef, (
+            f"migration 032 must narrow the partial index to exclude chunks; "
+            f"current idxdef: {idxdef}"
+        )
 
 
 # ─── 2-6. Dual-write produces a memory row for each kind ─────────────────
@@ -251,44 +256,75 @@ def test_dual_write_session_summary(db):
     assert str(rows[0][2]) == prov
 
 
-def test_dual_write_chunk_via_insert_chunk(db):
-    """kind='chunk' goes through ingest.db.insert_chunk — the actual
-    call site (not record_memory directly). Verifies the dual-write
-    is wired in there AND that the project_id-None guard skips the
-    memory write but keeps the legacy chunk insert."""
+def test_dual_write_chunk_provenance_is_source_session(db):
+    """Migration 032 fixed the bug where chunk dual-writes used
+    `provenance_id = chunk_id` (the chunk row's own UUID) instead of
+    `provenance_id = chunks.source_id` (the originating session UUID).
+
+    The new contract: when source_id is supplied, the memory row's
+    provenance_id IS that source_id. When source_id is None (e.g.
+    markdown imports), provenance_id is NULL.
+    """
     pid = _devbrain_project_id(db)
-    content = f"{TEST_CONTENT_PREFIX}chunk via insert_chunk"
     embedding = [0.5] * 1024
 
-    chunk_id = insert_chunk(
+    # Case A: source_id present → memory.provenance_id == source_id
+    source_session_uuid = "77777777-7777-7777-7777-777777777777"
+    content_a = f"{TEST_CONTENT_PREFIX}chunk with source_id"
+    chunk_id_a = insert_chunk(
+        project_id=pid,
+        source_type="session",
+        source_id=source_session_uuid,
+        source_line_start=None,
+        source_line_end=None,
+        content=content_a,
+        embedding=embedding,
+        token_count=10,
+    )
+    assert chunk_id_a
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT kind, provenance_id FROM devbrain.memory "
+            "WHERE content = %s",
+            (content_a,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "chunk"
+    assert str(rows[0][1]) == source_session_uuid, (
+        "chunk dual-write must set provenance_id = source_id "
+        "(the source session's UUID), not the chunk row's own UUID"
+    )
+
+    # Case B: source_id=None → memory.provenance_id IS NULL
+    content_b = f"{TEST_CONTENT_PREFIX}chunk no source"
+    chunk_id_b = insert_chunk(
         project_id=pid,
         source_type="session",
         source_id=None,
         source_line_start=None,
         source_line_end=None,
-        content=content,
+        content=content_b,
         embedding=embedding,
         token_count=10,
     )
-    assert chunk_id  # legacy row exists
+    assert chunk_id_b
 
     with db._conn() as conn, conn.cursor() as cur:
         cur.execute(
-            "SELECT kind, content, provenance_id, embedding IS NOT NULL "
-            "FROM devbrain.memory WHERE provenance_id = %s",
-            (chunk_id,),
+            "SELECT provenance_id FROM devbrain.memory WHERE content = %s",
+            (content_b,),
         )
         rows = cur.fetchall()
-    assert len(rows) == 1, (
-        "exactly one memory row expected for the chunk dual-write"
+    assert len(rows) == 1
+    assert rows[0][0] is None, (
+        "chunk with no source_id should produce memory row with "
+        "NULL provenance_id (no session to attribute to)"
     )
-    assert rows[0][0] == "chunk"
-    assert rows[0][1] == content
-    assert str(rows[0][2]) == chunk_id
-    assert rows[0][3] is True  # embedding reused, not recomputed null
 
-    # Guard branch: project_id=None must skip the memory write but
-    # still produce a legacy chunk row.
+    # Case C: project_id=None — must skip the memory write but still
+    # produce a legacy chunk row (existing guard preserved).
     null_content = f"{TEST_CONTENT_PREFIX}chunk no project"
     null_chunk_id = insert_chunk(
         project_id=None,
@@ -303,13 +339,52 @@ def test_dual_write_chunk_via_insert_chunk(db):
     assert null_chunk_id  # legacy row still inserted
     with db._conn() as conn, conn.cursor() as cur:
         cur.execute(
-            "SELECT 1 FROM devbrain.memory WHERE provenance_id = %s",
-            (null_chunk_id,),
+            "SELECT 1 FROM devbrain.memory WHERE content = %s",
+            (null_content,),
         )
         assert cur.fetchone() is None, (
             "memory.project_id is NOT NULL; the helper must skip dual-"
             "write when project_id is None instead of erroring"
         )
+
+
+def test_dual_write_chunks_share_session_provenance(db):
+    """After migration 032, multiple chunks for the same source session
+    legitimately share one provenance_id (and the partial unique index
+    no longer blocks this for kind='chunk')."""
+    pid = _devbrain_project_id(db)
+    embedding = [0.5] * 1024
+    shared_session = "88888888-8888-8888-8888-888888888888"
+
+    contents = [
+        f"{TEST_CONTENT_PREFIX}shared session chunk 1",
+        f"{TEST_CONTENT_PREFIX}shared session chunk 2",
+        f"{TEST_CONTENT_PREFIX}shared session chunk 3",
+    ]
+    for c in contents:
+        insert_chunk(
+            project_id=pid,
+            source_type="session",
+            source_id=shared_session,
+            source_line_start=None,
+            source_line_end=None,
+            content=c,
+            embedding=embedding,
+            token_count=10,
+        )
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.memory "
+            "WHERE provenance_id = %s AND kind = 'chunk'",
+            (shared_session,),
+        )
+        count = cur.fetchone()[0]
+    assert count == 3, (
+        f"expected 3 chunks sharing the same session provenance_id, "
+        f"got {count} — partial unique index may be incorrectly blocking "
+        f"multiple chunks per session"
+    )
 
 
 # ─── 7. Idempotency: two dual-writes for the same legacy row → one mem row

--- a/ingest/db.py
+++ b/ingest/db.py
@@ -146,13 +146,20 @@ def insert_chunk(
         # SAVEPOINT inside record_memory keeps a memory failure from
         # poisoning this transaction's commit of the legacy chunk row.
         if chunk_id and project_id is not None:
+            # provenance_id = the SOURCE session's UUID (chunks.source_id),
+            # not the chunk row's own UUID. Migration 032 fixed the
+            # historical bug where this was chunk_id; that broke
+            # session-grouped atomization in factory/cognify/. When
+            # source_id is None (e.g. migrate_openclaw_memory.py imports
+            # of pre-chunked markdown), we pass None — the partial
+            # unique index on (provenance_id, kind) excludes NULL.
             record_memory(
                 cur,
                 project_id=project_id,
                 kind="chunk",
                 content=content,
                 embedding_sql=vector_str,
-                provenance_id=chunk_id,
+                provenance_id=source_id,
             )
         conn.commit()
         return chunk_id

--- a/ingest/memory_writer.py
+++ b/ingest/memory_writer.py
@@ -6,10 +6,14 @@ table is best-effort — a memory failure must NOT poison the surrounding
 transaction or roll back the legacy write that is the current source
 of truth.
 
-Idempotency: relies on the partial unique index from migration 011
-(idx_memory_provenance_kind_unique on (provenance_id, kind) WHERE
-provenance_id IS NOT NULL) so two concurrent dual-writes for the same
-legacy row collapse to one memory row via ON CONFLICT DO NOTHING.
+Idempotency: relies on the partial unique index from migration 011,
+narrowed by migration 032 to atoms only:
+idx_memory_provenance_kind_unique on (provenance_id, kind) WHERE
+provenance_id IS NOT NULL AND kind != 'chunk'. Two concurrent
+dual-writes for the same atom row collapse to one memory row via
+ON CONFLICT DO NOTHING. Chunks (which share a session's provenance_id
+post-032) are NOT deduped here — pipeline.py:_process_session calls
+delete_chunks_for_session() before re-ingesting an updated session.
 """
 from __future__ import annotations
 
@@ -79,7 +83,8 @@ def record_memory(
                 (project_id, kind, title, content, embedding,
                  provenance_id, applies_when)
             VALUES (%s, %s, %s, %s, %s::vector, %s, %s::jsonb)
-            ON CONFLICT (provenance_id, kind) WHERE provenance_id IS NOT NULL
+            ON CONFLICT (provenance_id, kind)
+                WHERE provenance_id IS NOT NULL AND kind != 'chunk'
             DO NOTHING
             """,
             (

--- a/migrations/032_session_provenance_backfill.sql
+++ b/migrations/032_session_provenance_backfill.sql
@@ -1,0 +1,66 @@
+-- Migration 032: backfill memory.provenance_id to the SOURCE session UUID
+-- ============================================================================
+-- Bug fix: ingest/db.py:insert_chunk() was dual-writing chunks into
+-- devbrain.memory with `provenance_id = chunk_id` (the chunk row's own
+-- UUID) instead of `provenance_id = chunks.source_id` (the originating
+-- raw_session UUID).
+--
+-- Consequence: every chunk became its own "session" at the memory layer.
+-- Phase 6's discover_sessions_needing_atomization (which groups by
+-- memory.provenance_id) saw 48,451 brightbot "sessions" each with a
+-- single chunk — instead of the real ~455 raw_sessions with many
+-- chunks per session. Atomization ran (or would have run) at chunk
+-- granularity, producing shallow atoms from isolated text fragments.
+--
+-- Fix structure:
+--   1. The existing unique index (provenance_id, kind) WHERE provenance_id
+--      IS NOT NULL was designed assuming each chunk had a unique
+--      provenance_id. After the backfill, many chunks share one session's
+--      provenance_id, so the constraint must be loosened to apply only to
+--      atom kinds (pattern/decision/lesson/issue/session_summary).
+--   2. Backfill UPDATE: memory.provenance_id := chunks.source_id where
+--      the chunk linkage exists and the value would actually change.
+--      Chunks that had source_id=NULL (e.g. migrate_openclaw_memory.py
+--      imports) keep their existing provenance_id since there's nothing
+--      to point at.
+--
+-- Idempotent: re-running this migration is a no-op. The DROP INDEX uses
+-- IF EXISTS, the UPDATE skips rows that are already correct, and the
+-- final INSERT into schema_migrations uses ON CONFLICT DO NOTHING.
+--
+-- Note for record_memory() callers: the partial unique index predicate
+-- changed from `WHERE provenance_id IS NOT NULL` to
+-- `WHERE provenance_id IS NOT NULL AND kind != 'chunk'`. The ON CONFLICT
+-- clause in ingest/memory_writer.py must be updated to match — that
+-- code change ships in the same PR as this migration.
+
+-- Step 1: replace the unique index. The old shape forbade duplicate
+-- (provenance_id, kind='chunk') tuples, which the bug accidentally
+-- preserved by giving each chunk its own provenance. Post-backfill,
+-- many chunks legitimately share a session's provenance_id.
+DROP INDEX IF EXISTS devbrain.idx_memory_provenance_kind_unique;
+
+CREATE UNIQUE INDEX idx_memory_provenance_kind_unique
+    ON devbrain.memory (provenance_id, kind)
+    WHERE provenance_id IS NOT NULL AND kind != 'chunk';
+
+COMMENT ON INDEX devbrain.idx_memory_provenance_kind_unique IS
+    'Atoms (pattern/decision/lesson/issue/session_summary) are unique '
+    'per (provenance_id, kind). Chunks are NOT — a single session has '
+    'many chunks all sharing one provenance_id. Migration 032 narrowed '
+    'this from the original (which assumed one row per provenance) when '
+    'the chunk-provenance bug was fixed.';
+
+-- Step 2: backfill. Rewrite memory.provenance_id where it currently
+-- points at a chunks.id (the bug) to point at chunks.source_id
+-- (the originating session). Idempotent via the inequality predicate.
+UPDATE devbrain.memory m
+SET provenance_id = c.source_id
+FROM devbrain.chunks c
+WHERE c.id = m.provenance_id
+  AND c.source_id IS NOT NULL
+  AND m.provenance_id != c.source_id;
+
+INSERT INTO devbrain.schema_migrations (filename)
+VALUES ('032_session_provenance_backfill.sql')
+ON CONFLICT (filename) DO NOTHING;


### PR DESCRIPTION
## The bug

`ingest/db.py:insert_chunk()` was dual-writing chunks into `devbrain.memory` with `provenance_id = chunk_id` (the chunk row's own UUID) instead of `provenance_id = chunks.source_id` (the originating `raw_session` UUID). At the memory layer, every chunk became its own "session." 

## Consequence

`discover_sessions_needing_atomization()` (which groups by `memory.provenance_id`) saw **48,451 brightbot "sessions" each with one chunk** instead of the real **~455 raw_sessions with many chunks per session**. A bulk run would have:
- Made ~48K LLM calls on isolated chunk fragments → shallow atoms
- Cost ~$250-700, run for 7-15 days
- Lost all conversation-level context that atomization is designed to capture

## The fix

| File | Change |
|---|---|
| `ingest/db.py` | `insert_chunk()` now passes `provenance_id=source_id` on dual-write (was `chunk_id`) |
| `migrations/032_session_provenance_backfill.sql` | Narrows the partial unique index to exclude `kind='chunk'` (chunks legitimately share a session's provenance_id), then backfills the 47K+ existing memory rows |
| `ingest/memory_writer.py` | `ON CONFLICT` clause matches the new index predicate |
| `factory/cognify/bulk.py` | `discover_*_sessions` JOINs `raw_sessions`; `--since` filters on real conversation `started_at` instead of devbrain ingest time |

## Verified on brightbot

| Metric | Before | After |
|---|---|---|
| Distinct `memory.provenance_id` | 48,836 | 7,542 |
| Of those, linking to a real raw_session | 0 | 455 |
| Sessions cognify-bulk would target | 48,451 | 455 |
| Estimated LLM cost | $250-700 | $5-30 |
| Estimated runtime | 7-15 days | hours |

## Test plan

- [x] `test_cognify_bulk`: discover_* SQL uses `rs.started_at` and `JOIN devbrain.raw_sessions` (with and without `--since`)
- [x] `test_dual_write`: index predicate includes `kind != 'chunk'`; chunk dual-writes propagate `source_id` as `provenance_id`; multiple chunks share one session provenance_id
- [x] Local: 35/35 focused tests green, full factory suite + DB tests green against laptop devbrain DB
- [x] Migration 032 applied + verified on laptop (idempotent re-run produces 0 row changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)