### PR TITLE
feat(cognify): Phase 8 PR 3 — all-time backfill orchestrator + 4 postulates

### DIFF
--- a/scripts/backfill_fanout_all_time.sh
+++ b/scripts/backfill_fanout_all_time.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Phase 8 PR 3 — all-time fan-out backfill orchestrator.
+#
+# Spawns N parallel `devbrain cognify-fanout --shard=I/N` workers, each
+# processing a deterministic stride of the discovered-sessions list, so
+# the ~3,000-session all-time backfill finishes in roughly 1/N the
+# wall-clock time of a single-worker run.
+#
+# The underlying cognify-fanout command is idempotent (migration 039's
+# partial unique index collapses re-emissions), so this script is safe
+# to re-run on partial completion / interruption.
+#
+# Usage:
+#   scripts/backfill_fanout_all_time.sh [--workers N] [--model MODEL]
+#                                       [--dry-run] [--since YYYY-MM-DD]
+#
+# Examples:
+#   scripts/backfill_fanout_all_time.sh                          # 4 workers default
+#   scripts/backfill_fanout_all_time.sh --workers 8              # heavier parallelism
+#   scripts/backfill_fanout_all_time.sh --dry-run                # size scope only
+#   scripts/backfill_fanout_all_time.sh --model claude-opus-4-7  # opus retry pass
+#
+# Logs land at ~/.devbrain/logs/fanout-backfill-<timestamp>-shard-N.log
+# A summary JSON is written to ~/.devbrain/logs/fanout-backfill-<timestamp>.json
+# after every worker exits.
+
+set -euo pipefail
+
+WORKERS=4
+MODEL=""
+SINCE=""
+DRY_RUN=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workers) WORKERS="$2"; shift 2 ;;
+    --model)   MODEL="$2"; shift 2 ;;
+    --since)   SINCE="$2"; shift 2 ;;
+    --dry-run) DRY_RUN="--dry-run"; shift ;;
+    -h|--help)
+      sed -n '2,30p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! [[ "$WORKERS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: --workers must be a positive integer; got '$WORKERS'" >&2
+  exit 2
+fi
+
+LOG_DIR="${HOME}/.devbrain/logs"
+mkdir -p "$LOG_DIR"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+SUMMARY_JSON="${LOG_DIR}/fanout-backfill-${TIMESTAMP}.json"
+
+# Resolve bin/devbrain — caller may invoke from anywhere.
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+DEVBRAIN_BIN="${REPO_ROOT}/bin/devbrain"
+if [[ ! -x "$DEVBRAIN_BIN" ]]; then
+  echo "Error: $DEVBRAIN_BIN not executable" >&2
+  exit 2
+fi
+
+echo "fanout-backfill: $WORKERS workers; logs at $LOG_DIR/fanout-backfill-${TIMESTAMP}-shard-*.log"
+
+declare -a PIDS
+declare -a SHARD_LOGS
+declare -a SHARD_JSON_LOGS
+
+for ((i=0; i<WORKERS; i++)); do
+  SHARD_LOG="${LOG_DIR}/fanout-backfill-${TIMESTAMP}-shard-${i}.log"
+  SHARD_JSON="${LOG_DIR}/fanout-backfill-${TIMESTAMP}-shard-${i}.json"
+  SHARD_LOGS+=("$SHARD_LOG")
+  SHARD_JSON_LOGS+=("$SHARD_JSON")
+
+  ARGS=(cognify-fanout --shard "${i}/${WORKERS}" --json)
+  if [[ -n "$MODEL" ]]; then
+    ARGS+=(--model "$MODEL")
+  fi
+  if [[ -n "$SINCE" ]]; then
+    ARGS+=(--since "$SINCE")
+  fi
+  if [[ -n "$DRY_RUN" ]]; then
+    ARGS+=("$DRY_RUN")
+  fi
+
+  # The CLI emits per-session progress to stderr and the summary JSON
+  # to stdout. We capture both: stderr → live log, stdout → json file.
+  ( "$DEVBRAIN_BIN" "${ARGS[@]}" 2>"$SHARD_LOG" >"$SHARD_JSON" ) &
+  PIDS+=("$!")
+  echo "fanout-backfill: spawned shard $i/${WORKERS} pid=${PIDS[-1]}"
+done
+
+# Wait for all shards. Capture exit codes.
+declare -a EXITS
+FAILED=0
+for ((i=0; i<WORKERS; i++)); do
+  if wait "${PIDS[$i]}"; then
+    EXITS+=("0")
+  else
+    EXITS+=("$?")
+    FAILED=1
+    echo "fanout-backfill: shard $i exited non-zero (see ${SHARD_LOGS[$i]})" >&2
+  fi
+done
+
+# Aggregate the per-shard JSON summaries into one combined file. Each
+# shard wrote a top-level object with sessions_* / rows_emitted /
+# llm_calls / failure_counts / dry_run. We sum the numeric fields and
+# merge the failure_counts maps.
+python3 - "$SUMMARY_JSON" "${SHARD_JSON_LOGS[@]}" <<'PYEOF'
+import json
+import sys
+
+out_path = sys.argv[1]
+shard_paths = sys.argv[2:]
+
+agg = {
+    "sessions_discovered": 0,
+    "sessions_processed":  0,
+    "sessions_failed":     0,
+    "sessions_skipped":    0,
+    "rows_emitted":        0,
+    "llm_calls":           0,
+    "failure_counts":      {},
+    "shards":              len(shard_paths),
+    "shard_paths":         shard_paths,
+}
+dry_run_any = False
+
+for p in shard_paths:
+    try:
+        with open(p) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        agg.setdefault("read_errors", []).append({"path": p, "error": str(exc)})
+        continue
+    for k in (
+        "sessions_discovered", "sessions_processed", "sessions_failed",
+        "sessions_skipped", "rows_emitted", "llm_calls",
+    ):
+        agg[k] += int(data.get(k, 0) or 0)
+    for fk, fv in (data.get("failure_counts") or {}).items():
+        agg["failure_counts"][fk] = agg["failure_counts"].get(fk, 0) + int(fv)
+    if data.get("dry_run"):
+        dry_run_any = True
+
+agg["dry_run"] = dry_run_any
+
+with open(out_path, "w") as f:
+    json.dump(agg, f, indent=2)
+
+# Print the summary so the shell wrapper can echo it too.
+print(json.dumps(agg, indent=2))
+PYEOF
+
+echo ""
+echo "fanout-backfill: summary written to $SUMMARY_JSON"
+
+exit $FAILED

--- a/tests/postulates/test_p_fanout_home_project_excluded_as_target.py
+++ b/tests/postulates/test_p_fanout_home_project_excluded_as_target.py
@@ -1,0 +1,35 @@
+"""P_fanout_home_project_excluded_as_target: home-* projects never
+appear in the classifier's taxonomy (they're canonical-only fallbacks,
+not fan-out targets).
+
+Per §12 design A3, home projects exist so dev-attribution-less sessions
+have somewhere to live as canonical. They are NOT discoverable subjects
+of cross-project discussion — fanning OUT into a home project would be
+a degenerate self-reference for sessions that already canonical-own
+that home project, and noise for any other session.
+
+Enforcement: _load_active_taxonomy in factory/cognify/fanout.py adds
+`AND slug NOT LIKE 'home-%'` to the projects SELECT.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.db
+def test_p_fanout_home_project_excluded_as_target(conn):
+    """The taxonomy fetcher excludes every home-* project."""
+    from cognify.fanout import _load_active_taxonomy
+
+    taxonomy = _load_active_taxonomy(conn)
+    slugs = [p["slug"] for p in taxonomy]
+
+    # No home-* in classifier targets.
+    home_slugs = [s for s in slugs if s.startswith("home-")]
+    assert home_slugs == [], (
+        f"home-* projects must not be fan-out targets; found: {home_slugs}"
+    )
+
+    # Sanity: at least one real project exists (otherwise the test is
+    # vacuously true and would mask a regression).
+    assert len(slugs) > 0, "expected at least one non-home project in taxonomy"

--- a/tests/postulates/test_p_fanout_idempotent.py
+++ b/tests/postulates/test_p_fanout_idempotent.py
@@ -1,0 +1,103 @@
+"""P_fanout_idempotent: running cognify_fanout twice on the same
+session produces no duplicate fan-out rows.
+
+The partial unique index from migration 039
+(idx_memory_fanout_unique on (fanout_source_session_id, project_id))
+is the enforcement; this test is the verification that the index +
+the writer's ON CONFLICT DO NOTHING clause cooperate correctly.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.db
+def test_p_fanout_idempotent(conn, project_factory, request):
+    proj_canonical = project_factory("p_fidem_c")
+    proj_target = project_factory("p_fidem_t")
+
+    session_id = str(uuid.uuid4())
+
+    def _cleanup_session():
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM devbrain.cognify_spend_log "
+                "WHERE project_id IN (%s, %s)",
+                (proj_canonical["id"], proj_target["id"]),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.memory WHERE fanout_source_session_id = %s",
+                (session_id,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.chunks WHERE source_id = %s",
+                (session_id,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.raw_sessions WHERE id = %s",
+                (session_id,),
+            )
+        conn.commit()
+    request.addfinalizer(_cleanup_session)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO devbrain.raw_sessions
+                (id, project_id, source_app, source_path, source_hash,
+                 session_id, raw_content, started_at)
+            VALUES (%s, %s, 'test', '/tmp/p-fidem', %s, 'fidem',
+                    'content', now())
+            """,
+            (session_id, proj_canonical["id"], f"hash-{uuid.uuid4().hex}"),
+        )
+        cur.execute(
+            """
+            INSERT INTO devbrain.chunks
+                (project_id, source_type, source_id, content)
+            VALUES (%s, 'session_summary', %s, 'fidem chunk')
+            """,
+            (proj_canonical["id"], session_id),
+        )
+    conn.commit()
+
+    from cognify import fanout as fanout_mod
+    from cognify.fanout import ClassificationResult, ProjectClassification
+
+    def stub(sess_id, _conn, **_kw):
+        return ClassificationResult(
+            session_id=sess_id,
+            per_project=[ProjectClassification(
+                project_slug=proj_target["slug"],
+                session_relevance=0.8,
+                section_count=2,
+                focused_summary="idempotent fan-out " * 30,
+            )],
+            usage={
+                "input_tokens": 100, "output_tokens": 50,
+                "cache_read_tokens": 0, "cache_write_tokens": 0,
+            },
+        )
+
+    with patch.object(fanout_mod, "classify_session", stub), \
+         patch.object(fanout_mod, "_embed_summary", lambda _t: None):
+        fanout_mod.run_fanout(conn, project_id=proj_canonical["id"])
+        # Second run should re-discover NOTHING (the session now has an
+        # active fan-out row, so the anti-join in discover excludes it).
+        result_2 = fanout_mod.run_fanout(conn, project_id=proj_canonical["id"])
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM devbrain.memory "
+            "WHERE fanout_source_session_id = %s "
+            "  AND archived_at IS NULL",
+            (session_id,),
+        )
+        count = cur.fetchone()[0]
+
+    assert count == 1, f"expected exactly one fan-out row, got {count}"
+    # The second run should have discovered zero sessions (anti-join hit).
+    assert result_2.sessions_discovered == 0

--- a/tests/postulates/test_p_fanout_no_canonical_rewrite.py
+++ b/tests/postulates/test_p_fanout_no_canonical_rewrite.py
@@ -1,0 +1,123 @@
+"""P_fanout_no_canonical_rewrite: run_fanout never modifies
+raw_sessions.project_id on existing sessions.
+
+This invariant protects the provenance_id chains in devbrain.memory —
+thousands of atoms reference their source raw_session by id, and a
+canonical-project rewrite would break atom-to-session lineage queries
+even if the underlying session content didn't change.
+
+Spec: docs/plans/2026-05-11-phase-8-cross-project-fan-out-design.md
+§12.4 ("Canonical assignment policy"): "Existing rows: canonical stays
+put. Period. Even when classifier disagrees..."
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.db
+def test_p_fanout_no_canonical_rewrite(conn, project_factory, request):
+    """Plant a session in project A, run fan-out with a stub classifier
+    that claims it 'belongs to' project B, confirm raw_sessions.project_id
+    is unchanged."""
+    proj_a = project_factory("p_fnocr_a")
+    proj_b = project_factory("p_fnocr_b")
+
+    # Create a raw_session canonical-owned by project A.
+    session_id = str(uuid.uuid4())
+
+    def _cleanup_session():
+        # Delete the raw_session + dependent chunks BEFORE project_factory's
+        # cleanup runs — otherwise raw_sessions_project_id_fkey blocks the
+        # project DELETE. Also clean cognify_spend_log rows that run_fanout
+        # writes (FK project_id blocks project delete too).
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM devbrain.cognify_spend_log "
+                "WHERE project_id IN (%s, %s)",
+                (proj_a["id"], proj_b["id"]),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.memory WHERE fanout_source_session_id = %s",
+                (session_id,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.chunks WHERE source_id = %s",
+                (session_id,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.raw_sessions WHERE id = %s",
+                (session_id,),
+            )
+        conn.commit()
+    request.addfinalizer(_cleanup_session)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO devbrain.raw_sessions
+                (id, project_id, source_app, source_path, source_hash,
+                 session_id, raw_content, started_at)
+            VALUES (%s, %s, 'test', '/tmp/p-fnocr', %s, 'fnocr', 'content', now())
+            """,
+            (session_id, proj_a["id"], f"hash-{uuid.uuid4().hex}"),
+        )
+        # And give it a chunk so discovery picks it up.
+        cur.execute(
+            """
+            INSERT INTO devbrain.chunks
+                (project_id, source_type, source_id, content)
+            VALUES (%s, 'session_summary', %s, 'chunk for P_fnocr')
+            """,
+            (proj_a["id"], session_id),
+        )
+    conn.commit()
+
+    # Stub classifier emits a fan-out target into project B.
+    from cognify import fanout as fanout_mod
+    from cognify.fanout import (
+        ClassificationResult, ProjectClassification,
+    )
+
+    def stub(sess_id, _conn, **_kw):
+        return ClassificationResult(
+            session_id=sess_id,
+            per_project=[ProjectClassification(
+                project_slug=proj_b["slug"],
+                session_relevance=0.9,
+                section_count=3,
+                focused_summary="reassign content " * 30,
+            )],
+            usage={
+                "input_tokens": 100, "output_tokens": 50,
+                "cache_read_tokens": 0, "cache_write_tokens": 0,
+            },
+        )
+
+    with patch.object(fanout_mod, "classify_session", stub), \
+         patch.object(fanout_mod, "_embed_summary", lambda _t: None):
+        # Scope discovery to the test session by passing project_id=proj_a.
+        fanout_mod.run_fanout(conn, project_id=proj_a["id"])
+
+    # Verify: raw_sessions.project_id still proj_a.
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT project_id FROM devbrain.raw_sessions WHERE id = %s",
+            (session_id,),
+        )
+        canonical = cur.fetchone()[0]
+    assert str(canonical) == str(proj_a["id"]), (
+        f"canonical should stay {proj_a['id']}; saw {canonical}"
+    )
+    # AND the fan-out row landed in project B (writer fired).
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT project_id FROM devbrain.memory "
+            "WHERE fanout_source_session_id = %s",
+            (session_id,),
+        )
+        targets = [str(r[0]) for r in cur.fetchall()]
+    assert str(proj_b["id"]) in targets

--- a/tests/postulates/test_p_fanout_relevance_threshold_honored.py
+++ b/tests/postulates/test_p_fanout_relevance_threshold_honored.py
@@ -1,0 +1,134 @@
+"""P_fanout_relevance_threshold_honored: fan-out rows are only emitted
+when session-level relevance is >= 0.30 (the locked threshold from
+PR #121 §12.1 A1).
+
+The classifier might emit borderline entries (model occasionally
+fudges on the boundary); the defensive validator + writer must drop
+anything below the floor before it lands in devbrain.memory.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.db
+def test_p_fanout_relevance_threshold_honored(conn, project_factory, request):
+    proj_canonical = project_factory("p_frth_c")
+    proj_above = project_factory("p_frth_above")
+    proj_below = project_factory("p_frth_below")
+
+    session_id = str(uuid.uuid4())
+
+    def _cleanup_session():
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM devbrain.cognify_spend_log "
+                "WHERE project_id IN (%s, %s, %s)",
+                (proj_canonical["id"], proj_above["id"], proj_below["id"]),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.memory WHERE fanout_source_session_id = %s",
+                (session_id,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.chunks WHERE source_id = %s",
+                (session_id,),
+            )
+            cur.execute(
+                "DELETE FROM devbrain.raw_sessions WHERE id = %s",
+                (session_id,),
+            )
+        conn.commit()
+    request.addfinalizer(_cleanup_session)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO devbrain.raw_sessions
+                (id, project_id, source_app, source_path, source_hash,
+                 session_id, raw_content, started_at)
+            VALUES (%s, %s, 'test', '/tmp/p-frth', %s, 'frth',
+                    'content', now())
+            """,
+            (session_id, proj_canonical["id"], f"hash-{uuid.uuid4().hex}"),
+        )
+        cur.execute(
+            """
+            INSERT INTO devbrain.chunks
+                (project_id, source_type, source_id, content)
+            VALUES (%s, 'session_summary', %s, 'frth chunk')
+            """,
+            (proj_canonical["id"], session_id),
+        )
+    conn.commit()
+
+    # The classifier raw output: one above-threshold, one below. The
+    # fanout writer should drop the below one. We patch *_parse_json_with_fallbacks*
+    # to bypass the model and feed the validator the raw mixture directly.
+    from cognify import fanout as fanout_mod
+
+    raw_parsed = {
+        "sections": [],
+        "per_project": [
+            {
+                "project_slug": proj_above["slug"],
+                "session_relevance": 0.5,
+                "section_count": 2,
+                "focused_summary": "above threshold " * 30,
+            },
+            {
+                "project_slug": proj_below["slug"],
+                "session_relevance": 0.20,   # below 0.30 floor
+                "section_count": 1,
+                "focused_summary": "below threshold " * 30,
+            },
+        ],
+    }
+
+    # Stub at the classify_session level — the validator runs inside
+    # classify_session, so feed it through there.
+    from cognify.fanout import ClassificationResult, ProjectClassification
+    from cognify.fanout_prompt import validate_output
+
+    valid_slugs = {proj_above["slug"], proj_below["slug"]}
+    validated = validate_output(raw_parsed, valid_slugs)
+    # Sanity: validator dropped the below row.
+    assert {p["project_slug"] for p in validated["per_project"]} == {proj_above["slug"]}
+
+    def stub(sess_id, _conn, **_kw):
+        return ClassificationResult(
+            session_id=sess_id,
+            per_project=[
+                ProjectClassification(
+                    project_slug=e["project_slug"],
+                    session_relevance=e["session_relevance"],
+                    section_count=e["section_count"],
+                    focused_summary=e["focused_summary"],
+                )
+                for e in validated["per_project"]
+            ],
+            usage={
+                "input_tokens": 100, "output_tokens": 50,
+                "cache_read_tokens": 0, "cache_write_tokens": 0,
+            },
+        )
+
+    with patch.object(fanout_mod, "classify_session", stub), \
+         patch.object(fanout_mod, "_embed_summary", lambda _t: None):
+        fanout_mod.run_fanout(conn, project_id=proj_canonical["id"])
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT project_id FROM devbrain.memory "
+            "WHERE fanout_source_session_id = %s",
+            (session_id,),
+        )
+        target_ids = [str(r[0]) for r in cur.fetchall()]
+
+    assert str(proj_above["id"]) in target_ids
+    assert str(proj_below["id"]) not in target_ids, (
+        "below-threshold project must not receive a fan-out row"
+    )


### PR DESCRIPTION
## Summary
PR 3 of 3 for Phase 8 cross-project fan-out. Adds the operational substrate to run the all-time backfill across the laptop's ~3,000 \`raw_sessions\` plus 4 AGM-style postulates that verify the design invariants from \`docs/plans/2026-05-11-phase-8-cross-project-fan-out-design.md\` §12.

## What ships
- **\`scripts/backfill_fanout_all_time.sh\`** — sharded orchestrator. Spawns N \`devbrain cognify-fanout --shard=I/N --json\` workers, aggregates per-shard JSON summaries, logs each shard to \`~/.devbrain/logs/\`. Safe to re-run via migration 039's partial unique index.
- **4 new postulates** (\`tests/postulates/test_p_fanout_*.py\`):
  - \`P_fanout_no_canonical_rewrite\` — preserves \`raw_sessions.project_id\`
  - \`P_fanout_idempotent\` — re-run produces no duplicates
  - \`P_fanout_relevance_threshold_honored\` — 0.30 floor enforced even when model fudges
  - \`P_fanout_home_project_excluded_as_target\` — \`home-*\` projects never appear in classifier taxonomy

## Test plan
- [x] \`pytest tests/postulates/test_p_fanout_*.py\` — 4/4 passed
- [x] \`pytest tests/postulates/\` full sweep — 90/90 passed (86 existing + 4 new)
- [x] \`scripts/backfill_fanout_all_time.sh --dry-run --workers 2\` produces valid sharded JSON aggregation
- [x] \`bin/devbrain cognify-fanout --dry-run\` on laptop → 3015 sessions discovered (the backfill scope)

## What this PR does NOT do
- Run the actual backfill. That's an operational step after merge:
  \`\`\`
  scripts/backfill_fanout_all_time.sh --workers 4
  \`\`\`
  Estimated cost ~$15–40 across ~3,000 sessions with Sonnet.
- Install the launchd plist (\`com.devbrain.cognify-fanout.plist\` from PR 2). \`bin/devbrain setup-cognify-launchd\` will pick it up on next install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)