### PR TITLE
fix(config): codex file_pattern is *.jsonl, not *.json

### DIFF
--- a/config/devbrain.yaml.example
+++ b/config/devbrain.yaml.example
@@ -68,10 +68,15 @@ ingest:
         # research_agent: someproject
 
     codex:
-      enabled: false  # Enable when adapter is built
+      enabled: false
       watch_paths:
         - "~/.codex"
-      file_pattern: "*.json"
+      # Codex CLI writes JSONL session files (not .json) under
+      # ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl and
+      # ~/.codex/archived_sessions/rollout-*.jsonl.
+      file_pattern: "*.jsonl"
+      # Project detection reads session_meta.cwd from each JSONL and
+      # looks up the slug in ingest.project_mappings above.
       project_detection: path
 
     gemini:


### PR DESCRIPTION
The codex adapter has been built since at least the 103 brightbot codex raw_sessions in the DB show its parse path works. The example config left two bugs:

1. **`file_pattern: \"*.json\"`** — Codex CLI actually writes JSONL session files under `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` and `~/.codex/archived_sessions/rollout-*.jsonl`. The `*.json` pattern matched only config/cache files (auth.json, models_cache.json) — not a single real session.

2. **\"Enable when adapter is built\" comment was stale** — the adapter has worked in production.

This fixes both. `enabled` defaults to `false` in the example so fresh installs don't error on missing `~/.codex`; operators flip to `true` once Codex is set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)