### PR TITLE
fix(ingest): dedup chunk dual-write — stop re-ingested duplicate chunks

### DIFF
--- a/factory/tests/test_dual_write.py
+++ b/factory/tests/test_dual_write.py
@@ -134,6 +134,78 @@ def test_memory_unique_indexes_applied(db):
             kind in atomdef for kind in ("pattern", "decision", "lesson")
         ), f"atom index predicate doesn't reference atom kinds: {atomdef}"
 
+        # Migration 045: the chunk dual-write's ON CONFLICT relies on a
+        # partial unique index keyed on (provenance_id, kind, md5(content)).
+        cur.execute(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE schemaname = 'devbrain' AND tablename = 'memory' "
+            "AND indexname = 'idx_memory_chunk_dedup_unique'"
+        )
+        chunkrow = cur.fetchone()
+        assert chunkrow is not None, (
+            "idx_memory_chunk_dedup_unique missing — run "
+            "`bin/devbrain migrate` (migration 045)"
+        )
+        chunkdef = chunkrow[0]
+        assert "UNIQUE" in chunkdef.upper()
+        assert "provenance_id" in chunkdef
+        assert "md5" in chunkdef.lower()
+        assert "chunk" in chunkdef
+
+
+def test_dual_write_chunk_is_idempotent(db):
+    """Re-running the chunk dual-write for the same (provenance_id,
+    content) must NOT create a second memory row — migration 045's
+    ON CONFLICT (provenance_id, kind, md5(content)) DO NOTHING. This is
+    the guard whose absence let BrightBrain accumulate 257k duplicate
+    chunk rows (one chunk had 824 copies)."""
+    pid = _devbrain_project_id(db)
+    prov = "55555555-5555-5555-5555-555555555555"
+    content = f"{TEST_CONTENT_PREFIX}chunk idempotent body"
+    emb = _embedding_sql(0.5)
+
+    # Two separate transactions, same natural key — simulates a backfill
+    # re-run over an already-ingested chunk.
+    for _ in range(2):
+        with db._conn() as conn, conn.cursor() as cur:
+            record_memory(
+                cur,
+                project_id=pid,
+                kind="chunk",
+                content=content,
+                embedding_sql=emb,
+                provenance_id=prov,
+            )
+            conn.commit()
+
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM devbrain.memory WHERE content = %s",
+            (content,),
+        )
+        (n,) = cur.fetchone()
+    assert n == 1, f"chunk dual-write not idempotent: {n} rows for one key"
+
+    # Different content under the SAME provenance (session) is a distinct
+    # chunk and MUST still insert — provenance alone is not the key.
+    content2 = f"{TEST_CONTENT_PREFIX}chunk idempotent body TWO"
+    with db._conn() as conn, conn.cursor() as cur:
+        record_memory(
+            cur, project_id=pid, kind="chunk", content=content2,
+            embedding_sql=emb, provenance_id=prov,
+        )
+        conn.commit()
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM devbrain.memory "
+            "WHERE provenance_id = %s AND content LIKE %s",
+            (prov, f"{TEST_CONTENT_PREFIX}chunk idempotent body%"),
+        )
+        (n2,) = cur.fetchone()
+    assert n2 == 2, (
+        "distinct content under one provenance must remain distinct rows"
+    )
+
 
 # ─── 2-6. Dual-write produces a memory row for each kind ─────────────────
 

--- a/ingest/memory_writer.py
+++ b/ingest/memory_writer.py
@@ -98,8 +98,27 @@ def record_memory(
             "  AND kind IN ('pattern', 'decision', 'lesson', 'issue') "
             "DO NOTHING"
         )
+    elif kind == "chunk":
+        # Chunks dedup on (provenance_id, kind, md5(content)) — the
+        # natural key for a re-ingested legacy chunk. provenance_id is
+        # the *source session* UUID (migration 032), so a session has
+        # many distinct chunks under one provenance; the content hash is
+        # what distinguishes (and dedups) them. Provenance-scoped, so
+        # identical text from *different* sessions is preserved (cf. the
+        # divergent-provenance rationale in migration 044). Backed by
+        # idx_memory_chunk_dedup_unique (migration 045). Without this the
+        # chunk dual-write had no ON CONFLICT, so every re-run of the
+        # chunk backfill re-inserted every chunk — observed 2026-06-25:
+        # BrightBrain's memory table was 83% duplicate chunk rows (one
+        # chunk had 824 copies), flooding deep_search's top-K with stale
+        # duplicates that tripped recency_warning on every query.
+        on_conflict = (
+            "ON CONFLICT (provenance_id, kind, md5(content)) "
+            "WHERE provenance_id IS NOT NULL AND kind = 'chunk' "
+            "DO NOTHING"
+        )
     else:
-        # Chunks (and any future non-deduped kind) just insert.
+        # Any future non-deduped kind just inserts.
         on_conflict = ""
 
     try:

--- a/migrations/045_chunk_dual_write_dedup.sql
+++ b/migrations/045_chunk_dual_write_dedup.sql
@@ -1,0 +1,108 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 045: Chunk dual-write dedup — collapse re-ingested duplicate chunks
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- Context (2026-06-25): BrightBrain's deep_search flagged a recency_warning
+-- ("stale by 75+ days") on essentially every result. Root cause: the
+-- legacy→memory dual-write (ingest/memory_writer.py) gave kind='chunk' no
+-- ON CONFLICT clause — migration 037's idempotency only covered atom +
+-- session_summary kinds — so every re-run of the chunk backfill re-inserted
+-- every chunk. The BrightBot project had grown to 315,776 chunk rows for
+-- only 58,628 distinct (provenance_id, content) chunks (one chunk had 824
+-- copies; the June ingests were 97–98% duplicate). Those old duplicates
+-- dominated deep_search's top-K and, being >30 days old, tripped the
+-- topic-age-gap staleness trigger on every query.
+--
+-- This migration:
+--   (1) repoints memory_dependencies edges off duplicate chunk rows onto
+--       the surviving (earliest) row that shares the natural key, skipping
+--       repoints that would violate uq_memory_dep_triplet (those duplicate
+--       edges CASCADE-drop with their dup row in step 2);
+--   (2) deletes the duplicate chunk rows, keeping the earliest per
+--       (provenance_id, kind, md5(content)); and
+--   (3) adds the partial unique index that makes the dual-write's new
+--       ON CONFLICT (provenance_id, kind, md5(content)) idempotent —
+--       mirroring idx_memory_session_summary_unique from 037.
+--
+-- Natural key rationale: provenance_id is the *source session* UUID
+-- (migration 032), so a session holds many distinct chunks under one
+-- provenance — the content hash is what identifies an individual chunk.
+-- The key is provenance-scoped, so identical text from *different* sessions
+-- is preserved (consistent with 044's divergent-provenance reasoning); only
+-- a re-ingestion of the *same* session's *same* chunk collapses.
+--
+-- Idempotent: on a DB with no chunk dupes (fresh installs, the laptop
+-- DevBrain) the repoint/delete touch zero rows and the index creates
+-- cleanly.
+
+-- (1) Repoint from-edges off dup chunks onto the surviving row.
+WITH ranked AS (
+    SELECT id,
+           first_value(id) OVER w AS survivor_id,
+           row_number()    OVER w AS rn
+      FROM devbrain.memory
+     WHERE kind = 'chunk' AND provenance_id IS NOT NULL
+    WINDOW w AS (
+        PARTITION BY provenance_id, md5(content)
+        ORDER BY created_at ASC, id ASC
+    )
+),
+dup_map AS (
+    SELECT id AS dup_id, survivor_id FROM ranked WHERE rn > 1
+)
+UPDATE devbrain.memory_dependencies d
+   SET from_memory_id = dm.survivor_id
+  FROM dup_map dm
+ WHERE d.from_memory_id = dm.dup_id
+   AND NOT EXISTS (
+        SELECT 1 FROM devbrain.memory_dependencies e
+         WHERE e.from_memory_id = dm.survivor_id
+           AND e.to_memory_id   = d.to_memory_id
+           AND e.edge_type      = d.edge_type
+   );
+
+-- (1b) Repoint to-edges off dup chunks (none observed today, included so
+--      the migration is correct regardless of edge direction).
+WITH ranked AS (
+    SELECT id,
+           first_value(id) OVER w AS survivor_id,
+           row_number()    OVER w AS rn
+      FROM devbrain.memory
+     WHERE kind = 'chunk' AND provenance_id IS NOT NULL
+    WINDOW w AS (
+        PARTITION BY provenance_id, md5(content)
+        ORDER BY created_at ASC, id ASC
+    )
+),
+dup_map AS (
+    SELECT id AS dup_id, survivor_id FROM ranked WHERE rn > 1
+)
+UPDATE devbrain.memory_dependencies d
+   SET to_memory_id = dm.survivor_id
+  FROM dup_map dm
+ WHERE d.to_memory_id = dm.dup_id
+   AND NOT EXISTS (
+        SELECT 1 FROM devbrain.memory_dependencies e
+         WHERE e.to_memory_id   = dm.survivor_id
+           AND e.from_memory_id = d.from_memory_id
+           AND e.edge_type      = d.edge_type
+   );
+
+-- (2) Delete the duplicate chunk rows (keep earliest per natural key).
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+               PARTITION BY provenance_id, md5(content)
+               ORDER BY created_at ASC, id ASC
+           ) AS rn
+      FROM devbrain.memory
+     WHERE kind = 'chunk' AND provenance_id IS NOT NULL
+)
+DELETE FROM devbrain.memory m
+ USING ranked r
+ WHERE m.id = r.id AND r.rn > 1;
+
+-- (3) Partial unique index — makes the chunk dual-write idempotent.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_chunk_dedup_unique
+    ON devbrain.memory (provenance_id, kind, md5(content))
+ WHERE kind = 'chunk' AND provenance_id IS NOT NULL;


### PR DESCRIPTION
## Problem

BrightBrain's `deep_search` flagged a `recency_warning` (\"stale by 75+ days\") on essentially every result. Root cause: the legacy→memory **chunk** dual-write (`ingest/memory_writer.py`) had **no `ON CONFLICT` clause** — migration 037's idempotency only covered atom + session_summary kinds — so every re-run of the chunk backfill re-inserted every chunk.

The BrightBot project had grown to **315,776 chunk rows for only 58,628 distinct `(provenance_id, content)` chunks** (one chunk had **824 copies**; the June ingests were 97–98% duplicate). Those old duplicates dominated `deep_search`'s top-K and, being >30 days old, tripped the topic-age-gap staleness trigger on every query.

## Fix

- **`memory_writer.py`**: add `ON CONFLICT (provenance_id, kind, md5(content)) DO NOTHING` for `kind='chunk'`. `provenance_id` is the *source session* UUID (032), so the content hash distinguishes a session's chunks; the key is provenance-scoped, so identical text from *different* sessions is preserved (cf. 044's divergent-provenance rationale).
- **Migration 045**: repoint `memory_dependencies` edges off dup rows onto the surviving (earliest) row, delete the dup chunk rows, add the partial unique index backing the `ON CONFLICT`. Idempotent on dupe-free DBs (laptop DevBrain, fresh installs).
- **Test**: chunk dual-write idempotency + distinct-content-under-one-provenance still inserts; extend the index-presence smoke test.

## Verification

- Local DevBrain: migration applied, `factory/tests/test_dual_write.py` 13/13 pass.
- BrightBrain (Studio): backup taken (2.35 GB, verified), writer jobs quiesced, migration applied (315,776 → 58,806 chunk rows; BrightBot total 341,253 → 84,301), 5,997 cites edges preserved, ivfflat REINDEXed, writer jobs restored, **0 dupes** under the natural key after ingest resumed.
- Same query that reproduced the bug now returns 8 **distinct** results; best match is **1.9 days old, `recency_warning: false`** (was 8 identical 78.8-day copies, all warned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)