### PR TITLE
feat(cognify): --model flag on cognify-bulk + Opus 4.7 pricing

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -3214,6 +3214,13 @@ def cognify_reextract_command(
                    "list. Use to parallelize across M concurrent instances "
                    "(0/M, 1/M, ..., (M-1)/M). Each shard has its own "
                    "checkpoint file so resumes don't collide.")
+@click.option("--model", default=None,
+              help="Override the extraction model (default: claude-sonnet-4-6). "
+                   "Useful for re-trying json_parse-stuck sessions with a more "
+                   "capable model (e.g. --model=claude-opus-4-7 at ~5x cost). "
+                   "Pricing for the new model must be registered in "
+                   "factory/observability/pricing.py — unknown models fall "
+                   "back to Sonnet's pricing for the spend log.")
 @click.option("--dry-run", is_flag=True, default=False,
               help="Report what would be processed; make no API calls or "
                    "DB writes.")
@@ -3222,7 +3229,7 @@ def cognify_reextract_command(
                    "still goes to stderr).")
 def cognify_bulk_command(
     project_slug, target, since, max_llm_calls, recycle_every,
-    no_resume, shard, dry_run, as_json,
+    no_resume, shard, model, dry_run, as_json,
 ):
     """Bulk-extract lessons/decisions from an existing chunk history.
 
@@ -3343,6 +3350,7 @@ def cognify_bulk_command(
             use_checkpoint=not no_resume,
             progress_callback=render_stderr_progress if not dry_run else None,
             shard=shard_tuple,
+            model=model,
         )
 
     # Final summary on stdout.
@@ -3350,6 +3358,7 @@ def cognify_bulk_command(
         "project": project_slug,
         "target": target,
         "shard": shard,
+        "model": model or "(default)",
         "sessions_targeted": result.sessions_targeted,
         "sessions_processed": result.sessions_processed,
         "sessions_skipped_resume": result.sessions_skipped_resume,

--- a/factory/cognify/bulk.py
+++ b/factory/cognify/bulk.py
@@ -248,6 +248,7 @@ def run_bulk(
     use_checkpoint: bool = True,
     progress_callback: Callable[[int, int, dict], None] | None = None,
     shard: tuple[int, int] | None = None,
+    model: str | None = None,
 ) -> BulkRunResult:
     """Process `sessions` in order, with checkpoint-resume + client
     recycle + cost cap.
@@ -321,6 +322,7 @@ def run_bulk(
                 session_id,
                 project_id,
                 reextract=reextract_mode,
+                model=model,
             )
         except Exception as exc:  # noqa: BLE001
             # extract_from_session normally returns failure as a field,

--- a/factory/cognify/extract.py
+++ b/factory/cognify/extract.py
@@ -40,7 +40,11 @@ from typing import Any
 from uuid import UUID
 
 from cognify.orchestrator import CognifyPass, PassResult, register_pass
-from observability.pricing import SONNET_4_6, compute_cost_usd
+from observability.pricing import (
+    SONNET_4_6,
+    compute_cost_usd,
+    get_pricing,
+)
 from observability.spend import record_spend
 
 logger = logging.getLogger(__name__)
@@ -210,6 +214,7 @@ def extract_from_session(
     *,
     max_llm_calls: int = MAX_LLM_CALLS_PER_PASS,
     reextract: bool = False,
+    model: str | None = None,
 ) -> ExtractResult:
     """Extract lessons and decisions from a single session's memory chunks.
 
@@ -221,6 +226,10 @@ def extract_from_session(
         max_llm_calls: upper bound on LLM calls this function may make.
         reextract: if True, archive existing lessons/decisions for this
             session before re-extracting (for reextract_cli).
+        model: optional Anthropic model id override (e.g.
+            "claude-opus-4-7"). Defaults to _EXTRACT_MODEL (Sonnet 4.6).
+            Lets callers run a more capable model on sessions that
+            failed json_parse with Sonnet — at higher cost per call.
 
     Returns:
         ExtractResult with counts.
@@ -243,14 +252,21 @@ def extract_from_session(
         return ExtractResult(session_id=session_id)
 
     # Call LLM for extraction.
-    extracted = _llm_extract(combined, max_llm_calls=max_llm_calls)
+    effective_model = model or _EXTRACT_MODEL
+    extracted = _llm_extract(
+        combined, max_llm_calls=max_llm_calls, model=effective_model,
+    )
     llm_calls = 1  # one call per session for v1
 
-    # Record spend for this LLM call.
+    # Record spend for this LLM call. Use the pricing registry to
+    # look up the right rates; fall back to SONNET_4_6 if the caller
+    # passed an unfamiliar model so we still bill something rather
+    # than crash.
     usage = extracted.get("_usage", {})
     if any(usage.get(k, 0) for k in ("input_tokens", "output_tokens")):
+        pricing = get_pricing(effective_model) or SONNET_4_6
         cost = compute_cost_usd(
-            SONNET_4_6,
+            pricing,
             input_tokens=usage.get("input_tokens", 0),
             output_tokens=usage.get("output_tokens", 0),
             cache_read_tokens=usage.get("cache_read_tokens", 0),
@@ -260,7 +276,7 @@ def extract_from_session(
             conn,
             project_id=project_id,
             pass_name="extract",
-            model=_EXTRACT_MODEL,
+            model=effective_model,
             input_tokens=usage.get("input_tokens", 0),
             output_tokens=usage.get("output_tokens", 0),
             cache_read_tokens=usage.get("cache_read_tokens", 0),
@@ -398,7 +414,12 @@ def _combine_chunks(chunks: list[dict]) -> str:
     return "\n\n".join(parts)
 
 
-def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
+def _llm_extract(
+    content: str,
+    *,
+    max_llm_calls: int = 1,
+    model: str = _EXTRACT_MODEL,
+) -> dict:
     """Call the LLM to extract structured lessons and decisions.
 
     Returns a dict with keys:
@@ -489,7 +510,7 @@ def _llm_extract(content: str, *, max_llm_calls: int = 1) -> dict:
     for attempt in range(_API_MAX_RETRIES):
         try:
             response = client.messages.create(
-                model=_EXTRACT_MODEL,
+                model=model,
                 max_tokens=16000,
                 system=system_blocks,
                 messages=[

--- a/factory/observability/pricing.py
+++ b/factory/observability/pricing.py
@@ -55,9 +55,24 @@ SONNET_4_6 = ModelPricing(
     cache_write_per_mtok=3.75,
 )
 
+# claude-opus-4-7 (as of 2026-05-18):
+#   Input:        $15.00 / Mtok   (5x Sonnet)
+#   Output:       $75.00 / Mtok   (5x Sonnet)
+#   Cache read:   $1.50 / Mtok
+#   Cache write:  $18.75 / Mtok
+# Source: https://www.anthropic.com/pricing
+OPUS_4_7 = ModelPricing(
+    model="claude-opus-4-7",
+    input_per_mtok=15.00,
+    output_per_mtok=75.00,
+    cache_read_per_mtok=1.50,
+    cache_write_per_mtok=18.75,
+)
+
 # Registry: model string → pricing. Extend as new models are added.
 _PRICING_REGISTRY: dict[str, ModelPricing] = {
     SONNET_4_6.model: SONNET_4_6,
+    OPUS_4_7.model: OPUS_4_7,
 }
 
 

--- a/factory/tests/test_cognify_bulk.py
+++ b/factory/tests/test_cognify_bulk.py
@@ -241,7 +241,7 @@ def test_run_bulk_counts_failures_by_kind(tmp_path, monkeypatch):
     sessions = ["good-1", "fail-api-1", "fail-json-1", "good-2", "fail-api-2"]
     monkeypatch.setenv("DEVBRAIN_HOME", str(tmp_path))
 
-    def _per_session(conn, sid, pid, *, reextract):
+    def _per_session(conn, sid, pid, *, reextract, **kwargs):
         if "fail-api" in sid:
             return _build_extract_result(lessons=0, decisions=0, llm_calls=1, failure="api")
         if "fail-json" in sid:
@@ -358,7 +358,7 @@ def test_run_bulk_preserves_checkpoint_when_any_failure(tmp_path, monkeypatch):
     monkeypatch.setenv("DEVBRAIN_HOME", str(tmp_path))
     sessions = ["good-1", "fail-1"]
 
-    def _per_session(conn, sid, pid, *, reextract):
+    def _per_session(conn, sid, pid, *, reextract, **kwargs):
         if sid == "fail-1":
             return _build_extract_result(lessons=0, decisions=0, llm_calls=1, failure="api")
         return _build_extract_result(lessons=1, decisions=1, llm_calls=1)
@@ -376,6 +376,54 @@ def test_run_bulk_preserves_checkpoint_when_any_failure(tmp_path, monkeypatch):
     ckpt_path = _checkpoint_path_for("failtest")
     assert result.sessions_failed == 1
     assert ckpt_path.exists()  # preserved for retry
+
+
+# ─── Model override ─────────────────────────────────────────────────────────
+
+
+def test_run_bulk_forwards_model_to_extract(tmp_path, monkeypatch):
+    """The --model flag must thread all the way down to extract_from_session.
+    Without this wiring, --model=claude-opus-4-7 would silently use Sonnet."""
+    monkeypatch.setenv("DEVBRAIN_HOME", str(tmp_path))
+    sessions = ["sess-A"]
+    seen_kwargs: list[dict] = []
+
+    def _capture(conn, sid, pid, *, reextract, **kwargs):
+        seen_kwargs.append({"reextract": reextract, **kwargs})
+        return _build_extract_result(lessons=1, decisions=0, llm_calls=1)
+
+    with patch("cognify.extract.extract_from_session", side_effect=_capture):
+        run_bulk(
+            conn=MagicMock(),
+            project_id="proj-1",
+            project_slug="modeltest",
+            sessions=sessions,
+            model="claude-opus-4-7",
+            use_checkpoint=False,
+            recycle_every=0,
+        )
+    assert seen_kwargs == [{"reextract": False, "model": "claude-opus-4-7"}]
+
+
+def test_run_bulk_default_model_is_none(tmp_path, monkeypatch):
+    """Default behavior: model=None is passed (extract.py picks Sonnet)."""
+    monkeypatch.setenv("DEVBRAIN_HOME", str(tmp_path))
+    seen_kwargs: list[dict] = []
+
+    def _capture(conn, sid, pid, *, reextract, **kwargs):
+        seen_kwargs.append({"reextract": reextract, **kwargs})
+        return _build_extract_result(lessons=1, decisions=0, llm_calls=1)
+
+    with patch("cognify.extract.extract_from_session", side_effect=_capture):
+        run_bulk(
+            conn=MagicMock(),
+            project_id="proj-1",
+            project_slug="defaulttest",
+            sessions=["sess-A"],
+            use_checkpoint=False,
+            recycle_every=0,
+        )
+    assert seen_kwargs == [{"reextract": False, "model": None}]
 
 
 # ─── Progress callback ──────────────────────────────────────────────────────


### PR DESCRIPTION
Adds a per-run model override so we can retry json_parse-stuck sessions with a more capable model (Opus 4.7) without permanently switching the default off Sonnet 4.6.

## Wiring

- \`factory/observability/pricing.py\` — register \`OPUS_4_7\` with public rates ($15/$75/$1.50/$18.75 Mtok)
- \`factory/cognify/extract.py\` — \`extract_from_session\` and \`_llm_extract\` accept \`model\`; defaults to Sonnet 4.6
- Spend recording uses \`get_pricing(model)\` so the cognify_spend_log reflects the actual model billed
- \`factory/cognify/bulk.py\` — \`run_bulk\` forwards \`model\` to \`extract_from_session\`
- \`factory/cli.py\` — \`cognify-bulk --model TEXT\` flag; summary JSON includes resolved model

## Tests

- \`test_run_bulk_forwards_model_to_extract\` — verifies \`--model=opus\` threads down to \`extract_from_session\`
- \`test_run_bulk_default_model_is_none\` — verifies default behavior
- 2 existing mocks updated to accept \`**kwargs\` defensively
- **43 cognify tests pass**

## Intended use

\`\`\`bash
devbrain cognify-bulk --project=brightbot --model=claude-opus-4-7 --no-resume --json
\`\`\`

Opus 4.7 at ~5x Sonnet cost on the ~245 json_parse-stuck sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)