### PR TITLE
feat(mcp): breadcrumb tool for long-session narrative tracking

### DIFF
--- a/factory/tests/test_migration_040_breadcrumb.py
+++ b/factory/tests/test_migration_040_breadcrumb.py
@@ -1,0 +1,148 @@
+"""Tests for migration 040 — session_breadcrumb kind + chain index.
+
+The MCP tool itself (breadcrumb) lives in mcp-server/src/index.ts;
+these tests exercise the DB substrate it sits on top of:
+  * kind='session_breadcrumb' is accepted by memory_kind_check
+  * The partial chain index speeds up conversation-grouped reads
+  * INSERT shape matches what the TS tool emits (provenance_id =
+    conversation_uuid, applies_when carries seq + conversation_uuid)
+  * Multiple breadcrumbs sharing a provenance_id coexist (no unique
+    collision against migration 037/039's session-summary indexes)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import psycopg2
+import pytest
+
+_FACTORY = Path(__file__).resolve().parents[1]
+if str(_FACTORY) not in sys.path:
+    sys.path.insert(0, str(_FACTORY))
+
+
+def _live_conn():
+    from config import DATABASE_URL  # noqa: PLC0415
+    return psycopg2.connect(DATABASE_URL)
+
+
+@pytest.fixture
+def live_db():
+    if not os.environ.get("DEVBRAIN_DB_PASSWORD") and not os.environ.get("DEVBRAIN_TEST_DATABASE_URL"):
+        pytest.skip("DB not configured for tests")
+    conn = _live_conn()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def synth_project(live_db):
+    """Disposable project. Removed at teardown."""
+    slug = f"breadcrumb-test-{uuid.uuid4().hex[:8]}"
+    with live_db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.projects (slug, name) VALUES (%s, %s) RETURNING id",
+            (slug, "Breadcrumb test"),
+        )
+        project_id = cur.fetchone()[0]
+    live_db.commit()
+    yield {"id": project_id, "slug": slug}
+    with live_db.cursor() as cur:
+        cur.execute("DELETE FROM devbrain.memory WHERE project_id = %s", (project_id,))
+        cur.execute("DELETE FROM devbrain.projects WHERE id = %s", (project_id,))
+    live_db.commit()
+
+
+def test_kind_check_accepts_session_breadcrumb(live_db, synth_project):
+    """Inserting kind='session_breadcrumb' succeeds — migration 040 added it."""
+    with live_db.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO devbrain.memory
+                (project_id, kind, title, content, tier, strength, provenance_id)
+            VALUES (%s, 'session_breadcrumb', 'milestone-1', 'noted it', 'memory', 1.0, %s)
+            RETURNING id
+            """,
+            (synth_project["id"], str(uuid.uuid4())),
+        )
+        new_id = cur.fetchone()[0]
+    live_db.commit()
+    assert new_id is not None
+
+
+def test_kind_check_still_rejects_unknown_kind(live_db, synth_project):
+    """Sanity: only the documented kinds are valid."""
+    with pytest.raises(psycopg2.errors.CheckViolation):
+        with live_db.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO devbrain.memory
+                    (project_id, kind, title, content, tier, strength)
+                VALUES (%s, 'fake-kind', 't', 'c', 'memory', 1.0)
+                """,
+                (synth_project["id"],),
+            )
+    live_db.rollback()
+
+
+def test_multiple_breadcrumbs_share_provenance_id(live_db, synth_project):
+    """A conversation's breadcrumbs share provenance_id without colliding
+    against the session_summary unique index."""
+    conv_uuid = str(uuid.uuid4())
+    with live_db.cursor() as cur:
+        for i in range(1, 4):
+            cur.execute(
+                """
+                INSERT INTO devbrain.memory
+                    (project_id, kind, title, content, tier, strength,
+                     provenance_id, applies_when)
+                VALUES (%s, 'session_breadcrumb', %s, %s, 'memory', 1.0,
+                        %s, %s::jsonb)
+                """,
+                (
+                    synth_project["id"],
+                    f"step-{i}",
+                    f"breadcrumb {i}",
+                    conv_uuid,
+                    json.dumps({"conversation_uuid": conv_uuid, "seq": i,
+                                "source": "mcp:breadcrumb"}),
+                ),
+            )
+    live_db.commit()
+
+    with live_db.cursor() as cur:
+        cur.execute(
+            """
+            SELECT title, applies_when->>'seq' AS seq
+            FROM devbrain.memory
+            WHERE provenance_id = %s AND kind = 'session_breadcrumb'
+            ORDER BY (applies_when->>'seq')::int
+            """,
+            (conv_uuid,),
+        )
+        rows = cur.fetchall()
+    assert [r[0] for r in rows] == ["step-1", "step-2", "step-3"]
+    assert [int(r[1]) for r in rows] == [1, 2, 3]
+
+
+def test_breadcrumb_chain_index_exists(live_db):
+    """Migration 040 created the partial index used by the chain query."""
+    with live_db.cursor() as cur:
+        cur.execute(
+            """
+            SELECT indexdef FROM pg_indexes
+            WHERE schemaname='devbrain'
+              AND indexname='idx_memory_breadcrumb_chain'
+            """,
+        )
+        row = cur.fetchone()
+    assert row is not None
+    indexdef = row[0]
+    assert "session_breadcrumb" in indexdef
+    assert "provenance_id" in indexdef
+    assert "created_at" in indexdef
+    assert "archived_at IS NULL" in indexdef

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -2211,6 +2211,89 @@ server.tool(
   },
 )
 
+// ─── Tool: breadcrumb (Phase 8 follow-up — long-session narrative tracker) ──
+
+server.tool(
+  'breadcrumb',
+  'Drop a mid-session progress marker. Call at meaningful milestones in a ' +
+    'long session (decision made, problem solved, direction change). ' +
+    "Multiple breadcrumbs sharing the same conversation_uuid chain into a " +
+    "narrative the final end_session can fold in. Generate conversation_uuid " +
+    "ONCE per conversation (e.g. crypto.randomUUID()) and reuse it across " +
+    "every breadcrumb + the eventual end_session call.",
+  {
+    project: z.string().describe('Project slug'),
+    conversation_uuid: z.string().uuid()
+      .describe('UUID generated once at session start; reused across all breadcrumb + end_session calls in this conversation.'),
+    title: z.string().min(1).max(200)
+      .describe('Short marker title (≤200 chars).'),
+    content: z.string().min(1).max(4000)
+      .describe('Breadcrumb body — what was decided/learned/changed at this point.'),
+    seq: z.number().int().optional()
+      .describe('Optional sequence number. Defaults to the count of existing breadcrumbs with this conversation_uuid + 1.'),
+  },
+  async ({ project, conversation_uuid, title, content, seq }) => {
+    const projectId = await resolveProjectId(project)
+    if (!projectId) {
+      return { content: [{ type: 'text', text: `Project "${project}" not found.` }] }
+    }
+
+    // Resolve seq: caller-provided wins; otherwise count existing breadcrumbs
+    // for this conversation and use (count + 1).
+    let effectiveSeq = seq
+    if (effectiveSeq === undefined) {
+      const countRes = await query<{ n: number }>(
+        `SELECT COUNT(*)::int AS n FROM devbrain.memory
+         WHERE kind = 'session_breadcrumb'
+           AND provenance_id = $1
+           AND archived_at IS NULL`,
+        [conversation_uuid],
+      )
+      effectiveSeq = (countRes.rows[0]?.n ?? 0) + 1
+    }
+
+    const embedText = `${title}\n${content}`
+    const embedding = await embed(embedText)
+    const vectorStr = toSqlVector(embedding)
+
+    const appliesWhen = {
+      conversation_uuid,
+      seq: effectiveSeq,
+      source: 'mcp:breadcrumb',
+    }
+
+    const result = await query<{ id: string }>(
+      `INSERT INTO devbrain.memory
+         (project_id, kind, title, content, embedding,
+          provenance_id, tier, strength, applies_when)
+       VALUES ($1, 'session_breadcrumb', $2, $3, $4::vector,
+               $5, 'memory', 1.0, $6::jsonb)
+       RETURNING id`,
+      [
+        projectId, title, content, vectorStr,
+        conversation_uuid, JSON.stringify(appliesWhen),
+      ],
+    )
+    const id = result.rows[0]?.id ?? null
+
+    if (!id) {
+      return { content: [{ type: 'text', text: 'breadcrumb: insert returned no row (unexpected).' }] }
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text:
+          `breadcrumb #${effectiveSeq} stored for conversation ` +
+          `${conversation_uuid.slice(0, 8)}… (id=${id.slice(0, 8)}…). ` +
+          `Use the same conversation_uuid on subsequent breadcrumb + ` +
+          `end_session calls to keep the chain intact.`,
+      }],
+    }
+  },
+)
+
+
 // ─── Start server ────────────────────────────────────────────────────────────
 
 async function main() {

--- a/migrations/040_session_breadcrumb_kind.sql
+++ b/migrations/040_session_breadcrumb_kind.sql
@@ -1,0 +1,52 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 040: Add 'session_breadcrumb' to memory.kind CHECK constraint
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- Powers the new `breadcrumb` MCP tool — a mid-session progress marker
+-- the agent emits at meaningful milestones in long sessions (a
+-- decision made, a problem solved, a direction change). Multiple
+-- breadcrumbs sharing the same `provenance_id` (the conversation's
+-- UUID, generated once at session start) chain into a narrative for
+-- the final end_session summary.
+--
+-- Schema notes:
+--   * The new kind goes through the same INSERT path as session_summary.
+--   * tier='memory' (not 'lesson') — breadcrumbs aren't promoted atoms.
+--   * Idempotency is NOT enforced via a unique index. Multiple
+--     breadcrumbs at the same (provenance_id, title) are valid (a dev
+--     can revisit the same topic with new insight). The seq column
+--     (stored in applies_when JSONB) preserves order; the partial
+--     index below speeds up "all breadcrumbs for this conversation".
+--
+-- Idempotent — wrapped in BEGIN/COMMIT for atomic apply under CI.
+
+BEGIN;
+
+-- Replace the kind check.
+ALTER TABLE devbrain.memory DROP CONSTRAINT IF EXISTS memory_kind_check;
+ALTER TABLE devbrain.memory ADD CONSTRAINT memory_kind_check
+    CHECK (kind = ANY (ARRAY[
+        'chunk',
+        'decision',
+        'pattern',
+        'issue',
+        'session_summary',
+        'session_breadcrumb'
+    ]));
+
+-- Recency-by-conversation lookup for the breadcrumb chain query.
+CREATE INDEX IF NOT EXISTS idx_memory_breadcrumb_chain
+    ON devbrain.memory (provenance_id, created_at)
+    WHERE kind = 'session_breadcrumb'
+      AND archived_at IS NULL;
+
+COMMENT ON INDEX devbrain.idx_memory_breadcrumb_chain IS
+    'Migration 040: speeds up "show me the breadcrumb chain for '
+    'conversation X" queries used by deep_search + the final '
+    'end_session summary aggregation.';
+
+INSERT INTO devbrain.schema_migrations (filename)
+VALUES ('040_session_breadcrumb_kind.sql')
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Adds a mid-session progress marker (\`mcp__brightbrain__breadcrumb\`) the agent drops at meaningful milestones in long sessions so the narrative arc is preserved beyond the final end_session summary.

Multiple breadcrumbs sharing the same \`conversation_uuid\` chain together; deep_search can surface the chain.

## What ships
- **Migration 040**: \`session_breadcrumb\` added to \`memory_kind_check\`; partial index \`idx_memory_breadcrumb_chain\` on \`(provenance_id, created_at) WHERE kind='session_breadcrumb' AND archived_at IS NULL\` for chain queries.
- **\`breadcrumb\` MCP tool** in \`mcp-server/src/index.ts\`:
  - Args: \`project\`, \`conversation_uuid\` (UUID, agent-generated once), \`title\`, \`content\`, optional \`seq\`
  - INSERT into \`devbrain.memory\` with kind=session_breadcrumb, tier=memory, applies_when carrying conversation_uuid + seq
  - Embedding via Ollama; auto-assigns seq if omitted (count of existing + 1)

## Design notes
- \`provenance_id = conversation_uuid\` by intent — agent-generated, doesn't have to match a \`raw_sessions.id\` (breadcrumb can fire before JSONL ingest).
- No idempotency dedup — breadcrumbs are append-only by design.
- Direct INSERT (not \`recordMemory\`) because the shared-provenance model doesn't fit recordMemory's ON CONFLICT path.

## Test plan
- [x] \`pytest factory/tests/test_migration_040_breadcrumb.py\` — 4/4 (constraint accepts new kind, rejects unknown, multiple breadcrumbs coexist on shared provenance, partial chain index exists)
- [x] \`tsc --noEmit\` clean
- [x] \`npm run build\` clean

## How agents use it
\`\`\`
// Once per conversation
const conversationUuid = crypto.randomUUID()

// During the session, at each milestone
await mcp__brightbrain__breadcrumb({
  project: "devbrain",
  conversation_uuid: conversationUuid,
  title: "Settled on Option B for fan-out canonical assignment",
  content: "Existing rows keep canonical; only new emit logic uses home-<dev>. Provenance_id chains preserved."
})

// At end_session, pass the same UUID
await mcp__brightbrain__end_session({
  project: "devbrain",
  session_id: conversationUuid,
  summary: "..."
})
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)