### PR TITLE
feat(invite): devbrain invite non-interactive CLI + close PR #146 open decisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ profiles/
 
 # Git worktrees — used for isolated feature work (using-git-worktrees skill)
 .worktrees/
+/onboarding/

--- a/docs/ONBOARDING_TEAMMATE.md
+++ b/docs/ONBOARDING_TEAMMATE.md
@@ -177,7 +177,24 @@ devbrain login --dev alice --cli codex
 devbrain login --dev alice --cli gemini
 ```
 
-Each CLI's login flow:
+### Browser-required auth from a headless SSH session
+
+All three supported CLIs (claude / codex / gemini) handle the "browser
+lives on YOUR laptop, code execution lives on the Mac Studio" gap by
+**printing a URL** that you open locally. There is no localhost
+callback over the tunnel; you finish OAuth in your local browser, then
+paste a verification code (or the OAuth picks up via Anthropic's hosted
+callback at `platform.claude.com`) back into the SSH session. The
+adapters block the auto-launch path (`BROWSER=/bin/false`, `DISPLAY=""`)
+so you always get the printable URL.
+
+**Claude Desktop (the GUI app) is NOT supported as an SSH-tunnel target.**
+Claude Desktop is designed to run as a local app on your own machine, not
+to be driven through SSH. If your workflow needs Claude Desktop, install
+it on your laptop and sign in there with your own subscription —
+DevBrain doesn't manage that.
+
+### Per-CLI specifics
 
 - **Codex**: prints a verification URL + short code. Open the URL in your
   laptop browser, enter the code, return to the SSH terminal. No

--- a/docs/plans/2026-05-17-onboarding-ssh-invitation-only.md
+++ b/docs/plans/2026-05-17-onboarding-ssh-invitation-only.md
@@ -199,11 +199,28 @@ Genuinely small set after the simplification:
    Useful for kit messaging ("you wanted claude-code") but not
    load-bearing. Recommend: yes, as a free-text annotation, no
    enum, no enforcement.
+
+   **RESOLVED (2026-05-19)** — `devbrain invite <dev_id>` shipped as
+   a non-interactive top-level command with `--cli` accepted as a
+   free-text annotation (default `"claude"`). Enforcement stays out
+   of the column; the kit/email body uses the hint for phrasing only.
+   See `factory/cli.py:invite_cmd` and
+   `factory/setup.py:finalize_invitation_and_kit`.
+
 2. **Browser-required auth flows in headless mode.** Some agent apps
    (claude-desktop) require a browser. The agent might not have one.
    Recommend: surface a clear interactive handoff to the human dev
    ("open this URL on your laptop, paste the code back"). Don't try
    to automate browsers from the dev's agent.
+
+   **RESOLVED (2026-05-19)** — All three supported adapters
+   (`claude.py` / `codex.py` / `gemini.py`) already block auto-launch
+   (`BROWSER=/bin/false`, `DISPLAY=""`) and print a URL for the dev
+   to open in their laptop browser. Claude Desktop is explicitly
+   NOT supported as an SSH-tunnel target — it's a local GUI app and
+   devs install it directly on their own machine. Documented in
+   `docs/ONBOARDING_TEAMMATE.md` §"Browser-required auth from a
+   headless SSH session".
 
 Both are minor compared to PR #131's 6 open questions, all of which
 dissolve here.

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2315,6 +2315,103 @@ def upgrade(
 # ─── Onboarding admin commands (Phase 6) ────────────────────────────────────
 
 
+@cli.command(name="invite")
+@click.argument("dev_id")
+@click.option("--full-name", required=True, help="Dev's display name.")
+@click.option("--email", required=True, help="Email — kit destination + dev contact.")
+@click.option(
+    "--cli", "cli_hint", default="claude", show_default=True,
+    help="Free-text annotation: which AI CLI the kit messaging targets. "
+         "Per PR #146 the post-SSH-bootstrap flow is agent-driven, so this "
+         "is just kit/email phrasing, not a load-bearing routing field.",
+)
+@click.option(
+    "--platform", "platform_hint", default="auto", show_default=True,
+    type=click.Choice(["auto", "mac", "linux", "windows"]),
+    help="Dev's local OS (kit prepends Windows/WSL2 preflight when 'windows').",
+)
+@click.option(
+    "--agent-app", "agent_app_hint", default="auto", show_default=True,
+    type=click.Choice([
+        "auto", "claude-desktop", "codex-desktop", "gemini-desktop",
+        "claude-cli", "codex-cli", "gemini-cli",
+    ]),
+    help="Which AI agent app the dev will read the kit in (controls kit framing + email body).",
+)
+@click.option("--slack", default=None, help="Slack handle (optional).")
+@click.option("--notes", default=None, help="Free-text notes attached to the invitation row.")
+@click.option(
+    "--ttl-days", default=7, show_default=True, type=int,
+    help="Invitation expiry, in days from now.",
+)
+@click.option(
+    "--auto-activate/--no-auto-activate", default=True, show_default=True,
+    help="When set, the reconciler auto-activates the dev once pubkey + "
+         "OAuth token arrive. With --no-auto-activate the admin must run "
+         "`devbrain activate --dev <id>` after both are received.",
+)
+@click.option(
+    "--email-now/--no-email-now", default=False, show_default=True,
+    help="Send the kit to the dev's email immediately on creation. Default off "
+         "for non-interactive use (Use `devbrain send-invite --dev <id>` later "
+         "if you want to email it).",
+)
+def invite_cmd(
+    dev_id, full_name, email, cli_hint, platform_hint, agent_app_hint,
+    slack, notes, ttl_days, auto_activate, email_now,
+):
+    """Non-interactive onboarding: stage dev + invitation + kit in one shot.
+
+    Use when you want to script invitations from CI, an admin tool, or a
+    config-file-driven add-dev flow. For the guided experience use
+    `devbrain setup add-dev` (which prompts for missing values).
+
+    Example:
+
+        devbrain invite alice \\
+          --full-name "Alice Example" --email alice@example.com \\
+          --cli claude --agent-app claude-cli --notes "FERPA team"
+
+    Returns nonzero on validation failure (invalid dev_id, malformed
+    email, etc.); the invitation row + bootstrap key are created in a
+    single side-effecting call, so a partial-failure leaves no half-state.
+    """
+    import re
+
+    from profiles import DEV_ID_RE
+
+    if not DEV_ID_RE.fullmatch(dev_id):
+        click.echo(
+            f"Error: '{dev_id}' is not a valid dev_id "
+            "(lowercase, [a-z0-9_-], 1-64 chars).",
+            err=True,
+        )
+        raise click.exceptions.Exit(2)
+    if not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", email):
+        click.echo(f"Error: '{email}' doesn't look like a valid email.", err=True)
+        raise click.exceptions.Exit(2)
+
+    # Late import — setup pulls in heavy click + yaml deps.
+    from setup import finalize_invitation_and_kit
+
+    inv_id_short, kit_path = finalize_invitation_and_kit(
+        dev_id=dev_id,
+        full_name=full_name,
+        email=email,
+        slack_handle=slack,
+        cli=cli_hint,
+        platform=platform_hint,
+        agent_app=agent_app_hint,
+        auto_activate=auto_activate,
+        notes=notes,
+        ttl_days=ttl_days,
+        email_now=email_now,
+        echo=click.echo,
+    )
+    # Helper already printed the success summary; just confirm exit-code clean.
+    _ = (inv_id_short, kit_path)
+
+
 @cli.command(name="invitations")
 @click.option(
     "--status", default=None,

--- a/factory/setup.py
+++ b/factory/setup.py
@@ -2165,6 +2165,90 @@ def setup_add_dev(
         _warn("Cancelled.")
         return
 
+    inv_id_short, kit_path = finalize_invitation_and_kit(
+        dev_id=dev_id,
+        full_name=full_name,
+        email=email,
+        slack_handle=slack_handle,
+        cli=cli,
+        platform=platform,
+        agent_app=agent_app,
+        auto_activate=auto_activate,
+        notes=notes,
+        ttl_days=7,
+        email_now=_confirm(f"Email the kit to {email} now?", default=True),
+        admin_name=None,  # helper resolves from $USER
+        echo=click.echo,
+    )
+
+    click.echo()
+    _info(
+        "The raw invite token is embedded inside the kit file — DevBrain "
+        "stores only its hash. If the kit is lost, run "
+        "`devbrain setup add-dev` again to issue a fresh one (revoke the "
+        "previous one with `devbrain revoke-invite <id>`)."
+    )
+
+
+def finalize_invitation_and_kit(
+    *,
+    dev_id: str,
+    full_name: str,
+    email: str,
+    slack_handle: str | None = None,
+    cli: str = "claude",
+    platform: str = "auto",
+    agent_app: str = "auto",
+    auto_activate: bool = True,
+    notes: str | None = None,
+    ttl_days: int = 7,
+    email_now: bool = False,
+    admin_name: str | None = None,
+    echo=None,
+) -> tuple[str, Path]:
+    """Non-interactive core of the onboarding flow.
+
+    Registers the dev, stages the invitation, generates the bootstrap
+    SSH keypair, appends it to authorized_keys, writes the kit, and
+    (optionally) emails it. Pure I/O — no prompts. Used by:
+      * ``setup_add_dev`` (the interactive wizard, which collects args
+        via _prompt/_confirm then calls here)
+      * ``devbrain invite`` (cli.py — fully scripted, all args via flags)
+
+    Returns ``(invitation_id_short, kit_path)``. Side effects:
+      * inserts rows in ``devbrain.devs`` + ``devbrain.invitations``
+      * appends a bootstrap ed25519 entry to ``~/.ssh/authorized_keys``
+      * writes the kit markdown under ``<DEVBRAIN_HOME>/onboarding/``
+      * (if ``email_now``) sends the kit via the configured SMTP/Gmail DWD
+
+    ``echo`` is an optional output callable (e.g. ``click.echo``). When
+    None the helper stays silent — the caller is responsible for any
+    user-facing summary. ``admin_name`` defaults to ``$USER`` /
+    ``getpass.getuser()`` (recorded as ``created_by`` on the invitation
+    row + signs the email).
+    """
+    import getpass
+    import os as _os
+    import subprocess as _sp
+    import tempfile as _tempfile
+    from datetime import timezone as _tz, timedelta as _td
+
+    from invitations import (
+        callback_base_url,
+        create_invitation,
+    )
+    from onboarding_kit import write_onboarding_kit
+    from state_machine import FactoryDB
+    from config import (
+        DATABASE_URL,
+        DEVBRAIN_HOME as _DEVBRAIN_HOME,
+        ONBOARDING_SSH_HOST,
+        ONBOARDING_SSH_PORT,
+    )
+
+    _echo = echo or (lambda *_a, **_k: None)
+    admin_user = admin_name or _os.environ.get("USER") or getpass.getuser()
+
     # ─── Stage the dev row + invitation ───────────────────────────────
     db = FactoryDB(DATABASE_URL)
 
@@ -2183,8 +2267,8 @@ def setup_add_dev(
         auto_activate=auto_activate,
         email=email,
         notes=notes,
-        created_by=_os.environ.get("USER") or getpass.getuser(),
-        ttl_days=7,
+        created_by=admin_user,
+        ttl_days=ttl_days,
         cli=cli,
     )
 
@@ -2278,17 +2362,18 @@ def setup_add_dev(
         agent_app=agent_app,
     )
 
-    # ─── Hand back to admin ───────────────────────────────────────────
-    click.echo()
-    _ok(f"Dev '{dev_id}' staged.")
-    _ok(f"Invitation id: {inv.id[:8]} (expires {inv.expires_at:%Y-%m-%d %H:%M %Z})")
-    _ok(f"Onboarding kit: {kit_path}")
-    click.echo()
+    _echo("")
+    _echo(f"✅ Dev '{dev_id}' staged.")
+    _echo(
+        f"   Invitation id: {inv.id[:8]} "
+        f"(expires {inv.expires_at:%Y-%m-%d %H:%M %Z})"
+    )
+    _echo(f"   Onboarding kit: {kit_path}")
+    _echo("")
 
     # ─── Optionally email the kit ────────────────────────────────────
-    if _confirm(f"Email the kit to {email} now?", default=True):
+    if email_now:
         from onboarding_email import send_onboarding_email
-        admin_user = _os.environ.get("USER") or getpass.getuser()
         sent = send_onboarding_email(
             to_email=email,
             dev_id=dev_id,
@@ -2300,26 +2385,20 @@ def setup_add_dev(
             agent_app=agent_app,
         )
         if sent:
-            _ok(f"Email sent to {email}.")
+            _echo(f"✅ Email sent to {email}.")
         else:
-            _warn(
-                "Email not sent (SMTP unconfigured or delivery failed). "
+            _echo(
+                f"⚠ Email not sent (SMTP unconfigured or delivery failed). "
                 f"Send the kit manually, or fix SMTP and re-run: "
                 f"devbrain send-invite --dev {dev_id}"
             )
     else:
-        _info(
-            f"Skipping auto-send. Email the kit yourself, or run later: "
+        _echo(
+            f"   Skipping auto-send. Email the kit yourself, or run later: "
             f"devbrain send-invite --dev {dev_id}"
         )
 
-    click.echo()
-    _info(
-        "The raw invite token is embedded inside the kit file — DevBrain "
-        "stores only its hash. If the kit is lost, run "
-        "`devbrain setup add-dev` again to issue a fresh one (revoke the "
-        "previous one with `devbrain revoke-invite <id>`)."
-    )
+    return invite_id_short, kit_path
 
 
 # (menu label, section key, runner callable)

--- a/factory/tests/test_cli_invite_command.py
+++ b/factory/tests/test_cli_invite_command.py
@@ -1,0 +1,132 @@
+"""Tests for the `devbrain invite` CLI command (PR #146 open decision 1).
+
+The command stages a dev + invitation + bootstrap key + kit in one
+non-interactive call. Validation tests use click.testing.CliRunner; the
+happy-path test uses a live DB and a temp ssh authorized_keys so the
+side-effecting calls don't pollute the real ~/.ssh/.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+_FACTORY = Path(__file__).resolve().parents[1]
+if str(_FACTORY) not in sys.path:
+    sys.path.insert(0, str(_FACTORY))
+
+import cli as cli_module
+
+
+def test_invite_rejects_invalid_dev_id():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "invite", "BadDevId",
+            "--full-name", "x", "--email", "x@y.z",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "not a valid dev_id" in result.output
+
+
+def test_invite_rejects_malformed_email():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "invite", "alice",
+            "--full-name", "Alice", "--email", "not-an-email",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "doesn't look like a valid email" in result.output
+
+
+def test_invite_requires_full_name_and_email():
+    runner = CliRunner()
+    result = runner.invoke(cli_module.cli, ["invite", "alice"])
+    # click should reject with usage error (exit 2)
+    assert result.exit_code != 0
+    # Either --full-name or --email is missing; both are required.
+    assert "Missing option" in result.output or "Error" in result.output
+
+
+def test_invite_help_lists_all_flags():
+    runner = CliRunner()
+    result = runner.invoke(cli_module.cli, ["invite", "--help"])
+    assert result.exit_code == 0
+    for flag in (
+        "--full-name", "--email", "--cli", "--platform", "--agent-app",
+        "--slack", "--notes", "--ttl-days", "--auto-activate", "--email-now",
+    ):
+        assert flag in result.output
+
+
+@pytest.fixture
+def isolated_authorized_keys(tmp_path, monkeypatch):
+    """Redirect ~/.ssh/authorized_keys to a tmp file so the test's
+    bootstrap-key append doesn't touch the real keyring."""
+    fake_home = tmp_path / "fake-home"
+    (fake_home / ".ssh").mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+    yield fake_home / ".ssh" / "authorized_keys"
+
+
+def test_invite_live_db_creates_invitation_and_kit(
+    isolated_authorized_keys, tmp_path, monkeypatch,
+):
+    """End-to-end against the real DB. Skipped without DEVBRAIN_DB_PASSWORD."""
+    if not os.environ.get("DEVBRAIN_DB_PASSWORD") and not os.environ.get("DEVBRAIN_TEST_DATABASE_URL"):
+        pytest.skip("DB not configured for tests")
+
+    # Avoid colliding with prior runs.
+    dev_id = f"invite-test-{os.getpid()}"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "invite", dev_id,
+            "--full-name", "Invite Test",
+            "--email", f"{dev_id}@example.test",
+            "--cli", "claude",
+            "--platform", "auto",
+            "--agent-app", "claude-cli",
+            "--ttl-days", "1",
+            "--no-auto-activate",
+            "--no-email-now",
+        ],
+    )
+    try:
+        assert result.exit_code == 0, f"output:\n{result.output}"
+        # Helper prints "Dev '<id>' staged." on success.
+        assert f"Dev '{dev_id}' staged" in result.output
+        assert "Onboarding kit:" in result.output
+        # Bootstrap key landed in our isolated authorized_keys.
+        ak = isolated_authorized_keys
+        assert ak.exists()
+        ak_content = ak.read_text()
+        assert dev_id in ak_content
+        assert "ssh-ed25519" in ak_content
+        # No --email-now so SMTP shouldn't have been attempted; check the
+        # output explicitly mentions the skip path.
+        assert "Skipping auto-send" in result.output
+    finally:
+        # Best-effort cleanup of the test row + on-disk kit so reruns
+        # don't accumulate state.
+        from config import DATABASE_URL  # noqa: PLC0415
+        from state_machine import FactoryDB  # noqa: PLC0415
+
+        db = FactoryDB(DATABASE_URL)
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM devbrain.invitations WHERE dev_id = %s", (dev_id,),
+            )
+            cur.execute("DELETE FROM devbrain.devs WHERE dev_id = %s", (dev_id,))
+            conn.commit()


### PR DESCRIPTION
## Summary
- Adds `devbrain invite <dev_id>` non-interactive command (PR #146 open decision 1 — free-text `--cli` hint, no enum, no enforcement)
- Refactored `setup_add_dev` to share core onboarding logic via `finalize_invitation_and_kit(...)` — wizard and scripted flow can't drift
- Codifies PR #146 open decision 2 — existing adapters already do the right thing for headless OAuth; documented in ONBOARDING_TEAMMATE.md
- Claude Desktop explicitly NOT supported as an SSH-tunnel target (it's a local GUI app)

## Resolutions on `docs/plans/2026-05-17-onboarding-ssh-invitation-only.md`
- **Decision 1** → IMPL: `factory/cli.py:invite_cmd` + `factory/setup.py:finalize_invitation_and_kit`
- **Decision 2** → DOCS: `docs/ONBOARDING_TEAMMATE.md` §"Browser-required auth from a headless SSH session"

## Example
\`\`\`
devbrain invite alice \\
  --full-name \"Alice Example\" --email alice@example.com \\
  --cli claude --agent-app claude-cli --notes \"FERPA team\" \\
  --no-email-now
\`\`\`

## Test plan
- [x] \`pytest factory/tests/test_cli_invite_command.py\` — 5/5 passed (validation + help + live-DB happy path with monkeypatched authorized_keys)
- [x] \`pytest factory/tests/test_onboarding_email.py test_invitations_oauth_receipt test_onboarding_kit test_onboard_reconciler\` — 78/78 passed (no regressions from the refactor)
- [x] \`bin/devbrain invite --help\` renders all flags
- [x] Pre-commit cleanup: ignored runtime \`/onboarding/\` dir; removed test kit artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)