### PR TITLE
perf(cognify): edges cites pass — kill the O(N×T) regex thrash (behavior-preserving)

### DIFF
--- a/docs/MEMORY_PIPELINE.md
+++ b/docs/MEMORY_PIPELINE.md
@@ -1,0 +1,113 @@
+# DevBrain / BrightBrain Memory Pipeline — full-stack map
+
+> Companion to [MEMORY_MODEL.md](MEMORY_MODEL.md) (which covers the `devbrain.memory`
+> table itself). This doc maps how the **whole** system writes, maintains, and
+> recalls memory across its layers — so a change in one layer doesn't silently
+> break an intentional function in another.
+>
+> Same codebase runs as **devbrain** (laptop, `DEVBRAIN_PROJECT=devbrain`) and
+> **brightbrain** (Mac Studio, `lhtdev`, Postgres in docker `devbrain-db`).
+
+## Three pipelines over one store
+
+Everything is `devbrain.memory` (unified table, 1024-dim pgvector embeddings) plus
+a typed edge graph (`devbrain.memory_dependencies`) and a hash-chained audit ledger
+(`devbrain.memory_ledger`).
+
+### A. Ingest / "memify" (write path)
+Always-on `com.devbrain.ingest` launchd watcher → `watchdog` sees a transcript in a
+watched dir / `~/ingest-incoming` drop-zone → adapter parses it → `chunk_text`
+(1600-char windows, 320 overlap) → `embed_batch` via local Ollama
+(`snowflake-arctic-embed2`, 1024-dim) → writes `raw_sessions` (lossless transcript) +
+`chunks` + **dual-writes** one `devbrain.memory` row per chunk.
+
+- Entry: `ingest/main.py:189` (`watch`), `ingest/pipeline.py:68` (`_process_session`).
+- Dual-write: `ingest/memory_writer.py:36` (`record_memory`), per-kind `ON CONFLICT`.
+- `provenance_id` for a chunk = the **source session UUID** (`chunks.source_id`,
+  migration 032), NOT the chunk's own id — so a session's many chunks share one
+  provenance and the content hash is the distinguishing key.
+
+The direct MCP tools (`store`, `start_session`, `breadcrumb`, `end_session`) bypass
+ingest and write `memory` straight from the TS server (`mcp-server/src/index.ts`),
+its own `pg.Pool`, its own Ollama embed call.
+
+### B. Cognify (knowledge maintenance)
+Seven scheduled launchd passes, orchestrated by `factory/cognify/orchestrator.py`
+(`PASS_ORDER`), each logged to `cognify_run_log` / `cognify_spend_log`:
+
+| pass | cadence | LLM? | mutates |
+|------|---------|------|---------|
+| `decay` | hourly | no | `memory.strength` (two-pass 90d/30d) |
+| `gc` | weekly | no | `memory.archived_at` (**never deletes** — HIPAA) |
+| `extract` | hourly | 1/session, cap 20 | lessons→`pattern`, decisions→`decision` |
+| `edges` | 6h | contradicts cap 15; cites zero-LLM | `memory_dependencies` (cites/contradicts) |
+| `strengthen` | daily | no | rule graduate/demote |
+| `fanout` | hourly | 1/session, **no cap** | cross-project `session_summary` rows |
+| `resummarize` | hourly | 1/session Sonnet, **no cap** | upgrades Ollama summaries |
+
+The **curator** runs at `end_session` (`factory/curator/end_session.py`): applies the
+agent's volunteered judgment (promote / contradict / refine / new-edges) and drains
+`curator_re_eval_queue`, decaying `strength` along `depends_on` cascade edges with a
+subtractive penalty and 24h-half-life freshness.
+
+### C. Retrieval (read path) — `deep_search`
+`mcp-server/src/index.ts:281`: embed query → ivfflat ANN over `memory` (filtered
+`project_id` / `kind` / `archived_at`) → annotate each hit via `recency.ts`
+(recency-neighbors, supersedes forward-walk, earliest-on-topic,
+`primary_age_days` / `recency_warning`) → optional graph enrichment (Python
+`factory/graph/walker.py` recursive-CTE, hop/node capped, via subprocess) →
+raw-transcript drill-down from `raw_sessions`.
+
+## Cross-cutting
+
+- **Ledger**: every `memory` write fires an AFTER trigger writing a SHA-256
+  hash-chain row (`memory_ledger`), serialized by a `pg_advisory_xact_lock` for
+  tamper-evidence.
+- **Idempotency** is content-natural-key everywhere (`ON CONFLICT` / anti-join),
+  NOT app-level locks. The only pipeline serialization is **launchd one-instance-
+  per-label** + time.
+- **Identifiers**: `provenance_id` (loose pointer, no FK — spans tables);
+  `conversation_uuid` chains `start_session`→`breadcrumb`→`end_session`.
+
+## Intentional designs — do NOT "optimize" these
+
+Each encodes a past incident or invariant:
+
+- **Best-effort dual-write that swallows errors** (`memory_writer.py` SAVEPOINT,
+  `memory.ts`) — legacy tables are source of truth; a memory failure must never
+  roll back the legacy write. (TS side needs no savepoint — `pg.Pool` is
+  connection-per-query.)
+- **`gc` archives, never deletes; `decay` clamps strength to 0.001; `created_at`
+  preserved on backfill** — HIPAA audit trail.
+- **`memory_ledger` has no FK; `provenance_id` is a loose pointer;
+  `curator_re_eval_queue.cascade_source_id` is RESTRICT** — ledger outlives
+  deleted rows; cascade source is the audit anchor.
+- **Dedup indexes are provenance/content-scoped; `idx_memory_import_dedup` is
+  deliberately non-unique** — identical text from *different* sessions is kept.
+- **Never reinstate migration 011's `(provenance_id, kind)` unique index** — an
+  operator did and hard-deleted 76k rows (2026-05-28). `backfill_memory._ensure_schema`
+  asserts the 037 index *specifically* to prevent this.
+- **codex-first → Sonnet fallback; no assistant-prefill on the OAuth path;
+  per-call client recycle** — each defends a real LLM failure mode.
+- **`supersedes` auto-walk in `recency.ts`** — writers don't reliably set edges,
+  so deep_search annotates staleness rather than trusting them.
+- **`end_session` always invokes the curator** (even empty judgment) — guarantees
+  an `end_session_log` row and a cascade-queue drain. Cross-project payloads are
+  **wholesale-rejected** (P_end_session_isolation).
+- **Subtractive (not multiplicative) cascade penalty; 24h half-life; decay
+  two-pass order** — tuned so multi-hop cascades don't zero memories by depth.
+- **import's post-commit conditional `REINDEX`; recency 5×/50× overfetch** — load-bearing.
+
+## Known seams that have bitten us
+
+- The chunk dual-write had **no** `ON CONFLICT` until migration 045 — re-running
+  the backfill duplicated every chunk (BrightBrain hit 83% dup chunk rows, one
+  chunk 824×), flooding `deep_search`'s top-K with stale duplicates that tripped
+  `recency_warning` on every query. Fixed: `idx_memory_chunk_dedup_unique` +
+  `ON CONFLICT (provenance_id, kind, md5(content))`.
+- `edges._detect_cites` was an O(N×T) regex double-loop (every memory row × every
+  distinct title) that re-compiled patterns past Python's 512 regex cache — it
+  pegged a core for ~36h on the bloated table. See the efficiency roadmap.
+
+See [plans/2026-06-25-memory-efficiency-roadmap.md](plans/2026-06-25-memory-efficiency-roadmap.md)
+for the prioritized efficiency/correctness work tracked off a full-stack audit.

--- a/docs/plans/2026-06-25-memory-efficiency-roadmap.md
+++ b/docs/plans/2026-06-25-memory-efficiency-roadmap.md
@@ -1,0 +1,87 @@
+# Memory pipeline efficiency & correctness roadmap (2026-06-25)
+
+Tracked off a full-stack audit of the DevBrain/BrightBrain memory system
+(ingest → cognify → retrieval → graph → curator → ops). Goal: make each layer
+accomplish the **same result more efficiently** without breaking intentional
+functions. See [../MEMORY_PIPELINE.md](../MEMORY_PIPELINE.md) for the architecture
+map and the "do not optimize these" list.
+
+Legend: ✅ shipped · 🔜 queued · 🧪 needs clean-DB validation · 🐛 correctness (changes wrong behavior).
+
+## Shipped
+
+- ✅ **Chunk dual-write dedup** (migration 045 + `memory_writer.py` ON CONFLICT).
+  Root cause of `deep_search` flagging "stale by 75+ days" on every query:
+  the chunk dual-write had no `ON CONFLICT`, so re-running the backfill
+  duplicated every chunk (BrightBrain hit 83% dup chunk rows, one chunk 824×).
+  Fixed; live BrightBrain cleaned 341k→84k rows, ivfflat reindexed.
+- ✅ **#1 `edges` cites pass efficiency** (this PR). The O(N×T) regex double-loop
+  re-compiled patterns past Python's 512-entry regex cache and pegged a core
+  ~36h on the bloated table. Behavior-preserving fixes: load the project's
+  memory **once** (was read twice), **pre-compile** each title pattern once, add
+  a lowercase **substring pre-filter** before the word-boundary regex (a
+  `\bTITLE\b` match is impossible unless TITLE is a substring, so the C-level
+  `in` skips the regex for nearly all pairs without changing which edges are
+  produced), and **early-exit** the contradiction seed-walks once `cap` pairs
+  exist (only `candidate_pairs[:cap]` is ever judged). Regression tests added
+  for the substring/word-boundary semantics and the load-once snapshot path.
+
+## Behavior-preserving efficiency wins (queued)
+
+- 🔜 **#2 ivfflat recall/size**: rebuild `idx_memory_embedding` `lists=100 → ~256`,
+  add `WHERE archived_at IS NULL`, and `SET LOCAL ivfflat.probes=10` in the
+  search transaction (default probes=1 scans one list). Improves recall (the
+  same retrieval, better) and shrinks the 656 MB index. Rebuild is online-able.
+- 🔜 **#3 ingest one-txn-per-session**: keep embedding *outside* the txn, then
+  write `raw_session + all chunks + dual-write` in ONE per-session transaction
+  with `execute_values` (today: a new connection + commit per chunk). Session
+  size profile checked — max 660 chunks / 1.1 MB, only 3 sessions >500, none
+  >1000 — so no commit boundary needed. This flips the invariant from
+  "partially-visible session that can't self-complete" (the hash gate skips a
+  crashed session on retry) to "atomically present or absent" — strictly better
+  for recall completeness and extract fidelity. Only cost: a mid-session crash
+  re-ingests from scratch (rare). No commit boundary unless giant sessions appear.
+- 🧪 **#4 `backfill_chunks` ON CONFLICT**: now that migration 045's unique index
+  exists, `backfill_chunks`' plain INSERT raises a unique violation on a dup and
+  the batch-failure path loses the whole batch's good inserts. Add
+  `ON CONFLICT (provenance_id, kind, md5(content)) … DO NOTHING` to match the
+  live path. NOTE: split out of the #1 PR — the existing
+  `test_backfill_chunks_inserts_to_memory` runs a slow (~4 min) whole-table
+  backfill and is environment-sensitive on a populated laptop DB; do this with
+  a focused clean-DB test and address the integration test's full-table scan.
+- 🔜 **#5 cognify per-(pass,project) advisory lock** (mirror the migration
+  runner): stops a manual `devbrain cognify` from double-spending LLM while the
+  scheduled run is mid-flight (correctness is saved today only by `ON CONFLICT`).
+- 🔜 **#6 circuit breaker on passes**: pre-load row-count guard + wall-clock cap
+  so a single pegged pass can't silently starve its launchd cadence again.
+- 🔜 **#7 `deep_search_graph_entry` single multi-seed CTE** instead of N
+  sequential `walk()` calls (3N → ~3 round-trips), reproducing the min-hop dedup.
+- 🔜 **#8** add `btree(project_id, created_at) WHERE archived_at IS NULL` for the
+  recency-neighbor / project-context queries now doing sort/ANN-filter.
+- 🔜 **#9 minor**: `findEarliestOnTopic`/recency LATERAL `DISTINCT ON` to cut
+  transfer; `breadcrumb` seq via `MAX+1` in the INSERT (avoid per-call COUNT).
+
+## Correctness bugs (change wrong behavior — schedule deliberately)
+
+- 🐛 **`with_graph=true` is silently dead**: `deep_search` reads `r.memory_id`
+  from the result objects, which never set that field, so `seedIds` is always
+  empty and the graph-enrichment subprocess never runs (`index.ts:668` vs the
+  correct `top[i].memory_id` at `:632`).
+- 🐛 **`extract` watermark poisoning**: `_last_successful_run` keys on
+  `error IS NULL`, but the run-log row is committed with NULL error *at start*
+  (`orchestrator.py:239`). A crashed/in-progress run looks "successful" → its
+  sessions are never re-extracted (silent memory loss) or a gap opens under
+  overlap. Fix: predicate on `completed_at IS NOT NULL AND error IS NULL`.
+- 🐛 **~26% of non-archived memory rows have no embedding** (≈65,850 / 89,372)
+  → invisible to `deep_search`. Identify which kinds (likely extract-inserted
+  lessons/decisions) — likely a backfill/embed gap.
+- 🐛 **Ollama `embed` has no timeout** → any tool call (search/store/breadcrumb)
+  hangs indefinitely if Ollama stalls. Add `AbortSignal.timeout()`.
+
+## Notes for whoever picks this up
+
+- All "do not optimize" invariants live in MEMORY_PIPELINE.md — read that first.
+- Migrations are additive and idempotent; the runner (`factory/schema_migrate.py`)
+  is advisory-locked + per-file-transactional and safe to re-run.
+- Deploy to BrightBrain = land on `main`, then `git pull` on the Mac Studio
+  (`/Users/lhtdev/devbrain`) and let the launchd jobs pick up the new code.

--- a/factory/cognify/edges.py
+++ b/factory/cognify/edges.py
@@ -121,11 +121,18 @@ def _run_edges(
     When None (default), uses MAX_LLM_CALLS_PER_PASS=15. cites detection
     is zero-LLM and ignores this.
     """
-    cites_new = _detect_cites(conn, project_id, dry_run=dry_run)
+    # Load the project's non-archived memory once and share it with both
+    # detectors — within a single pass the snapshot is identical, so the
+    # previous two separate full-table reads were pure duplication.
+    memories = _load_memories(conn, project_id)
+    cites_new = _detect_cites(
+        conn, project_id, dry_run=dry_run, memories=memories
+    )
     contradicts_new, llm_calls = _detect_contradicts(
         conn, project_id, dry_run=dry_run, record_conn=conn,
         cross_project=cross_project,
         max_llm_calls=max_llm_calls,
+        memories=memories,
     )
     return cites_new, contradicts_new, llm_calls
 
@@ -134,16 +141,20 @@ def _run_edges(
 
 
 def _detect_cites(
-    conn: Any, project_id: Any, *, dry_run: bool = False
+    conn: Any, project_id: Any, *, dry_run: bool = False, memories: list | None = None
 ) -> int:
     """Detect cites edges via text pattern matching.
 
     A cites edge is inferred when memory row A's content contains a
     reference pattern that matches memory row B's title (case-insensitive,
     normalised). Deterministic; zero LLM cost.
+
+    `memories` lets the caller pass a pre-loaded snapshot so the edges
+    pass reads the table only once; when None it loads its own (keeps the
+    direct-call test contract).
     """
-    # Load all non-archived memory rows for the project.
-    memories = _load_memories(conn, project_id)
+    if memories is None:
+        memories = _load_memories(conn, project_id)
     if len(memories) < 2:
         return 0
 
@@ -154,20 +165,43 @@ def _detect_cites(
             norm = _normalize_title(m["title"])
             if norm:
                 title_index[norm] = m["id"]
+    if not title_index:
+        return 0
+
+    # Pre-compile each title's word-boundary pattern ONCE. Previously the
+    # inner loop rebuilt `re.escape(title)` + re-compiled on every
+    # (row, title) pair; with thousands of distinct titles this blew past
+    # Python's 512-entry regex cache and recompiled constantly (the cause
+    # of the multi-hour single-core peg). Same patterns, same matches.
+    compiled: dict[str, "re.Pattern[str]"] = {
+        norm: re.compile(r"\b" + re.escape(norm) + r"\b", re.IGNORECASE)
+        for norm in title_index
+    }
 
     new_edges = 0
     for m in memories:
         content = m.get("content") or ""
+        if not content:
+            continue
+        # Cheap substring pre-filter: a \bTITLE\b match is impossible
+        # unless the (already-lowercased) title appears as a substring of
+        # the lowercased content, so the C-level `in` test skips the regex
+        # for the vast majority of pairs WITHOUT changing which edges are
+        # produced (the regex still confirms the word boundary).
+        content_lower = content.lower()
+        m_id = m["id"]
         for norm_title, target_id in title_index.items():
-            if target_id == m["id"]:
+            if target_id == m_id:
                 continue
-            if re.search(r"\b" + re.escape(norm_title) + r"\b", content, re.IGNORECASE):
+            if norm_title not in content_lower:
+                continue
+            if compiled[norm_title].search(content):
                 if dry_run:
                     new_edges += 1
                     continue
                 inserted = _insert_edge(
                     conn,
-                    from_id=m["id"],
+                    from_id=m_id,
                     to_id=target_id,
                     edge_type=EDGE_TYPE_CITES,
                     confidence=0.7,
@@ -195,6 +229,7 @@ def _detect_contradicts(
     record_conn: Any = None,
     cross_project: bool = False,
     max_llm_calls: int | None = None,
+    memories: list | None = None,
 ) -> tuple[int, int]:
     """Detect contradicts edges using Phase 5 graph_walk + LLM judgment.
 
@@ -217,7 +252,9 @@ def _detect_contradicts(
         canonical regulatory rule. When False (default), traversal stays
         strict same-project (P3-aligned).
     """
-    all_memories = _load_memories(conn, project_id)
+    all_memories = (
+        memories if memories is not None else _load_memories(conn, project_id)
+    )
     if len(all_memories) < 2:
         return 0, 0
 
@@ -230,10 +267,17 @@ def _detect_contradicts(
         # project that only has 'decision' rows). Cost ceiling still applies.
         seed_memories = all_memories
 
+    # Only candidate_pairs[:cap] is ever LLM-judged, so stop walking seeds
+    # once we have `cap` pairs — the walks (4 DB round-trips each) are the
+    # expensive part, and pairs are appended in deterministic seed order so
+    # the first `cap` are identical either way.
+    cap = max_llm_calls if max_llm_calls is not None else MAX_LLM_CALLS_PER_PASS
     candidate_pairs: list[tuple[UUID, UUID]] = []
     seen: set[frozenset] = set()
 
     for m in seed_memories:
+        if len(candidate_pairs) >= cap:
+            break
         result = walk(
             conn,
             seed_memory_id=m["id"],
@@ -263,7 +307,6 @@ def _detect_contradicts(
 
     new_edges = 0
     llm_calls = 0
-    cap = max_llm_calls if max_llm_calls is not None else MAX_LLM_CALLS_PER_PASS
     for from_id, to_id in candidate_pairs[:cap]:
         if llm_calls >= cap:
             break

--- a/factory/tests/test_cognify_edges_cites.py
+++ b/factory/tests/test_cognify_edges_cites.py
@@ -20,6 +20,7 @@ from cognify.edges import (
     EDGE_TYPE_CITES,
     _detect_cites,
     _insert_edge,
+    _load_memories,
     _normalize_title,
 )
 
@@ -220,3 +221,45 @@ def test_cites_single_memory_no_cross_reference(conn, project_factory):
     found = _detect_cites(conn, project["id"])
 
     assert found == 0
+
+
+@pytest.mark.db
+def test_cites_substring_not_word_boundary_no_edge(conn, project_factory):
+    """A title that appears only as a substring of a LARGER word must NOT
+    cite. This guards the substring pre-filter added for performance: the
+    cheap `in` check passes (the title is a substring), but the
+    word-boundary regex must still reject it — so no edge is created."""
+    project = project_factory("cites_substr")
+    # "Auth" is a substring of "Authentication" but not a whole word there.
+    m_a = _insert_mem(
+        conn, project["id"], "Caller",
+        "We rely on Authentication throughout the service."
+    )
+    m_b = _insert_mem(conn, project["id"], "Auth", "The Auth subsystem.")
+
+    found = _detect_cites(conn, project["id"])
+
+    assert found == 0
+    assert _edge_count(conn, m_a, m_b, EDGE_TYPE_CITES) == 0
+
+
+@pytest.mark.db
+def test_cites_shared_memories_snapshot_equivalent(conn, project_factory):
+    """Passing a pre-loaded `memories` snapshot (the edges-pass load-once
+    path) produces the identical cite count as letting _detect_cites load
+    its own. dry_run avoids inserting so both paths see the same data."""
+    project = project_factory("cites_snapshot")
+    _insert_mem(
+        conn, project["id"], "Impl Notes",
+        "We chose OAuthStrategy and also FeatureFlags."
+    )
+    _insert_mem(conn, project["id"], "OAuthStrategy", "Details.")
+    _insert_mem(conn, project["id"], "FeatureFlags", "More details.")
+
+    internal = _detect_cites(conn, project["id"], dry_run=True)
+    snapshot = _load_memories(conn, project["id"])
+    shared = _detect_cites(
+        conn, project["id"], dry_run=True, memories=snapshot
+    )
+
+    assert internal == shared >= 2


### PR DESCRIPTION
## Problem
`cognify --pass=edges` pegged a core for **~36h** on the bloated BrightBrain table. Root cause: `_detect_cites` is a single-threaded O(N×T) regex double-loop (every memory row × every distinct title) that rebuilt `re.escape()` + recompiled the pattern on **every** (row, title) pair — with thousands of titles this blows past Python's 512-entry regex cache and recompiles constantly. The pass also read the whole project memory table **twice** (once per detector).

## Fix (behavior-preserving — identical edges produced)
- `_run_edges` loads the project's non-archived memory **once** and shares it with both detectors.
- `_detect_cites` **pre-compiles** each title's `\bTITLE\b` pattern once and adds a lowercase **substring pre-filter**: a word-boundary match is impossible unless the (already-lowercased) title is a substring of the lowercased content, so the C-level `in` check skips the regex for the vast majority of pairs *without changing which edges are produced* (the regex still confirms the boundary).
- `_detect_contradicts` **early-exits** the seed walks once `cap` candidate pairs exist — only `candidate_pairs[:cap]` is ever LLM-judged and pairs are appended in deterministic seed order, so the first `cap` are identical.

## Tests
Added regression tests for the exact semantics the optimization could break: substring-but-not-word-boundary → **no** edge, and a pre-loaded `memories` snapshot → identical count. Full cites/contradicts/cap suite green (the one unrelated red — `test_llm_judge_returns_false_without_api_key` — fails identically on `main`; it's environmental, the codex CLI answers without an API key).

## Docs
- `docs/MEMORY_PIPELINE.md` — full-stack architecture map + the "do not optimize these" invariants, from a layer-by-layer audit.
- `docs/plans/2026-06-25-memory-efficiency-roadmap.md` — prioritized efficiency/correctness backlog (what shipped, what's queued, the split-out backfill ON CONFLICT, and the correctness bugs found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)