### PR TITLE
feat(cognify): Phase 8 PR 1 foundation — migration 039 + classifier helper

### DIFF
--- a/factory/cognify/fanout.py
+++ b/factory/cognify/fanout.py
@@ -1,0 +1,325 @@
+"""cognify_fanout — classify a session's per-project relevance + focused summaries.
+
+Phase 8 PR 1 (foundation). This module exposes a single pure helper:
+
+    classify_session(session_id, conn, *, model=...) -> ClassificationResult
+
+It reads the raw_session, renders the project taxonomy, makes one LLM
+call, parses the response, and returns a structured result. **It does
+NOT write to the DB.** PR 2 will add `run_fanout()` that calls this
+helper and inserts the per-project session_summary rows + derived_from
+edges.
+
+Spec reference: docs/plans/2026-05-11-phase-8-cross-project-fan-out-design.md
+§12 (the 2026-05-19 addendum) for the locked thresholds, prompt shape,
+and output schema.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+from cognify.fanout_prompt import (
+    SESSION_RELEVANCE_THRESHOLD,
+    SUMMARY_MAX_CHARS,
+    SUMMARY_MIN_CHARS,
+    WITHIN_SECTION_THRESHOLD,
+    build_system_prompt,
+    build_user_message,
+    render_taxonomy,
+    validate_output,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default model. Mirrors the cognify-bulk default. Switch to
+# claude-opus-4-7 via the model= kwarg for stuck-case retries.
+DEFAULT_MODEL = "claude-sonnet-4-6"
+
+# Max output tokens. 4K is plenty for the JSON shape: even with 6
+# sections + 5 per_project entries × 800 chars summary, the response
+# stays under ~3500 tokens.
+MAX_OUTPUT_TOKENS = 4_000
+
+
+@dataclass(frozen=True)
+class ProjectClassification:
+    """One per-project entry from a classifier response.
+
+    Only emitted when ``session_relevance >= SESSION_RELEVANCE_THRESHOLD``
+    (already filtered by ``validate_output``).
+    """
+
+    project_slug: str
+    session_relevance: float
+    section_count: int
+    focused_summary: str
+
+
+@dataclass
+class ClassificationResult:
+    """Output of classify_session().
+
+    ``failure`` is None on success; otherwise one of:
+      - "no_session"    — the session_id didn't resolve
+      - "no_content"    — session had no chunks/content to classify
+      - "no_taxonomy"   — projects table empty / no active projects
+      - "no_auth"       — no Anthropic credential configured (test env)
+      - "api"           — API call itself errored (network/auth/429)
+      - "json_parse"    — model returned non-JSON
+      - "empty"         — valid JSON but no project entries cleared threshold
+    """
+
+    session_id: str
+    per_project: list[ProjectClassification] = field(default_factory=list)
+    sections: list[dict] = field(default_factory=list)
+    usage: dict = field(default_factory=lambda: {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    })
+    failure: str | None = None
+    failure_detail: str | None = None
+
+
+def _load_active_taxonomy(conn: Any) -> list[dict[str, Any]]:
+    """Fetch active projects for the classifier's taxonomy block.
+
+    Excludes archived projects (status filter) and the orphan/home
+    catch-alls — those exist for canonical-assignment fallback, not
+    as classifier targets. A session that's purely "home-mike" content
+    legitimately shouldn't fan out *into* home-mike — it'd be a
+    self-reference.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT slug, name, description
+            FROM devbrain.projects
+            WHERE (status IS NULL OR status = 'active')
+              AND slug NOT LIKE 'home-%'
+            ORDER BY slug
+            """,
+        )
+        return [
+            {"slug": r[0], "name": r[1], "description": r[2]}
+            for r in cur.fetchall()
+        ]
+
+
+def _load_session_content(conn: Any, session_id: str) -> str | None:
+    """Assemble the classifier's input text from a session's chunks.
+
+    Returns None if the session_id doesn't exist; "" if it exists but
+    has no chunks (the classifier won't have anything to work with).
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.raw_sessions WHERE id = %s",
+            (session_id,),
+        )
+        if cur.fetchone() is None:
+            return None
+
+        # chunks has no chunk_index column today; ordering by
+        # (source_line_start, created_at) approximates the source order
+        # well enough for the classifier. Falls back gracefully when
+        # source_line_start is NULL (codex/openclaw adapters).
+        cur.execute(
+            """
+            SELECT content
+            FROM devbrain.chunks
+            WHERE source_id = %s
+            ORDER BY source_line_start NULLS LAST, created_at
+            """,
+            (session_id,),
+        )
+        rows = cur.fetchall()
+
+    if not rows:
+        return ""
+    return "\n\n".join(r[0] for r in rows if r[0])
+
+
+def classify_session(
+    session_id: str | UUID,
+    conn: Any,
+    *,
+    model: str = DEFAULT_MODEL,
+    max_retries: int = 3,
+) -> ClassificationResult:
+    """Run one classifier LLM call for a session. Returns parsed results.
+
+    Pure function — does NOT write to the DB. Caller (PR 2's
+    ``run_fanout``) is responsible for inserting the resulting memory
+    rows + ``derived_from`` edges + spend log entry.
+
+    Args:
+        session_id: raw_sessions.id (UUID or string form).
+        conn: psycopg2 connection.
+        model: Anthropic model string. Sonnet for the bulk run; Opus
+               retry on json_parse / empty cases.
+        max_retries: connection retries on ``APIConnectionError``. Stale
+               httpx pool defense — same pattern cognify_extract uses.
+
+    Returns:
+        ClassificationResult with ``failure`` set on any failure mode.
+        The caller can shard / retry / log accordingly.
+    """
+    session_id_str = str(session_id)
+    result = ClassificationResult(session_id=session_id_str)
+
+    # 1. Load taxonomy + session content.
+    taxonomy = _load_active_taxonomy(conn)
+    if not taxonomy:
+        result.failure = "no_taxonomy"
+        result.failure_detail = "no active non-home projects in devbrain.projects"
+        return result
+
+    session_text = _load_session_content(conn, session_id_str)
+    if session_text is None:
+        result.failure = "no_session"
+        return result
+    if not session_text.strip():
+        result.failure = "no_content"
+        return result
+
+    valid_slugs = {p["slug"] for p in taxonomy}
+
+    # 2. Resolve Anthropic auth.
+    try:
+        import anthropic  # noqa: PLC0415
+    except ImportError:
+        result.failure = "no_auth"
+        result.failure_detail = "anthropic SDK not installed"
+        return result
+
+    from cognify.extract import _resolve_auth  # noqa: PLC0415
+
+    auth_kwargs = _resolve_auth()
+    if auth_kwargs is None:
+        result.failure = "no_auth"
+        return result
+
+    # 3. Build prompt + make the call.
+    system_text = build_system_prompt(render_taxonomy(taxonomy))
+    user_text = build_user_message(session_text)
+
+    # OAuth path needs the Claude Code system-prefix; console API key path
+    # returns None and is unaffected. Mirrors cognify_extract's setup.
+    from cognify._anthropic_auth import claude_code_system_prefix  # noqa: PLC0415
+
+    system_blocks: list[dict[str, Any]] = []
+    oauth_prefix = claude_code_system_prefix()
+    if oauth_prefix:
+        system_blocks.append({"type": "text", "text": oauth_prefix})
+    system_blocks.append(
+        {
+            "type": "text",
+            "text": system_text,
+            "cache_control": {"type": "ephemeral"},
+        }
+    )
+
+    client = anthropic.Anthropic(**auth_kwargs)
+    response = None
+    api_error: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            response = client.messages.create(
+                model=model,
+                max_tokens=MAX_OUTPUT_TOKENS,
+                system=system_blocks,
+                messages=[{"role": "user", "content": user_text}],
+            )
+            break
+        except anthropic.APIConnectionError as exc:
+            api_error = exc
+            # Recycle the client on retry to clear stale httpx pool —
+            # same pattern as cognify_extract's _API_MAX_RETRIES loop.
+            client = anthropic.Anthropic(**auth_kwargs)
+            continue
+        except Exception as exc:  # noqa: BLE001
+            api_error = exc
+            break
+
+    if response is None:
+        result.failure = "api"
+        result.failure_detail = type(api_error).__name__ + ": " + str(api_error)[:200]
+        return result
+
+    # 4. Record usage for spend tracking (caller writes the spend row).
+    usage = getattr(response, "usage", None)
+    if usage is not None:
+        result.usage = {
+            "input_tokens": getattr(usage, "input_tokens", 0) or 0,
+            "output_tokens": getattr(usage, "output_tokens", 0) or 0,
+            "cache_read_tokens": getattr(usage, "cache_read_input_tokens", 0) or 0,
+            "cache_write_tokens": getattr(usage, "cache_creation_input_tokens", 0) or 0,
+        }
+
+    # 5. Parse + validate.
+    text_blocks = [
+        b.text for b in (response.content or [])
+        if getattr(b, "type", None) == "text"
+    ]
+    text = "".join(text_blocks).strip()
+
+    from cognify.extract import _parse_json_with_fallbacks  # noqa: PLC0415
+
+    parsed = _parse_json_with_fallbacks(text)
+    if parsed is None:
+        result.failure = "json_parse"
+        result.failure_detail = (
+            f"all parse strategies exhausted; sample={text[:400]!r}"
+        )
+        return result
+
+    validated = validate_output(parsed, valid_slugs)
+    result.sections = validated["sections"]
+    result.per_project = [
+        ProjectClassification(
+            project_slug=e["project_slug"],
+            session_relevance=e["session_relevance"],
+            section_count=e["section_count"],
+            focused_summary=_clip_summary(e["focused_summary"]),
+        )
+        for e in validated["per_project"]
+    ]
+
+    if not result.per_project:
+        result.failure = "empty"
+        result.failure_detail = "no project entries cleared session_relevance threshold"
+
+    return result
+
+
+def _clip_summary(text: str) -> str:
+    """Defensive length clamp — the prompt asks for 200–800 chars but
+    models occasionally over/undershoot. We pad NO ONE — if the model
+    returns <200 chars we accept it (a terse summary is still better
+    than nothing). For >800 we truncate at a sentence boundary if
+    possible, else hard-cut.
+    """
+    if len(text) <= SUMMARY_MAX_CHARS:
+        return text
+    cut = text[:SUMMARY_MAX_CHARS]
+    last_period = cut.rfind(". ")
+    if last_period >= SUMMARY_MIN_CHARS:
+        return cut[: last_period + 1]
+    return cut.rstrip() + "…"
+
+
+# Re-export thresholds at module level for callers/tests that want to
+# assert against the locked spec without reaching into fanout_prompt.
+__all__ = [
+    "SESSION_RELEVANCE_THRESHOLD",
+    "WITHIN_SECTION_THRESHOLD",
+    "DEFAULT_MODEL",
+    "ProjectClassification",
+    "ClassificationResult",
+    "classify_session",
+]

--- a/factory/cognify/fanout_prompt.py
+++ b/factory/cognify/fanout_prompt.py
@@ -1,0 +1,170 @@
+"""Prompt template + project-taxonomy renderer for cognify_fanout.
+
+Phase 8 — see docs/plans/2026-05-11-phase-8-cross-project-fan-out-design.md
+§12 for the locked spec.
+
+The classifier is one LLM call per session. The prompt asks the model to
+identify topic sections inside the session, score per-section relevance
+against each project (within-section threshold 0.75), aggregate to
+session-level relevance, and emit a focused per-project summary for
+each project that clears 0.30.
+
+The single-call shape keeps cost predictable; the section-aware
+prompt structure forces the model to reason about WHICH PARTS of the
+session belong to which project rather than treating the whole session
+as a soup.
+"""
+from __future__ import annotations
+
+import json as _json
+from typing import Any
+
+# Thresholds (locked in §12.1).
+SESSION_RELEVANCE_THRESHOLD = 0.30  # emit fan-out row when ≥ this
+WITHIN_SECTION_THRESHOLD = 0.75     # section "belongs to" a project when ≥ this
+
+# Per-project focused-summary length bounds (§12 A8).
+SUMMARY_MIN_CHARS = 200
+SUMMARY_MAX_CHARS = 800
+
+
+def render_taxonomy(projects: list[dict[str, Any]]) -> str:
+    """Render the project taxonomy for the prompt's SYSTEM block.
+
+    Args:
+        projects: list of {"slug": str, "name": str, "description": str|None}.
+                  Caller is responsible for filtering to active projects only.
+
+    Output is JSON, intentionally — gives the model a structured anchor
+    and lets us prompt-cache the whole block.
+    """
+    sanitized = [
+        {
+            "slug": p["slug"],
+            "name": p.get("name") or p["slug"],
+            "description": (p.get("description") or "").strip() or None,
+        }
+        for p in projects
+    ]
+    return _json.dumps(sanitized, ensure_ascii=False, indent=2)
+
+
+def build_system_prompt(taxonomy_json: str) -> str:
+    """Construct the SYSTEM message body for the classifier call.
+
+    Cache this — the taxonomy + instructions are stable across sessions.
+    """
+    return (
+        "You are classifying a developer's work session into the projects "
+        "it discussed. Project taxonomy (slug + name + description):\n\n"
+        f"{taxonomy_json}\n\n"
+        "Your job has four internal steps:\n"
+        "  1. Identify topic sections — groups of consecutive turns about "
+        "one subject. Could be 1 section or 6; you decide.\n"
+        "  2. For each section, score per-project relevance 0.0–1.0. A "
+        "section 'belongs to' a project only when its within-section "
+        f"score is ≥ {WITHIN_SECTION_THRESHOLD}.\n"
+        "  3. Aggregate to session-level per-project relevance = fraction "
+        "of session sections that belong to that project. Drop any "
+        f"project below {SESSION_RELEVANCE_THRESHOLD}.\n"
+        "  4. For each kept project, write a focused summary "
+        f"({SUMMARY_MIN_CHARS}–{SUMMARY_MAX_CHARS} chars) of the relevant "
+        "sections' content, in the dev's voice (first person; concrete; "
+        "name files/functions/decisions where useful).\n\n"
+        "Return ONLY JSON. No preamble, no commentary, no markdown fences. "
+        "First character must be `{`. Last character must be `}`.\n\n"
+        "Schema:\n"
+        "{\n"
+        '  "sections": [\n'
+        '    {"start_turn": int, "end_turn": int, "topic": str,\n'
+        '     "project_scores": {"<slug>": 0.0-1.0, ...}}\n'
+        "  ],\n"
+        '  "per_project": [\n'
+        '    {"project_slug": str,\n'
+        '     "session_relevance": 0.0-1.0,\n'
+        '     "section_count": int,\n'
+        '     "focused_summary": str}\n'
+        "  ]\n"
+        "}\n"
+    )
+
+
+def build_user_message(session_content: str) -> str:
+    """User-role payload: the session content the classifier reads.
+
+    Capped at 200K characters — same as cognify_extract's ceiling. Real
+    session_summaries top out well below this. If a session exceeds, the
+    tail is truncated with a marker so the classifier knows.
+    """
+    cap = 200_000
+    if len(session_content) <= cap:
+        body = session_content
+    else:
+        body = (
+            session_content[: cap - 200]
+            + "\n\n[...TRUNCATED — session exceeded 200K characters...]"
+        )
+    return (
+        "Classify the following session per the schema. Output ONLY the JSON.\n\n"
+        f"<<< SESSION CONTENT >>>\n{body}"
+    )
+
+
+def validate_output(parsed: dict[str, Any], valid_slugs: set[str]) -> dict[str, Any]:
+    """Defensive post-parse validation.
+
+    Drops `per_project` entries where:
+      * `session_relevance` is missing, non-numeric, or < SESSION_RELEVANCE_THRESHOLD
+      * `project_slug` isn't in the live taxonomy (`valid_slugs`)
+      * `focused_summary` is missing or empty
+
+    Returns the SAME dict shape (sections + per_project) with the
+    invalid entries removed. Does NOT mutate the input.
+
+    Drops sections silently if shape is malformed — sections are
+    advisory ("how did the model reason") and not load-bearing for
+    the writer in PR 2.
+    """
+    out_per_project = []
+    for entry in (parsed.get("per_project") or []):
+        if not isinstance(entry, dict):
+            continue
+        slug = entry.get("project_slug")
+        if slug not in valid_slugs:
+            continue
+        try:
+            relevance = float(entry.get("session_relevance"))
+        except (TypeError, ValueError):
+            continue
+        if relevance < SESSION_RELEVANCE_THRESHOLD:
+            continue
+        summary = entry.get("focused_summary") or ""
+        if not isinstance(summary, str) or not summary.strip():
+            continue
+        out_per_project.append({
+            "project_slug": slug,
+            "session_relevance": relevance,
+            "section_count": int(entry.get("section_count") or 0),
+            "focused_summary": summary.strip(),
+        })
+
+    out_sections = []
+    for sec in (parsed.get("sections") or []):
+        if not isinstance(sec, dict):
+            continue
+        scores = sec.get("project_scores")
+        if not isinstance(scores, dict):
+            continue
+        # Filter unknown slugs out of section scores too.
+        clean_scores = {
+            k: float(v) for k, v in scores.items()
+            if k in valid_slugs and isinstance(v, (int, float))
+        }
+        out_sections.append({
+            "start_turn": int(sec.get("start_turn") or 0),
+            "end_turn": int(sec.get("end_turn") or 0),
+            "topic": (sec.get("topic") or "").strip(),
+            "project_scores": clean_scores,
+        })
+
+    return {"sections": out_sections, "per_project": out_per_project}

--- a/factory/tests/test_cognify_fanout_foundation.py
+++ b/factory/tests/test_cognify_fanout_foundation.py
@@ -1,0 +1,288 @@
+"""Tests for Phase 8 PR 1 — foundation pieces only.
+
+Covers:
+  * fanout_prompt.render_taxonomy / build_system_prompt / build_user_message
+    output shape + spec compliance
+  * fanout_prompt.validate_output filters per the locked thresholds
+  * migration 039 schema state (home-* projects exist, fanout column +
+    partial unique index live)
+  * classify_session() error paths that don't require an LLM call
+    (no_session, no_content, no_taxonomy)
+
+LLM-bearing happy-path tests for classify_session() are deferred to
+PR 2 where they can ride on top of run_fanout's mock harness — at this
+foundation stage we cover the wiring + the failure modes that don't
+involve an API call.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import psycopg2
+import pytest
+
+_FACTORY = Path(__file__).resolve().parents[1]
+if str(_FACTORY) not in sys.path:
+    sys.path.insert(0, str(_FACTORY))
+
+
+# ─── fanout_prompt: pure-function unit tests ────────────────────────────────
+
+
+def test_thresholds_match_locked_spec():
+    """Locked values from PR #121 §12.1 (A1, A2)."""
+    from cognify.fanout_prompt import (
+        SESSION_RELEVANCE_THRESHOLD,
+        WITHIN_SECTION_THRESHOLD,
+        SUMMARY_MIN_CHARS,
+        SUMMARY_MAX_CHARS,
+    )
+    assert SESSION_RELEVANCE_THRESHOLD == 0.30
+    assert WITHIN_SECTION_THRESHOLD == 0.75
+    assert SUMMARY_MIN_CHARS == 200
+    assert SUMMARY_MAX_CHARS == 800
+
+
+def test_render_taxonomy_emits_valid_json_with_expected_shape():
+    from cognify.fanout_prompt import render_taxonomy
+    rendered = render_taxonomy([
+        {"slug": "brightbot", "name": "BrightBot", "description": "EMR stuff"},
+        {"slug": "pkrelay", "name": "PKRelay", "description": ""},
+        {"slug": "devbrain"},  # missing name + description tolerated
+    ])
+    parsed = json.loads(rendered)
+    assert isinstance(parsed, list) and len(parsed) == 3
+    assert parsed[0] == {
+        "slug": "brightbot",
+        "name": "BrightBot",
+        "description": "EMR stuff",
+    }
+    assert parsed[1]["description"] is None  # empty string → None
+    assert parsed[2]["name"] == "devbrain"     # name falls back to slug
+
+
+def test_build_system_prompt_includes_thresholds_and_schema():
+    from cognify.fanout_prompt import build_system_prompt, render_taxonomy
+    sys_prompt = build_system_prompt(render_taxonomy([
+        {"slug": "alpha", "name": "Alpha", "description": "x"},
+    ]))
+    assert "0.75" in sys_prompt
+    assert "0.3" in sys_prompt
+    assert "per_project" in sys_prompt
+    assert "sections" in sys_prompt
+    assert "focused_summary" in sys_prompt
+
+
+def test_build_user_message_truncates_huge_input():
+    from cognify.fanout_prompt import build_user_message
+    huge = "x" * 250_000
+    msg = build_user_message(huge)
+    assert "TRUNCATED" in msg
+    assert len(msg) < 210_000
+
+
+def test_build_user_message_passes_short_input_through():
+    from cognify.fanout_prompt import build_user_message
+    msg = build_user_message("session content")
+    assert "session content" in msg
+    assert "TRUNCATED" not in msg
+
+
+def test_validate_output_drops_below_threshold_entries():
+    from cognify.fanout_prompt import validate_output
+    parsed = {
+        "per_project": [
+            {"project_slug": "brightbot", "session_relevance": 0.5,
+             "section_count": 3, "focused_summary": "x" * 250},
+            {"project_slug": "pkrelay", "session_relevance": 0.15,
+             "section_count": 1, "focused_summary": "y" * 250},
+            {"project_slug": "devbrain", "session_relevance": 0.30,
+             "section_count": 1, "focused_summary": "z" * 250},
+        ]
+    }
+    out = validate_output(parsed, {"brightbot", "pkrelay", "devbrain"})
+    slugs = [p["project_slug"] for p in out["per_project"]]
+    assert "brightbot" in slugs
+    assert "devbrain" in slugs   # at exactly 0.30 — boundary inclusive
+    assert "pkrelay" not in slugs
+
+
+def test_validate_output_drops_unknown_slugs():
+    from cognify.fanout_prompt import validate_output
+    parsed = {
+        "per_project": [
+            {"project_slug": "real-project", "session_relevance": 0.5,
+             "section_count": 1, "focused_summary": "ok"},
+            {"project_slug": "made-up", "session_relevance": 0.9,
+             "section_count": 1, "focused_summary": "hallucinated"},
+        ]
+    }
+    out = validate_output(parsed, {"real-project"})
+    slugs = [p["project_slug"] for p in out["per_project"]]
+    assert slugs == ["real-project"]
+
+
+def test_validate_output_drops_empty_summaries():
+    from cognify.fanout_prompt import validate_output
+    parsed = {
+        "per_project": [
+            {"project_slug": "a", "session_relevance": 0.5,
+             "section_count": 1, "focused_summary": "   "},
+            {"project_slug": "b", "session_relevance": 0.5,
+             "section_count": 1, "focused_summary": "real"},
+        ]
+    }
+    out = validate_output(parsed, {"a", "b"})
+    slugs = [p["project_slug"] for p in out["per_project"]]
+    assert slugs == ["b"]
+
+
+def test_validate_output_tolerates_missing_sections_key():
+    from cognify.fanout_prompt import validate_output
+    out = validate_output({"per_project": []}, set())
+    assert out == {"sections": [], "per_project": []}
+
+
+def test_validate_output_filters_section_scores_to_valid_slugs():
+    from cognify.fanout_prompt import validate_output
+    parsed = {
+        "sections": [
+            {"start_turn": 0, "end_turn": 3, "topic": "auth",
+             "project_scores": {"alpha": 0.9, "ghost": 0.5}},
+        ],
+        "per_project": [],
+    }
+    out = validate_output(parsed, {"alpha"})
+    assert out["sections"][0]["project_scores"] == {"alpha": 0.9}
+
+
+# ─── classify_session: failure-mode tests (no LLM call) ─────────────────────
+
+
+def _build_conn_with_cursor(fetchone_return, fetchall_returns_seq):
+    """Mock conn whose cursor returns a fixed sequence of fetch results."""
+    cursor = MagicMock()
+    cursor.fetchone.return_value = fetchone_return
+    cursor.fetchall.side_effect = fetchall_returns_seq
+
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cursor
+    return conn, cursor
+
+
+def test_classify_session_returns_no_taxonomy_when_no_projects():
+    from cognify.fanout import classify_session
+
+    # Empty taxonomy fetchall.
+    conn, _cur = _build_conn_with_cursor(
+        fetchone_return=None, fetchall_returns_seq=[[]],
+    )
+    result = classify_session("00000000-0000-0000-0000-000000000001", conn)
+    assert result.failure == "no_taxonomy"
+
+
+def test_classify_session_returns_no_session_when_unknown_id():
+    from cognify.fanout import classify_session
+
+    # Taxonomy: one row. raw_sessions lookup: None.
+    conn, _cur = _build_conn_with_cursor(
+        fetchone_return=None,
+        fetchall_returns_seq=[
+            [("alpha", "Alpha", "")],  # taxonomy
+        ],
+    )
+    result = classify_session("00000000-0000-0000-0000-000000000001", conn)
+    assert result.failure == "no_session"
+
+
+def test_classify_session_returns_no_content_when_chunks_empty():
+    from cognify.fanout import classify_session
+
+    # taxonomy → 1 row; raw_session exists; chunks fetchall → []
+    cursor = MagicMock()
+    cursor.fetchone.return_value = ("00000000-0000-0000-0000-000000000001",)
+    cursor.fetchall.side_effect = [
+        [("alpha", "Alpha", "")],   # taxonomy
+        [],                          # chunks
+    ]
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cursor
+
+    result = classify_session("00000000-0000-0000-0000-000000000001", conn)
+    assert result.failure == "no_content"
+
+
+# ─── Migration 039: live-DB schema state ────────────────────────────────────
+
+
+def _live_conn():
+    from config import DATABASE_URL  # noqa: PLC0415
+    return psycopg2.connect(DATABASE_URL)
+
+
+@pytest.fixture
+def live_db():
+    try:
+        conn = _live_conn()
+    except Exception as exc:
+        pytest.skip(f"live DB unavailable: {exc}")
+    yield conn
+    conn.close()
+
+
+def test_migration_039_home_projects_exist_one_per_dev(live_db):
+    with live_db.cursor() as cur:
+        cur.execute("SELECT dev_id FROM devbrain.devs")
+        dev_ids = {r[0] for r in cur.fetchall()}
+        cur.execute(
+            "SELECT slug FROM devbrain.projects WHERE slug LIKE 'home-%'"
+        )
+        home_slugs = {r[0] for r in cur.fetchall()}
+    # Every dev has a home project (slug = 'home-' + dev_id).
+    for d in dev_ids:
+        assert f"home-{d}" in home_slugs, f"missing home project for dev {d}"
+    # And the orphan catch-all exists.
+    assert "home-orphan" in home_slugs
+
+
+def test_migration_039_fanout_column_present(live_db):
+    with live_db.cursor() as cur:
+        cur.execute(
+            """
+            SELECT data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema='devbrain'
+              AND table_name='memory'
+              AND column_name='fanout_source_session_id'
+            """,
+        )
+        row = cur.fetchone()
+    assert row is not None
+    data_type, nullable = row
+    assert data_type == "uuid"
+    assert nullable == "YES"
+
+
+def test_migration_039_fanout_unique_index_present(live_db):
+    with live_db.cursor() as cur:
+        cur.execute(
+            """
+            SELECT indexdef FROM pg_indexes
+            WHERE schemaname='devbrain'
+              AND indexname='idx_memory_fanout_unique'
+            """,
+        )
+        row = cur.fetchone()
+    assert row is not None
+    indexdef = row[0]
+    # Partial unique on (fanout_source_session_id, project_id) with the
+    # kind/tier/archived predicate.
+    assert "UNIQUE" in indexdef
+    assert "fanout_source_session_id" in indexdef
+    assert "project_id" in indexdef
+    assert "session_summary" in indexdef
+    assert "archived_at IS NULL" in indexdef

--- a/migrations/039_phase8_home_projects_and_fanout_attribution.sql
+++ b/migrations/039_phase8_home_projects_and_fanout_attribution.sql
@@ -1,0 +1,99 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 039: Phase 8 foundation — per-dev home projects + fan-out attribution
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- Three independent pieces:
+--
+--   1. Backfill one `home-<dev_id>` project per existing dev. Future devs
+--      get theirs lazily on first cognify_fanout encounter (handled in
+--      Python). Replaces the deferred "inbox" concept from PR #121 §6.
+--
+--   2. Add `memory.fanout_source_session_id` (FK → raw_sessions). This
+--      column is the discriminator that lets the dashboard panel +
+--      `derived_from` graph queries tell fan-out rows apart from
+--      agent-volunteered session_summary rows. NULL for non-fan-out rows.
+--
+--   3. Partial unique index on (fanout_source_session_id, project_id)
+--      WHERE kind='session_summary' AND tier='memory' AND archived_at
+--      IS NULL — the idempotency seal. Replaying cognify_fanout on the
+--      same source session is a no-op against the same target.
+--
+-- All three pieces are idempotent (IF NOT EXISTS / WHERE NOT EXISTS).
+-- Wrapped in an explicit transaction so the migration applies atomically
+-- under CI's psql -f runner (which uses implicit-transaction-per-statement
+-- if not wrapped — see incident notes on migration 034).
+--
+-- Roll-back: drop the unique index + the column. The home projects can be
+-- archived (status='archived') without harm; they hold only fan-out rows
+-- that are themselves archive-on-demand.
+
+BEGIN;
+
+-- 1. Per-dev home projects ---------------------------------------------------
+--
+-- One row per dev, slug='home-<dev_id>'. Idempotent via WHERE NOT EXISTS.
+-- description prefix makes these searchable in admin UIs.
+INSERT INTO devbrain.projects (id, slug, name, description, created_at)
+SELECT
+    gen_random_uuid(),
+    'home-' || d.dev_id,
+    COALESCE(d.full_name, d.dev_id) || ' — home',
+    'Auto-managed catch-all for ' || d.dev_id || ' sessions with no other ' ||
+        'clear project signal. Created by migration 039 (Phase 8 fan-out).',
+    now()
+FROM devbrain.devs d
+WHERE NOT EXISTS (
+    SELECT 1 FROM devbrain.projects p WHERE p.slug = 'home-' || d.dev_id
+);
+
+-- Orphan home for pre-PR-146 sessions with no dev_id attribution.
+INSERT INTO devbrain.projects (id, slug, name, description, created_at)
+SELECT
+    gen_random_uuid(),
+    'home-orphan',
+    'Orphan sessions (pre-PR-146)',
+    'Auto-managed catch-all for sessions with no dev_id attribution. ' ||
+        'Created by migration 039 (Phase 8 fan-out). Stops accumulating ' ||
+        'once every adapter attaches dev_id at ingest time.',
+    now()
+WHERE NOT EXISTS (
+    SELECT 1 FROM devbrain.projects WHERE slug = 'home-orphan'
+);
+
+
+-- 2. Fan-out attribution column ----------------------------------------------
+ALTER TABLE devbrain.memory
+    ADD COLUMN IF NOT EXISTS fanout_source_session_id UUID
+    REFERENCES devbrain.raw_sessions(id);
+
+COMMENT ON COLUMN devbrain.memory.fanout_source_session_id IS
+    'Set on Phase 8 fan-out rows: the raw_session whose content was '
+    'classified into this project. NULL for non-fan-out memory rows. '
+    'Powers the (fanout_source_session_id, project_id) idempotency '
+    'index — re-running cognify_fanout on the same source is a no-op.';
+
+
+-- 3. Fan-out idempotency seal -----------------------------------------------
+--
+-- Partial unique covers exactly: "this fan-out has already written an
+-- active session_summary into this project for this source." Re-runs
+-- collapse to ON CONFLICT DO NOTHING in the writer.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_fanout_unique
+    ON devbrain.memory (fanout_source_session_id, project_id)
+    WHERE kind = 'session_summary'
+      AND tier = 'memory'
+      AND archived_at IS NULL
+      AND fanout_source_session_id IS NOT NULL;
+
+COMMENT ON INDEX devbrain.idx_memory_fanout_unique IS
+    'Migration 039: idempotency seal for cognify_fanout. One active '
+    'session_summary row per (source_session, target_project). Combined '
+    'with classifier checkpoint per session, re-running cognify_fanout '
+    'is safe at any partial-failure point.';
+
+
+INSERT INTO devbrain.schema_migrations (filename)
+VALUES ('039_phase8_home_projects_and_fanout_attribution.sql')
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary
PR 1 of 3 for Phase 8 cross-project fan-out. Lays the substrate so PR 2 can wire writes + CLI on top.

Spec: \`docs/plans/2026-05-11-phase-8-cross-project-fan-out-design.md\` §12 (the 2026-05-19 addendum)

## What ships
- **Migration 039** — per-dev \`home-<dev_id>\` projects (incl. \`home-orphan\`), \`memory.fanout_source_session_id\` column, partial unique index for idempotency
- **\`factory/cognify/fanout_prompt.py\`** — section-aware prompt template + JSON output schema (sections + per_project) + defensive validator
- **\`factory/cognify/fanout.py::classify_session()\`** — pure function: load taxonomy, read session chunks, one LLM call, return ClassificationResult. **No DB writes.**
- 16 new tests, all green

## What does NOT ship (PR 2/3)
- \`run_fanout()\` writer
- \`bin/devbrain cognify-fanout\` CLI
- launchd plist
- All-time backfill orchestrator

## Test plan
- [x] \`pytest factory/tests/test_cognify_fanout_foundation.py\` — 16/16 (10 unit + 3 mock + 3 live-DB schema)
- [x] Regression: \`pytest factory/tests/test_cognify_extract test_extract_json_parse_fallbacks test_cognify_bulk\` — 43/43 still pass
- [x] Migration 039 applied locally: \`bin/devbrain migrate\` → \`applied 039_phase8_home_projects_and_fanout_attribution.sql (67ms)\`
- [x] Verified: 9 home-* projects exist (8 devs + home-orphan), column + partial unique index live

## Deploy notes
- Migration is idempotent (\`IF NOT EXISTS\`, \`WHERE NOT EXISTS\`) — safe to re-apply
- No service restart needed; this PR doesn't change any running code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)