### PR TITLE
feat(mcp): start_session tool + optional conversation_uuid on breadcrumb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,13 +21,17 @@ If you find yourself accidentally calling `mcp__brightbrain__*` while in
 this repo, you're hitting the wrong DB. Stop and re-route to `mcp__devbrain__*`.
 
 ### ALWAYS do these things:
-1. **Start of session**: Call `get_project_context` (via `mcp__devbrain__*`) to load project context, recent decisions, and known issues
-2. **Before starting work**: Call `deep_search` (via `mcp__devbrain__*`) to check for relevant past decisions, patterns, and implementation history — never assume
-3. **During work**: Call `store` (via `mcp__devbrain__*`) when you:
+1. **Start of session — load context**: Call `get_project_context` (via `mcp__devbrain__*`) to load project context, recent decisions, and known issues.
+2. **Start of session — anchor the chain**: After reading the user's first prompt, call `start_session(project, intent)` where `intent` is a 1-3 sentence paraphrase of what the user is asking. **Save the returned `conversation_uuid`** in your working memory — you'll reuse it on every subsequent breadcrumb + end_session call so the whole conversation chains together.
+3. **Before starting work**: Call `deep_search` (via `mcp__devbrain__*`) to check for relevant past decisions, patterns, and implementation history — never assume
+4. **During work — atomic memories**: Call `store` (via `mcp__devbrain__*`) when you:
    - Make an architecture or design decision (type="decision")
    - Discover a reusable pattern (type="pattern")
    - Fix a bug worth remembering (type="issue")
-4. **End of session**: Call `end_session` (via `mcp__devbrain__*`) with a summary of what was accomplished, decisions made, files changed, and next steps
+5. **During work — narrative breadcrumbs**: Call `breadcrumb(project, conversation_uuid, title, content)` at meaningful milestones in long sessions — a decision settled, a problem solved, a direction change, completion of a sub-task in an autonomous run. Use the `conversation_uuid` you saved in step 2.
+6. **End of session**: Call `end_session(project, session_id=conversation_uuid, summary, ...)` with a summary of what was accomplished, decisions made, files changed, and next steps. Pass the same `conversation_uuid` as `session_id` so the final summary chains to the intent + breadcrumbs.
+
+If you forget step 2 and call `breadcrumb` first, the server auto-generates a `conversation_uuid` and returns it — reuse that for the remaining calls. The intent anchor (seq=0) is lost in that path, so calling `start_session` explicitly is strongly preferred.
 
 ### DevBrain Search Tips:
 - `deep_search` with depth="auto" will automatically fetch raw transcript context for high-confidence matches

--- a/factory/tests/test_start_session_breadcrumb_schema.py
+++ b/factory/tests/test_start_session_breadcrumb_schema.py
@@ -1,0 +1,147 @@
+"""Tests for the start_session MCP tool's data path.
+
+The MCP tool lives in mcp-server/src/index.ts; these tests exercise
+the schema-level invariants the TS code relies on:
+
+  * A start_session row is just a breadcrumb at seq=0 with
+    `is_session_start=true` in applies_when.
+  * The chain query (provenance_id + seq order) puts the
+    start_session row first.
+  * Breadcrumbs after start_session increment seq from 1 upward.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import psycopg2
+import pytest
+
+_FACTORY = Path(__file__).resolve().parents[1]
+if str(_FACTORY) not in sys.path:
+    sys.path.insert(0, str(_FACTORY))
+
+
+def _live_conn():
+    from config import DATABASE_URL  # noqa: PLC0415
+    return psycopg2.connect(DATABASE_URL)
+
+
+@pytest.fixture
+def live_db():
+    if not os.environ.get("DEVBRAIN_DB_PASSWORD") and not os.environ.get("DEVBRAIN_TEST_DATABASE_URL"):
+        pytest.skip("DB not configured for tests")
+    conn = _live_conn()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def synth_project(live_db):
+    slug = f"start-session-test-{uuid.uuid4().hex[:8]}"
+    with live_db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.projects (slug, name) VALUES (%s, %s) RETURNING id",
+            (slug, "start_session test"),
+        )
+        project_id = cur.fetchone()[0]
+    live_db.commit()
+    yield {"id": project_id, "slug": slug}
+    with live_db.cursor() as cur:
+        cur.execute("DELETE FROM devbrain.memory WHERE project_id = %s", (project_id,))
+        cur.execute("DELETE FROM devbrain.projects WHERE id = %s", (project_id,))
+    live_db.commit()
+
+
+def _insert_breadcrumb(conn, project_id, conv_uuid, title, content, seq, is_start):
+    """Mirror of writeBreadcrumbRow() in mcp-server/src/index.ts."""
+    applies_when = {
+        "conversation_uuid": conv_uuid,
+        "seq": seq,
+        "source": "mcp:breadcrumb",
+    }
+    if is_start:
+        applies_when["is_session_start"] = True
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO devbrain.memory
+                (project_id, kind, title, content, tier, strength,
+                 provenance_id, applies_when)
+            VALUES (%s, 'session_breadcrumb', %s, %s, 'memory', 1.0,
+                    %s, %s::jsonb)
+            RETURNING id
+            """,
+            (project_id, title, content, conv_uuid, json.dumps(applies_when)),
+        )
+        return cur.fetchone()[0]
+
+
+def test_start_session_row_has_is_session_start_marker(live_db, synth_project):
+    conv = str(uuid.uuid4())
+    _insert_breadcrumb(
+        live_db, synth_project["id"], conv,
+        "User wants Phase 8 done", "Build fan-out + breadcrumb tooling",
+        seq=0, is_start=True,
+    )
+    live_db.commit()
+    with live_db.cursor() as cur:
+        cur.execute(
+            """
+            SELECT applies_when->'is_session_start', applies_when->>'seq'
+            FROM devbrain.memory
+            WHERE provenance_id = %s AND kind = 'session_breadcrumb'
+            """,
+            (conv,),
+        )
+        is_start, seq = cur.fetchone()
+    assert is_start is True
+    assert seq == "0"
+
+
+def test_chain_query_orders_start_session_first(live_db, synth_project):
+    conv = str(uuid.uuid4())
+    _insert_breadcrumb(live_db, synth_project["id"], conv,
+                       "intent", "user wants X", seq=0, is_start=True)
+    _insert_breadcrumb(live_db, synth_project["id"], conv,
+                       "milestone 1", "did Y", seq=1, is_start=False)
+    _insert_breadcrumb(live_db, synth_project["id"], conv,
+                       "milestone 2", "did Z", seq=2, is_start=False)
+    live_db.commit()
+    with live_db.cursor() as cur:
+        cur.execute(
+            """
+            SELECT title, (applies_when->>'seq')::int AS s,
+                   (applies_when->'is_session_start')::bool AS is_start
+            FROM devbrain.memory
+            WHERE provenance_id = %s AND kind = 'session_breadcrumb'
+            ORDER BY (applies_when->>'seq')::int
+            """,
+            (conv,),
+        )
+        rows = cur.fetchall()
+    assert [r[0] for r in rows] == ["intent", "milestone 1", "milestone 2"]
+    assert [r[1] for r in rows] == [0, 1, 2]
+    # Only seq=0 is the session start.
+    assert rows[0][2] is True
+    assert rows[1][2] is None  # absent in applies_when
+    assert rows[2][2] is None
+
+
+def test_breadcrumb_chain_index_covers_query(live_db):
+    """Sanity: the index from migration 040 is what the chain query uses."""
+    with live_db.cursor() as cur:
+        cur.execute(
+            "EXPLAIN SELECT id FROM devbrain.memory "
+            "WHERE provenance_id = '00000000-0000-0000-0000-000000000000'::uuid "
+            "  AND kind = 'session_breadcrumb' "
+            "  AND archived_at IS NULL "
+            "ORDER BY created_at"
+        )
+        plan = "\n".join(r[0] for r in cur.fetchall())
+    assert "idx_memory_breadcrumb_chain" in plan, (
+        f"chain index not used by query planner:\n{plan}"
+    )

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -2266,26 +2266,150 @@ server.tool(
   },
 )
 
-// ─── Tool: breadcrumb (Phase 8 follow-up — long-session narrative tracker) ──
+// ─── Session-narrative tools (Phase 8 follow-up) ────────────────────────────
+//
+// start_session   — anchor a conversation with its intent at seq=0
+// breadcrumb      — mid-session progress markers at seq=1..N
+// end_session     — final summary (separate tool above; takes session_id)
+//
+// All three share the same `conversation_uuid` so deep_search /
+// graph-walking can recover the whole chain.
+
+/**
+ * Shared writer for kind='session_breadcrumb' rows. Used by both
+ * start_session (seq=0, is_session_start=true) and breadcrumb (seq>=1).
+ *
+ * Returns the new memory.id, the resolved conversation_uuid (matches
+ * input or freshly-generated), and the resolved seq.
+ */
+async function writeBreadcrumbRow(args: {
+  projectId: string
+  conversationUuid: string
+  title: string
+  content: string
+  seq: number
+  isSessionStart: boolean
+}): Promise<{ id: string | null; seq: number }> {
+  const embedText = `${args.title}\n${args.content}`
+  const embedding = await embed(embedText)
+  const vectorStr = toSqlVector(embedding)
+
+  const appliesWhen: Record<string, unknown> = {
+    conversation_uuid: args.conversationUuid,
+    seq: args.seq,
+    source: 'mcp:breadcrumb',
+  }
+  if (args.isSessionStart) {
+    appliesWhen.is_session_start = true
+  }
+
+  const result = await query<{ id: string }>(
+    `INSERT INTO devbrain.memory
+       (project_id, kind, title, content, embedding,
+        provenance_id, tier, strength, applies_when)
+     VALUES ($1, 'session_breadcrumb', $2, $3, $4::vector,
+             $5, 'memory', 1.0, $6::jsonb)
+     RETURNING id`,
+    [
+      args.projectId, args.title, args.content, vectorStr,
+      args.conversationUuid, JSON.stringify(appliesWhen),
+    ],
+  )
+  return {
+    id: result.rows[0]?.id ?? null,
+    seq: args.seq,
+  }
+}
+
+
+server.tool(
+  'start_session',
+  'Anchor a new conversation chain with an intent statement. Call this ' +
+    "ONCE per conversation, right after reading the user's first prompt + " +
+    "loading project context. Returns a conversation_uuid you reuse across " +
+    'every subsequent breadcrumb + end_session call to keep the chain ' +
+    'linked.\n\nUsage pattern:\n' +
+    "  1. (first turn) call get_project_context, then start_session(project, intent)\n" +
+    "  2. save the returned conversation_uuid in your working memory\n" +
+    "  3. at meaningful milestones, call breadcrumb(project, conversation_uuid, ...)\n" +
+    '  4. at end_session, pass conversation_uuid as session_id.\n\n' +
+    'If you forget to call start_session, the first breadcrumb auto-creates ' +
+    'a UUID — but the intent anchor (seq=0) is lost, so calling start_session ' +
+    'explicitly is strongly preferred.',
+  {
+    project: z.string().describe('Project slug'),
+    intent: z.string().min(1).max(2000)
+      .describe(
+        "1–3 sentence summary of what the user is asking. The first " +
+          "breadcrumb in the chain — anchors search results so deep_search " +
+          "by intent words later surfaces the whole conversation arc.",
+      ),
+    conversation_uuid: z.string().uuid().optional()
+      .describe(
+        'Optional pre-generated UUID. Most callers omit this and let the ' +
+          "server generate one. Pass it explicitly only when you have a " +
+          "lab-native session id you want to reuse (Claude Code's JSONL " +
+          "filename UUID, etc.).",
+      ),
+  },
+  async ({ project, intent, conversation_uuid }) => {
+    const projectId = await resolveProjectId(project)
+    if (!projectId) {
+      return { content: [{ type: 'text', text: `Project "${project}" not found.` }] }
+    }
+
+    const conv = conversation_uuid ?? randomUUID()
+    const title = intent.length > 200 ? intent.slice(0, 197) + '...' : intent
+    const { id } = await writeBreadcrumbRow({
+      projectId,
+      conversationUuid: conv,
+      title,
+      content: intent,
+      seq: 0,
+      isSessionStart: true,
+    })
+
+    if (!id) {
+      return { content: [{ type: 'text', text: 'start_session: insert returned no row (unexpected).' }] }
+    }
+    return {
+      content: [{
+        type: 'text',
+        text:
+          `Session anchored. conversation_uuid=${conv}\n\n` +
+          `Reuse this UUID on every subsequent breadcrumb + end_session ` +
+          `call to chain the conversation. The intent breadcrumb (seq=0) ` +
+          `was stored at id=${id.slice(0, 8)}….`,
+      }],
+    }
+  },
+)
+
 
 server.tool(
   'breadcrumb',
   'Drop a mid-session progress marker. Call at meaningful milestones in a ' +
     'long session (decision made, problem solved, direction change). ' +
     "Multiple breadcrumbs sharing the same conversation_uuid chain into a " +
-    "narrative the final end_session can fold in. Generate conversation_uuid " +
-    "ONCE per conversation (e.g. crypto.randomUUID()) and reuse it across " +
-    "every breadcrumb + the eventual end_session call.",
+    "narrative the final end_session can fold in.\n\n" +
+    "Prefer to call start_session(project, intent) ONCE at conversation " +
+    "start and reuse the returned conversation_uuid here. If conversation_uuid " +
+    "is omitted, the server auto-generates one and returns it — but the " +
+    "intent anchor (seq=0) is lost, so an explicit start_session is preferred.",
   {
     project: z.string().describe('Project slug'),
-    conversation_uuid: z.string().uuid()
-      .describe('UUID generated once at session start; reused across all breadcrumb + end_session calls in this conversation.'),
+    conversation_uuid: z.string().uuid().optional()
+      .describe(
+        'UUID returned by start_session at conversation start; omit only ' +
+          'on the first breadcrumb of an un-anchored chain (server will ' +
+          'auto-generate one and return it for reuse).',
+      ),
     title: z.string().min(1).max(200)
       .describe('Short marker title (≤200 chars).'),
     content: z.string().min(1).max(4000)
       .describe('Breadcrumb body — what was decided/learned/changed at this point.'),
     seq: z.number().int().optional()
-      .describe('Optional sequence number. Defaults to the count of existing breadcrumbs with this conversation_uuid + 1.'),
+      .describe('Optional sequence number. Defaults to (count of existing breadcrumbs with this conversation_uuid) + 1.'),
   },
   async ({ project, conversation_uuid, title, content, seq }) => {
     const projectId = await resolveProjectId(project)
@@ -2293,8 +2417,13 @@ server.tool(
       return { content: [{ type: 'text', text: `Project "${project}" not found.` }] }
     }
 
-    // Resolve seq: caller-provided wins; otherwise count existing breadcrumbs
-    // for this conversation and use (count + 1).
+    const conv = conversation_uuid ?? randomUUID()
+    const isAutoGenerated = conversation_uuid === undefined
+
+    // Resolve seq: caller-provided wins; otherwise count existing
+    // breadcrumbs for this conversation. For a freshly auto-generated
+    // UUID the count is always 0 → seq=1, but the query is cheap and
+    // keeps the code-path symmetric.
     let effectiveSeq = seq
     if (effectiveSeq === undefined) {
       const countRes = await query<{ n: number }>(
@@ -2302,47 +2431,38 @@ server.tool(
          WHERE kind = 'session_breadcrumb'
            AND provenance_id = $1
            AND archived_at IS NULL`,
-        [conversation_uuid],
+        [conv],
       )
       effectiveSeq = (countRes.rows[0]?.n ?? 0) + 1
     }
 
-    const embedText = `${title}\n${content}`
-    const embedding = await embed(embedText)
-    const vectorStr = toSqlVector(embedding)
-
-    const appliesWhen = {
-      conversation_uuid,
+    const { id } = await writeBreadcrumbRow({
+      projectId,
+      conversationUuid: conv,
+      title,
+      content,
       seq: effectiveSeq,
-      source: 'mcp:breadcrumb',
-    }
-
-    const result = await query<{ id: string }>(
-      `INSERT INTO devbrain.memory
-         (project_id, kind, title, content, embedding,
-          provenance_id, tier, strength, applies_when)
-       VALUES ($1, 'session_breadcrumb', $2, $3, $4::vector,
-               $5, 'memory', 1.0, $6::jsonb)
-       RETURNING id`,
-      [
-        projectId, title, content, vectorStr,
-        conversation_uuid, JSON.stringify(appliesWhen),
-      ],
-    )
-    const id = result.rows[0]?.id ?? null
+      isSessionStart: false,
+    })
 
     if (!id) {
       return { content: [{ type: 'text', text: 'breadcrumb: insert returned no row (unexpected).' }] }
     }
+
+    const reuseHint = isAutoGenerated
+      ? `\n\n⚠ conversation_uuid was auto-generated (no start_session call observed). ` +
+        `Reuse ${conv} on every subsequent breadcrumb + end_session call to ` +
+        `keep the chain intact. Consider calling start_session at the top of ` +
+        `your next conversation to capture intent.`
+      : ` Reuse the same conversation_uuid on subsequent breadcrumb + ` +
+        `end_session calls to keep the chain intact.`
 
     return {
       content: [{
         type: 'text',
         text:
           `breadcrumb #${effectiveSeq} stored for conversation ` +
-          `${conversation_uuid.slice(0, 8)}… (id=${id.slice(0, 8)}…). ` +
-          `Use the same conversation_uuid on subsequent breadcrumb + ` +
-          `end_session calls to keep the chain intact.`,
+          `${conv.slice(0, 8)}… (id=${id.slice(0, 8)}…).${reuseHint}`,
       }],
     }
   },


### PR DESCRIPTION
## Summary
Implements Patrick's session-lifecycle proposal: agent calls \`start_session(project, intent)\` once after reading the user's first prompt; server generates \`conversation_uuid\` + writes the intent as breadcrumb #0; returns the UUID for reuse across subsequent breadcrumb + end_session calls.

## Lifecycle (now documented in CLAUDE.md)
\`\`\`
1. (first turn) get_project_context → load context
                start_session(project, intent) → returns conversation_uuid
2. (during)    breadcrumb(project, conversation_uuid, ...)
3. (end)       end_session(project, session_id=conversation_uuid, summary, ...)
\`\`\`

## Fallback
- \`conversation_uuid\` on \`breadcrumb\` is now optional — auto-generated + returned if omitted.
- Response includes a warning when auto-generated so the agent knows to call \`start_session\` next time.

## What ships
- \`start_session\` MCP tool
- \`breadcrumb\` accepts optional \`conversation_uuid\`
- Shared \`writeBreadcrumbRow\` helper (DRY between start_session + breadcrumb)
- DevBrain \`CLAUDE.md\` refreshed with the lifecycle pattern
- 7 tests green (3 new + 4 prior migration 040 tests)

## No DB migration — \`is_session_start\` is a marker in the existing \`applies_when\` JSONB on \`session_breadcrumb\` rows (PR #160's substrate).

## Test plan
- [x] \`pytest factory/tests/test_start_session_breadcrumb_schema.py test_migration_040_breadcrumb.py\` — 7/7
- [x] \`tsc --noEmit\` + \`npm run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)