### PR TITLE
feat(cognify): Phase 8 PR 2 — fan-out pass writer + CLI + launchd

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -3493,5 +3493,162 @@ def cognify_bulk_command(
             )
 
 
+# ─── Phase 8: cognify_fanout ────────────────────────────────────────────────
+
+
+@cli.command("cognify-fanout")
+@click.option(
+    "--project", "project_slug", default=None,
+    help="Project slug — restrict discovery to sessions whose canonical "
+         "project_id matches. Omit to fan-out across all projects.",
+)
+@click.option(
+    "--since", default=None,
+    help="ISO date — only process raw_sessions with started_at >= this date. "
+         "Omit for all-time backfill scope.",
+)
+@click.option(
+    "--max-sessions", type=int, default=None,
+    help="Cap discovery at N sessions. Useful for budgeted runs / smoke tests.",
+)
+@click.option(
+    "--shard", default=None,
+    help="N/M — process only sessions[i % M == N] of the sorted session list. "
+         "Use to parallelize across M concurrent instances (0/M, 1/M, ...).",
+)
+@click.option(
+    "--model", default=None,
+    help="Override the classifier model (default: claude-sonnet-4-6). Use "
+         "claude-opus-4-7 to retry sessions whose Sonnet output failed "
+         "json_parse. Pricing must be registered in "
+         "factory/observability/pricing.py — unknown models fall back to "
+         "Sonnet pricing for the spend log.",
+)
+@click.option(
+    "--dry-run", is_flag=True, default=False,
+    help="Report discovery scope only. No LLM calls. No DB writes.",
+)
+@click.option(
+    "--json", "as_json", is_flag=True, default=False,
+    help="Emit the final summary as JSON on stdout.",
+)
+def cognify_fanout_command(
+    project_slug, since, max_sessions, shard, model, dry_run, as_json,
+):
+    """Cross-project fan-out (Phase 8). Classifies each session into the
+    projects it actually discussed and writes per-project focused-summary
+    rows so single-project deep_search finds cross-project content.
+
+    Examples:
+
+      devbrain cognify-fanout --dry-run                       # size scope
+      devbrain cognify-fanout --since=2026-04-01              # last month
+      devbrain cognify-fanout --project=brightbot             # canonical filter
+      devbrain cognify-fanout --shard=0/4                     # parallel worker 1
+      devbrain cognify-fanout --model=claude-opus-4-7         # retry stuck cases
+
+    Reads the locked thresholds (0.30 session-level, 0.75 within-section)
+    from factory/cognify/fanout_prompt.py. Idempotent against the partial
+    unique index from migration 039 — safe to re-run.
+    """
+    import json
+    import sys
+    from datetime import datetime, timezone
+
+    from cognify.fanout import (  # noqa: PLC0415
+        run_fanout, DEFAULT_MODEL,
+    )
+
+    db = get_db()
+
+    project_id = None
+    if project_slug:
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM devbrain.projects WHERE slug = %s",
+                (project_slug,),
+            )
+            row = cur.fetchone()
+        if not row:
+            raise click.ClickException(f"Project {project_slug!r} not found.")
+        project_id = row[0]
+
+    since_dt = None
+    if since:
+        try:
+            since_dt = datetime.fromisoformat(since)
+            if since_dt.tzinfo is None:
+                since_dt = since_dt.replace(tzinfo=timezone.utc)
+        except ValueError as exc:
+            raise click.ClickException(f"Invalid --since date: {since!r}") from exc
+
+    shard_tuple: tuple[int, int] | None = None
+    if shard:
+        try:
+            n_str, m_str = shard.split("/", 1)
+            shard_tuple = (int(n_str), int(m_str))
+        except (ValueError, AttributeError) as exc:
+            raise click.ClickException(
+                f"--shard must be N/M (e.g. 0/4); got {shard!r}"
+            ) from exc
+
+    effective_model = model or DEFAULT_MODEL
+
+    def _on_progress(idx, total, info):
+        rows = info.get("rows", 0)
+        failure = info.get("failure")
+        sid = info.get("session_id", "?")[:8]
+        status = (
+            f"FAILED ({failure})" if failure else f"{rows} fan-out rows"
+        )
+        click.echo(
+            f"cognify-fanout: [{idx:>4}/{total:>4}] {sid}…  {status}",
+            err=True,
+        )
+
+    with db._conn() as conn:
+        result = run_fanout(
+            conn,
+            project_id=project_id,
+            since=since_dt,
+            model=effective_model,
+            dry_run=dry_run,
+            shard=shard_tuple,
+            max_sessions=max_sessions,
+            progress_callback=_on_progress if not as_json else None,
+        )
+
+    summary = {
+        "sessions_discovered": result.sessions_discovered,
+        "sessions_processed": result.sessions_processed,
+        "sessions_failed": result.sessions_failed,
+        "sessions_skipped": result.sessions_skipped,
+        "rows_emitted": result.rows_emitted,
+        "llm_calls": result.llm_calls,
+        "failure_counts": result.failure_counts,
+        "dry_run": result.dry_run,
+    }
+
+    if as_json:
+        click.echo(json.dumps(summary, indent=2))
+        return
+
+    click.echo("", err=True)
+    click.echo("─" * 60, err=True)
+    click.echo(
+        f"cognify-fanout: complete"
+        + (" (DRY RUN)" if dry_run else "")
+        + f"\n  discovered:  {result.sessions_discovered}"
+        + f"\n  processed:   {result.sessions_processed}"
+        + f"\n  skipped:     {result.sessions_skipped}"
+        + f"\n  failed:      {result.sessions_failed}"
+        + f"\n  rows:        {result.rows_emitted}"
+        + f"\n  llm calls:   {result.llm_calls}"
+        + (f"\n  failures:    {result.failure_counts}"
+           if result.failure_counts else ""),
+        err=True,
+    )
+
+
 if __name__ == "__main__":
     cli()

--- a/factory/cognify/fanout.py
+++ b/factory/cognify/fanout.py
@@ -313,6 +313,401 @@ def _clip_summary(text: str) -> str:
     return cut.rstrip() + "…"
 
 
+# ─── PR 2 additions: writer + pass registration ─────────────────────────────
+
+
+@dataclass
+class FanoutResult:
+    """Aggregate outcome of a run_fanout invocation."""
+
+    sessions_discovered: int = 0
+    sessions_processed: int = 0
+    sessions_failed: int = 0
+    sessions_skipped: int = 0       # idempotency / no-content / no-targets
+    rows_emitted: int = 0           # fan-out memory rows written
+    llm_calls: int = 0
+    failure_counts: dict = field(default_factory=dict)
+    dry_run: bool = False
+
+
+def discover_sessions_needing_fanout(
+    conn: Any,
+    *,
+    project_id: Any = None,
+    since=None,
+    limit: int | None = None,
+) -> list[str]:
+    """raw_sessions that lack any active fan-out memory row.
+
+    Discovery rule: a session "needs fan-out" when:
+      * it has at least one chunk in `devbrain.chunks` (atomized — there's
+        content for the classifier to read),
+      * AND no active memory row exists with
+        `fanout_source_session_id = rs.id`. The classifier has not yet
+        been run, or it ran and produced zero targets (in which case
+        we skip rather than re-classify — see §12.7 calibration note).
+
+    Optional filters:
+      * `project_id` scopes to sessions whose canonical project_id matches.
+      * `since` is a datetime cutoff on `raw_sessions.started_at`.
+      * `limit` caps the discover return for shard/dry-run sizing.
+    """
+    where = ["EXISTS (SELECT 1 FROM devbrain.chunks c WHERE c.source_id = rs.id)"]
+    params: list = []
+
+    if project_id is not None:
+        where.append("rs.project_id = %s")
+        params.append(project_id)
+    if since is not None:
+        where.append("rs.started_at >= %s")
+        params.append(since)
+
+    # Anti-join: skip sessions that already have a fan-out row.
+    where.append(
+        "NOT EXISTS ("
+        " SELECT 1 FROM devbrain.memory m "
+        " WHERE m.fanout_source_session_id = rs.id "
+        "   AND m.archived_at IS NULL "
+        ")"
+    )
+
+    sql = (
+        "SELECT rs.id::text "
+        "FROM devbrain.raw_sessions rs "
+        "WHERE " + " AND ".join(where) + " "
+        "ORDER BY rs.started_at DESC NULLS LAST"
+    )
+    if limit is not None:
+        sql += f" LIMIT {int(limit)}"
+
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        return [r[0] for r in cur.fetchall()]
+
+
+def apply_shard(sessions: list[str], shard: tuple[int, int] | None) -> list[str]:
+    """Stride-slice for parallel runs. shard=(N, M) returns sessions where
+    index % M == N. Mirrors cognify-bulk's apply_shard so the operator
+    mental model is consistent.
+    """
+    if shard is None:
+        return sessions
+    n, m = shard
+    if m <= 0 or not (0 <= n < m):
+        raise ValueError(f"shard must be (N, M) with 0 <= N < M; got {shard}")
+    return [s for i, s in enumerate(sessions) if i % m == n]
+
+
+def _insert_fanout_row(
+    conn: Any,
+    *,
+    project_id_target: Any,
+    source_session_id: str,
+    classification: ProjectClassification,
+    embedding: list[float] | None,
+) -> str | None:
+    """Insert one fan-out memory row. Returns the new row's id, or None on
+    a DO NOTHING collision (already present — idempotent re-run).
+
+    Inheritance: compliance_profiles are pulled from the TARGET project
+    so cross-project rule isolation holds (§12 design decision #4).
+    """
+    # Title = "<project_slug> session: <date> · <relevance>"
+    # Short, scannable in deep_search results. The content holds the
+    # focused_summary itself.
+    title = f"Cross-project session ({classification.session_relevance:.2f})"
+
+    # Pull target project's compliance_profiles. The projects table stores
+    # the per-project allowlist as `compliance_profiles_enabled` (text[]);
+    # we propagate that array onto the fan-out row's compliance_profiles
+    # column so cross-project rule isolation holds (§12 design decision #4).
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT compliance_profiles_enabled FROM devbrain.projects "
+            "WHERE id = %s",
+            (project_id_target,),
+        )
+        row = cur.fetchone()
+    target_profiles = (row[0] if row else None) or []
+
+    # applies_when records the per-fan-out metadata for traceability.
+    applies_when = {
+        "fanout_source_session": source_session_id,
+        "session_relevance": classification.session_relevance,
+        "section_count": classification.section_count,
+        "source_pass": "cognify_fanout",
+    }
+
+    cols = [
+        "project_id", "kind", "title", "content", "tier", "strength",
+        "applies_when", "fanout_source_session_id", "compliance_profiles",
+    ]
+    vals: list = [
+        project_id_target, "session_summary", title,
+        classification.focused_summary, "memory", 1.0,
+        _json_dumps(applies_when), source_session_id, target_profiles,
+    ]
+    placeholders = ["%s"] * len(cols)
+
+    if embedding is not None:
+        cols.insert(4, "embedding")
+        vals.insert(4, embedding)
+        placeholders.insert(4, "%s::vector")
+
+    # ON CONFLICT must repeat the partial index predicate verbatim
+    # (Postgres requires matching the inference clause for partial
+    # unique indexes).
+    sql = (
+        "INSERT INTO devbrain.memory (" + ", ".join(cols) + ") "
+        "VALUES (" + ", ".join(placeholders) + ") "
+        "ON CONFLICT (fanout_source_session_id, project_id) "
+        "  WHERE kind = 'session_summary' "
+        "    AND tier = 'memory' "
+        "    AND archived_at IS NULL "
+        "    AND fanout_source_session_id IS NOT NULL "
+        "  DO NOTHING "
+        "RETURNING id"
+    )
+    with conn.cursor() as cur:
+        cur.execute(sql, vals)
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def _resolve_project_id_by_slug(conn: Any, slug: str) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.projects WHERE slug = %s",
+            (slug,),
+        )
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def _embed_summary(text: str) -> list[float] | None:
+    """Compute an embedding for the focused summary via Ollama.
+
+    Returns None if Ollama is unreachable — the fan-out row is still
+    written (sans embedding) so search via metadata/title still works;
+    a subsequent `cognify reembed` pass can backfill the vector.
+    """
+    try:
+        import json
+        import urllib.request
+        # Re-resolve config at call-time so test envs can monkeypatch.
+        try:
+            from ingest.config import OLLAMA_URL, EMBED_MODEL  # noqa: PLC0415
+        except ImportError:
+            # Fallback: ingest package not on path (shouldn't happen under
+            # devbrain's standard installs, but be tolerant in CI).
+            import os  # noqa: PLC0415
+            OLLAMA_URL = os.environ.get("DEVBRAIN_OLLAMA_URL", "http://localhost:11434")
+            EMBED_MODEL = os.environ.get("DEVBRAIN_EMBEDDING_MODEL", "snowflake-arctic-embed2")
+        data = json.dumps({"model": EMBED_MODEL, "input": text}).encode()
+        req = urllib.request.Request(
+            f"{OLLAMA_URL}/api/embed",
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read())
+        return payload["embeddings"][0]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("cognify_fanout: embedding failed (%s); writing row without vector", exc)
+        return None
+
+
+def _json_dumps(obj: dict) -> str:
+    import json
+    return json.dumps(obj, default=str)
+
+
+def run_fanout(
+    conn: Any,
+    *,
+    project_id: Any = None,
+    since=None,
+    model: str = DEFAULT_MODEL,
+    dry_run: bool = False,
+    shard: tuple[int, int] | None = None,
+    max_sessions: int | None = None,
+    progress_callback=None,
+) -> FanoutResult:
+    """Run the Phase 8 cross-project fan-out pass.
+
+    For each discovered raw_session:
+      1. Classify via the LLM (one call) into per-project relevance + summary.
+      2. For each per_project entry, write a `kind='session_summary'`
+         memory row into the target project with `fanout_source_session_id`
+         set. Compliance profiles inherited from the target.
+      3. Record spend in `cognify_spend_log` (one row per classifier call).
+
+    Idempotency: the (fanout_source_session_id, project_id) partial unique
+    index from migration 039 collapses re-emissions into DO NOTHING.
+
+    No `memory_dependencies` edges are emitted today. The
+    `fanout_source_session_id` FK column is the linkage; an explicit
+    `derived_from` edge would only be valuable for multi-hop graph
+    walks, which can be added later without changing this writer.
+
+    Returns FanoutResult with counts. ``dry_run=True`` walks discovery
+    + reports counts but skips the LLM call and DB writes.
+    """
+    from observability.spend import record_spend  # noqa: PLC0415
+    from observability.pricing import (  # noqa: PLC0415
+        get_pricing, compute_cost_usd, SONNET_4_6,
+    )
+
+    result = FanoutResult(dry_run=dry_run)
+
+    sessions = discover_sessions_needing_fanout(
+        conn, project_id=project_id, since=since, limit=max_sessions,
+    )
+    sessions = apply_shard(sessions, shard)
+    result.sessions_discovered = len(sessions)
+
+    if dry_run or not sessions:
+        return result
+
+    pricing = get_pricing(model) or SONNET_4_6
+
+    for idx, session_id in enumerate(sessions, start=1):
+        try:
+            classification = classify_session(session_id, conn, model=model)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("cognify_fanout: classify_session raised on %s", session_id)
+            result.sessions_failed += 1
+            result.failure_counts["exception"] = result.failure_counts.get("exception", 0) + 1
+            if progress_callback:
+                progress_callback(idx, len(sessions), {
+                    "session_id": session_id, "failure": "exception", "rows": 0,
+                })
+            continue
+
+        # Spend tracking — record even on per-project=empty results since
+        # the LLM call happened. Skip when classifier short-circuited
+        # before the API call (no_taxonomy/no_session/no_content/no_auth).
+        usage = classification.usage
+        if any(usage.get(k, 0) for k in ("input_tokens", "output_tokens")):
+            cost = compute_cost_usd(
+                pricing,
+                input_tokens=usage.get("input_tokens", 0),
+                output_tokens=usage.get("output_tokens", 0),
+                cache_read_tokens=usage.get("cache_read_tokens", 0),
+                cache_write_tokens=usage.get("cache_write_tokens", 0),
+            )
+            try:
+                record_spend(
+                    conn,
+                    project_id=project_id,
+                    pass_name="fanout",
+                    model=model,
+                    input_tokens=usage.get("input_tokens", 0),
+                    output_tokens=usage.get("output_tokens", 0),
+                    cache_read_tokens=usage.get("cache_read_tokens", 0),
+                    cache_write_tokens=usage.get("cache_write_tokens", 0),
+                    cost_usd=cost,
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("cognify_fanout: record_spend failed on %s", session_id)
+
+            result.llm_calls += 1
+
+        if classification.failure:
+            if classification.failure == "empty":
+                # Empty → the classifier ran but no target cleared 0.30.
+                # Count as skipped, not failed (no rework needed; the
+                # session legitimately doesn't fan out).
+                result.sessions_skipped += 1
+            else:
+                result.sessions_failed += 1
+                key = classification.failure
+                result.failure_counts[key] = result.failure_counts.get(key, 0) + 1
+            if progress_callback:
+                progress_callback(idx, len(sessions), {
+                    "session_id": session_id,
+                    "failure": classification.failure,
+                    "rows": 0,
+                })
+            continue
+
+        # Happy path: write fan-out rows.
+        rows_for_session = 0
+        for pc in classification.per_project:
+            target_pid = _resolve_project_id_by_slug(conn, pc.project_slug)
+            if not target_pid:
+                # Project was in taxonomy at classification time but
+                # disappeared between then and write (rare). Skip rather
+                # than crash.
+                logger.warning(
+                    "cognify_fanout: target project %r vanished mid-run; skip",
+                    pc.project_slug,
+                )
+                continue
+            embedding = _embed_summary(pc.focused_summary)
+            new_id = _insert_fanout_row(
+                conn,
+                project_id_target=target_pid,
+                source_session_id=session_id,
+                classification=pc,
+                embedding=embedding,
+            )
+            if new_id is not None:
+                rows_for_session += 1
+
+        conn.commit()
+        result.sessions_processed += 1
+        result.rows_emitted += rows_for_session
+
+        if progress_callback:
+            progress_callback(idx, len(sessions), {
+                "session_id": session_id,
+                "rows": rows_for_session,
+                "failure": None,
+            })
+
+    return result
+
+
+# ─── Pass registration (orchestrator framework) ─────────────────────────────
+
+
+def _register_fanout_pass() -> None:
+    """Late-binding registration with the cognify orchestrator.
+
+    Imported lazily by orchestrator._ensure_registry() so the import
+    graph stays acyclic.
+    """
+    from cognify.orchestrator import CognifyPass, PassResult, register_pass
+
+    @register_pass
+    class FanoutPass(CognifyPass):
+        pass_name = "fanout"
+
+        def run(
+            self, conn, project_id, *, dry_run: bool = False,
+        ) -> "PassResult":
+            res = run_fanout(conn, project_id=project_id, dry_run=dry_run)
+            return PassResult(
+                rows_processed=res.rows_emitted,
+                llm_calls=res.llm_calls,
+                metadata={
+                    "pass": "fanout",
+                    "sessions_discovered": res.sessions_discovered,
+                    "sessions_processed": res.sessions_processed,
+                    "sessions_failed": res.sessions_failed,
+                    "sessions_skipped": res.sessions_skipped,
+                    "failure_counts": res.failure_counts,
+                },
+                dry_run=dry_run,
+            )
+
+    return FanoutPass
+
+
+_register_fanout_pass()
+
+
 # Re-export thresholds at module level for callers/tests that want to
 # assert against the locked spec without reaching into fanout_prompt.
 __all__ = [
@@ -321,5 +716,9 @@ __all__ = [
     "DEFAULT_MODEL",
     "ProjectClassification",
     "ClassificationResult",
+    "FanoutResult",
     "classify_session",
+    "run_fanout",
+    "discover_sessions_needing_fanout",
+    "apply_shard",
 ]

--- a/factory/cognify/launchd/com.devbrain.cognify-fanout.plist
+++ b/factory/cognify/launchd/com.devbrain.cognify-fanout.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- cognify_fanout: cross-project fan-out classifier (Phase 8).        -->
+<!-- Every 60 min: discovers sessions lacking active fan-out rows,      -->
+<!-- runs the LLM classifier, writes per-project focused-summary rows.  -->
+<!-- Idempotent via the partial unique on                               -->
+<!-- (memory.fanout_source_session_id, project_id).                     -->
+<!-- Placeholders ${DEVBRAIN_HOME}, ${USER}, and the credential-env     -->
+<!-- marker are substituted by `devbrain setup-cognify-launchd`.        -->
+<!-- Note: fan-out is global (no --project arg) — the classifier picks  -->
+<!-- targets per-session from the taxonomy.                             -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.devbrain.cognify-fanout</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>${DEVBRAIN_HOME}/.venv/bin/python</string>
+        <string>${DEVBRAIN_HOME}/factory/cli.py</string>
+        <string>cognify</string>
+        <string>--pass=fanout</string>
+    </array>
+
+    <!-- Run every 60 min. Cadence intentionally slower than          -->
+    <!-- cognify_extract (30 min) so fan-out always runs against     -->
+    <!-- settled atom state.                                          -->
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>DEVBRAIN_HOME</key>
+        <string>${DEVBRAIN_HOME}</string>
+        <key>PYTHONPATH</key>
+        <string>${DEVBRAIN_HOME}/factory</string>
+        <!-- @CREDENTIAL_ENV_BLOCK@ — installer emits ANTHROPIC_API_KEY  -->
+        <!-- or CLAUDE_CODE_OAUTH_TOKEN here based on env at install     -->
+        <!-- time.                                                       -->
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>${DEVBRAIN_HOME}/factory</string>
+
+    <key>StandardOutPath</key>
+    <string>/Users/${USER}/.devbrain/logs/cognify-fanout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/${USER}/.devbrain/logs/cognify-fanout.err</string>
+
+    <key>ThrottleInterval</key>
+    <integer>300</integer>
+</dict>
+</plist>

--- a/factory/cognify/orchestrator.py
+++ b/factory/cognify/orchestrator.py
@@ -98,6 +98,7 @@ def _ensure_registry() -> None:
     from cognify import extract as _  # noqa: F401
     from cognify import edges as _  # noqa: F401
     from cognify import strengthen as _  # noqa: F401
+    from cognify import fanout as _  # noqa: F401  # Phase 8 fan-out
 
 
 def register_pass(cls: type[CognifyPass]) -> type[CognifyPass]:
@@ -109,7 +110,7 @@ def register_pass(cls: type[CognifyPass]) -> type[CognifyPass]:
 
 # ── Dependency order ──────────────────────────────────────────────────────
 
-PASS_ORDER = ["decay", "gc", "extract", "edges", "strengthen"]
+PASS_ORDER = ["decay", "gc", "extract", "edges", "strengthen", "fanout"]
 
 
 # ── Main entrypoints ──────────────────────────────────────────────────────

--- a/factory/tests/test_cognify_fanout_pass.py
+++ b/factory/tests/test_cognify_fanout_pass.py
@@ -1,0 +1,331 @@
+"""Tests for cognify_fanout PR 2 — writer + CLI + pass registration.
+
+Most tests use a live DB + a monkeypatched classifier so we exercise
+the real INSERT path / partial unique idempotency seal without
+spending on LLM calls.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import psycopg2
+import pytest
+
+_FACTORY = Path(__file__).resolve().parents[1]
+if str(_FACTORY) not in sys.path:
+    sys.path.insert(0, str(_FACTORY))
+
+
+# ─── apply_shard: pure unit ─────────────────────────────────────────────────
+
+
+def test_apply_shard_none_passthrough():
+    from cognify.fanout import apply_shard
+    sessions = ["a", "b", "c", "d", "e"]
+    assert apply_shard(sessions, None) == sessions
+
+
+def test_apply_shard_splits_evenly():
+    from cognify.fanout import apply_shard
+    sessions = ["a", "b", "c", "d", "e", "f"]
+    s0 = apply_shard(sessions, (0, 3))
+    s1 = apply_shard(sessions, (1, 3))
+    s2 = apply_shard(sessions, (2, 3))
+    assert s0 == ["a", "d"]
+    assert s1 == ["b", "e"]
+    assert s2 == ["c", "f"]
+    # Union covers every session, no overlap.
+    assert sorted(s0 + s1 + s2) == sorted(sessions)
+
+
+def test_apply_shard_rejects_bad_args():
+    from cognify.fanout import apply_shard
+    with pytest.raises(ValueError):
+        apply_shard(["a"], (2, 2))  # N == M
+    with pytest.raises(ValueError):
+        apply_shard(["a"], (-1, 3))
+
+
+# ─── Live-DB fixtures ───────────────────────────────────────────────────────
+
+
+def _live_conn():
+    from config import DATABASE_URL  # noqa: PLC0415
+    return psycopg2.connect(DATABASE_URL)
+
+
+@pytest.fixture
+def live_db():
+    if not os.environ.get("DEVBRAIN_DB_PASSWORD") and not os.environ.get("DEVBRAIN_TEST_DATABASE_URL"):
+        pytest.skip("DB not configured for tests")
+    try:
+        conn = _live_conn()
+    except Exception as exc:
+        pytest.skip(f"live DB unavailable: {exc}")
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def synth_session(live_db):
+    """Create a raw_session + one chunk for fan-out tests. Tears down on exit."""
+    with live_db.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM devbrain.projects WHERE slug NOT LIKE 'home-%' "
+            "ORDER BY slug LIMIT 1"
+        )
+        row = cur.fetchone()
+        if row is None:
+            pytest.skip("no projects in DB")
+        canonical_project_id = row[0]
+
+        cur.execute(
+            """
+            INSERT INTO devbrain.raw_sessions
+                (id, project_id, source_app, source_path, source_hash,
+                 session_id, started_at, raw_content)
+            VALUES (gen_random_uuid(), %s, 'test', '/tmp/synthetic',
+                    'test-hash-' || extract(epoch from now())::text,
+                    'fanout-test', now(),
+                    'Synthetic session content for fan-out tests.')
+            RETURNING id
+            """,
+            (canonical_project_id,),
+        )
+        session_id = cur.fetchone()[0]
+
+        cur.execute(
+            """
+            INSERT INTO devbrain.chunks
+                (project_id, source_type, source_id, content)
+            VALUES (%s, 'session_summary', %s,
+                    'Synthetic session content for fan-out tests')
+            """,
+            (canonical_project_id, session_id),
+        )
+        live_db.commit()
+
+    yield {
+        "session_id": str(session_id),
+        "canonical_project_id": str(canonical_project_id),
+    }
+
+    with live_db.cursor() as cur:
+        # Cascade-clean: chunks + fan-out memory rows + the raw_session row.
+        cur.execute(
+            "DELETE FROM devbrain.memory "
+            "WHERE fanout_source_session_id = %s",
+            (session_id,),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.chunks WHERE source_id = %s",
+            (session_id,),
+        )
+        cur.execute(
+            "DELETE FROM devbrain.raw_sessions WHERE id = %s",
+            (session_id,),
+        )
+        live_db.commit()
+
+
+# ─── discover_sessions_needing_fanout ────────────────────────────────────────
+
+
+def test_discover_finds_new_atomized_session(live_db, synth_session):
+    from cognify.fanout import discover_sessions_needing_fanout
+
+    ids = discover_sessions_needing_fanout(live_db)
+    assert synth_session["session_id"] in ids
+
+
+def test_discover_skips_session_with_existing_fanout_row(live_db, synth_session):
+    """After a fan-out row exists, discover excludes that session."""
+    from cognify.fanout import discover_sessions_needing_fanout
+
+    sess_id = synth_session["session_id"]
+    target_pid = synth_session["canonical_project_id"]
+
+    # Plant a fan-out row directly.
+    with live_db.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO devbrain.memory
+                (project_id, kind, title, content, tier, strength,
+                 fanout_source_session_id)
+            VALUES (%s, 'session_summary', 'plant', 'plant', 'memory', 1.0, %s)
+            """,
+            (target_pid, sess_id),
+        )
+        live_db.commit()
+
+    ids = discover_sessions_needing_fanout(live_db)
+    assert sess_id not in ids
+
+
+# ─── run_fanout: end-to-end with mocked classifier ───────────────────────────
+
+
+def _stub_classification(session_id, conn, **kwargs):
+    """Returns a fixed two-target classification — used to test the writer
+    without spending on LLM calls."""
+    from cognify.fanout import ClassificationResult, ProjectClassification
+
+    # Pick two distinct projects from the live taxonomy.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT slug FROM devbrain.projects WHERE slug NOT LIKE 'home-%' "
+            "ORDER BY slug LIMIT 2"
+        )
+        slugs = [r[0] for r in cur.fetchall()]
+    if len(slugs) < 2:
+        pytest.skip("need ≥2 non-home projects in DB for two-target test")
+
+    return ClassificationResult(
+        session_id=session_id,
+        per_project=[
+            ProjectClassification(
+                project_slug=slugs[0],
+                session_relevance=0.85,
+                section_count=4,
+                focused_summary=(
+                    "Synthetic summary A — long enough to look real. "
+                    * 8
+                ),
+            ),
+            ProjectClassification(
+                project_slug=slugs[1],
+                session_relevance=0.45,
+                section_count=2,
+                focused_summary=(
+                    "Synthetic summary B — also long enough. " * 8
+                ),
+            ),
+        ],
+        sections=[],
+        usage={
+            "input_tokens": 1000,
+            "output_tokens": 200,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        },
+        failure=None,
+    )
+
+
+def test_run_fanout_writes_per_project_rows(live_db, synth_session):
+    from cognify import fanout as fanout_mod
+
+    with patch.object(fanout_mod, "classify_session", _stub_classification), \
+         patch.object(fanout_mod, "_embed_summary", lambda _t: None):
+        result = fanout_mod.run_fanout(
+            live_db, max_sessions=10,
+        )
+
+    sess_id = synth_session["session_id"]
+    with live_db.cursor() as cur:
+        cur.execute(
+            "SELECT project_id, kind, content FROM devbrain.memory "
+            "WHERE fanout_source_session_id = %s "
+            "ORDER BY project_id",
+            (sess_id,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 2, f"expected 2 fan-out rows, got {len(rows)}"
+    assert all(r[1] == "session_summary" for r in rows)
+    assert result.sessions_processed >= 1
+    assert result.rows_emitted >= 2
+    # llm_calls reflects every session run_fanout touched (our synthetic
+    # plus any other live sessions max_sessions covers); just confirm
+    # at least one happened.
+    assert result.llm_calls >= 1
+
+
+def test_run_fanout_idempotent_rerun(live_db, synth_session):
+    """Re-running fan-out on the same session emits no new rows."""
+    from cognify import fanout as fanout_mod
+
+    with patch.object(fanout_mod, "classify_session", _stub_classification), \
+         patch.object(fanout_mod, "_embed_summary", lambda _t: None):
+        # First run writes 2 rows.
+        result_1 = fanout_mod.run_fanout(live_db, max_sessions=10)
+        # Second run discovers nothing (session already has fan-out rows).
+        result_2 = fanout_mod.run_fanout(live_db, max_sessions=10)
+
+    sess_id = synth_session["session_id"]
+    with live_db.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.memory "
+            "WHERE fanout_source_session_id = %s",
+            (sess_id,),
+        )
+        count = cur.fetchone()[0]
+    assert count == 2  # unchanged
+    assert result_2.sessions_discovered <= result_1.sessions_discovered
+    # The session shouldn't appear in run 2's discovery at all.
+    from cognify.fanout import discover_sessions_needing_fanout
+    assert sess_id not in discover_sessions_needing_fanout(live_db)
+
+
+def test_run_fanout_dry_run_writes_nothing(live_db, synth_session):
+    from cognify import fanout as fanout_mod
+
+    with patch.object(fanout_mod, "classify_session", _stub_classification):
+        result = fanout_mod.run_fanout(live_db, max_sessions=10, dry_run=True)
+
+    sess_id = synth_session["session_id"]
+    with live_db.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.memory "
+            "WHERE fanout_source_session_id = %s",
+            (sess_id,),
+        )
+        count = cur.fetchone()[0]
+    assert count == 0
+    assert result.dry_run is True
+    assert result.sessions_processed == 0
+    assert result.rows_emitted == 0
+
+
+def test_run_fanout_propagates_classifier_failure(live_db, synth_session):
+    """A classifier 'empty' failure counts as skipped, not failed."""
+    from cognify import fanout as fanout_mod
+    from cognify.fanout import ClassificationResult
+
+    def stub_empty(sess_id, conn, **kw):
+        return ClassificationResult(
+            session_id=sess_id,
+            per_project=[],
+            failure="empty",
+            usage={
+                "input_tokens": 500, "output_tokens": 50,
+                "cache_read_tokens": 0, "cache_write_tokens": 0,
+            },
+        )
+
+    with patch.object(fanout_mod, "classify_session", stub_empty), \
+         patch.object(fanout_mod, "_embed_summary", lambda _t: None):
+        result = fanout_mod.run_fanout(live_db, max_sessions=10)
+
+    assert result.sessions_skipped >= 1
+    # And no fan-out rows were written for this session.
+    sess_id = synth_session["session_id"]
+    with live_db.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.memory "
+            "WHERE fanout_source_session_id = %s",
+            (sess_id,),
+        )
+        assert cur.fetchone()[0] == 0
+
+
+# ─── Orchestrator registration ──────────────────────────────────────────────
+
+
+def test_fanout_pass_registered_with_orchestrator():
+    from cognify.orchestrator import _ensure_registry, _PASS_REGISTRY
+    _ensure_registry()
+    assert "fanout" in _PASS_REGISTRY


### PR DESCRIPTION
## Summary
PR 2 of 3 for Phase 8. Builds on PR #156's foundation: adds the writer that calls \`classify_session()\`, inserts per-project session_summary rows with \`fanout_source_session_id\` set, records LLM spend, and skips sessions with existing fan-out rows (idempotent via migration 039's partial unique index).

Spec: \`docs/plans/2026-05-11-phase-8-cross-project-fan-out-design.md\` §12

## What ships
- \`factory/cognify/fanout.py\` — \`discover_sessions_needing_fanout\`, \`apply_shard\`, \`_insert_fanout_row\`, \`_embed_summary\` (Ollama, fails open), \`run_fanout\` writer, \`FanoutPass\` (orchestrator-registered)
- \`factory/cognify/orchestrator.py\` — fanout in import graph + PASS_ORDER
- \`factory/cognify/launchd/com.devbrain.cognify-fanout.plist\` — 60-min cadence (slower than \`cognify_extract\`'s 30 min so fan-out runs against settled atom state)
- \`factory/cli.py\` — \`bin/devbrain cognify-fanout\` top-level command (\`--project\` / \`--since\` / \`--max-sessions\` / \`--shard N/M\` / \`--model\` / \`--dry-run\` / \`--json\`)

## Notable design choices
- **No \`derived_from\` edges emitted today.** \`memory.fanout_source_session_id\` IS the linkage; an explicit edge would only matter for multi-hop graph walks, which can be added later without changing this writer.
- **Compliance inheritance:** target project's \`compliance_profiles_enabled\` (text[]) propagates onto the fan-out row's \`compliance_profiles\` col, so cross-project rule isolation holds.
- **Spend:** recorded per LLM call with \`pass_name='fanout'\` so the dashboard cognify panel picks it up naturally.

## Test plan
- [x] \`pytest factory/tests/test_cognify_fanout_pass.py\` — 10/10 (apply_shard ×3 + discover ×2 + run_fanout ×4 + pass-registration ×1)
- [x] \`pytest factory/tests/test_cognify_fanout_foundation.py\` — 16/16 (PR 1 still green)
- [x] \`pytest -k "cognify or dashboard or curator_end_session or invitations or onboarding"\` — 322 passed, no regressions
- [x] \`bin/devbrain cognify-fanout --dry-run\` against live laptop devbrain → 3015 sessions discovered (matches the all-time backfill scope PR 3 will process)

## Deploy notes
After merge, install the launchd plist via the existing \`bin/devbrain setup-cognify-launchd\` flow (it'll pick up the new plist template from \`factory/cognify/launchd/\`). The plist is a template — \${DEVBRAIN_HOME}/\${USER}/credential-env block get substituted at install time. **PR 3 will run the actual backfill**; this PR ships the substrate to do so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)