### PR TITLE
perf(cognify): cites pass — first-word inverted index (exactly equivalent)

### DIFF
--- a/factory/cognify/edges.py
+++ b/factory/cognify/edges.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections import defaultdict
 from typing import Any
 from uuid import UUID
 
@@ -168,47 +169,61 @@ def _detect_cites(
     if not title_index:
         return 0
 
-    # Pre-compile each title's word-boundary pattern ONCE. Previously the
-    # inner loop rebuilt `re.escape(title)` + re-compiled on every
-    # (row, title) pair; with thousands of distinct titles this blew past
-    # Python's 512-entry regex cache and recompiled constantly (the cause
-    # of the multi-hour single-core peg). Same patterns, same matches.
-    compiled: dict[str, "re.Pattern[str]"] = {
-        norm: re.compile(r"\b" + re.escape(norm) + r"\b", re.IGNORECASE)
-        for norm in title_index
-    }
+    # Index titles by their FIRST word, and pre-compile each title's
+    # word-boundary pattern ONCE.
+    #
+    # Exactness: a `\bTITLE\b` match is impossible unless TITLE's first word
+    # appears as a whole word in the content — the leading `\b` plus the
+    # non-word char that follows the first word *inside* TITLE force that
+    # word to be a maximal `\w`-run in the content. So we only test titles
+    # whose first word is present in the content's word set, turning the old
+    # O(rows × all-titles) scan into O(rows × content-words × small-bucket)
+    # WITHOUT changing which edges are produced (the regex still confirms the
+    # full boundary match). This replaces the per-(row,title) substring scan
+    # that, while cheap per op, still ran rows×titles times.
+    titles_by_first_word: dict[str, list[tuple[str, UUID]]] = defaultdict(list)
+    compiled: dict[str, "re.Pattern[str]"] = {}
+    for norm_title, target_id in title_index.items():
+        first = re.match(r"\w+", norm_title)
+        if first is None:
+            continue  # no leading word char → can never \b-match
+        titles_by_first_word[first.group()].append((norm_title, target_id))
+        compiled[norm_title] = re.compile(
+            r"\b" + re.escape(norm_title) + r"\b", re.IGNORECASE
+        )
 
     new_edges = 0
     for m in memories:
         content = m.get("content") or ""
         if not content:
             continue
-        # Cheap substring pre-filter: a \bTITLE\b match is impossible
-        # unless the (already-lowercased) title appears as a substring of
-        # the lowercased content, so the C-level `in` test skips the regex
-        # for the vast majority of pairs WITHOUT changing which edges are
-        # produced (the regex still confirms the word boundary).
         content_lower = content.lower()
         m_id = m["id"]
-        for norm_title, target_id in title_index.items():
-            if target_id == m_id:
-                continue
-            if norm_title not in content_lower:
-                continue
-            if compiled[norm_title].search(content):
-                if dry_run:
-                    new_edges += 1
+        # Only titles whose first word is a whole word in this content can
+        # match. Each title lives in exactly one first-word bucket, and each
+        # distinct content word is visited once, so every (row, target) pair
+        # is considered at most once — same as iterating all titles, fewer
+        # candidates. The substring `in` then the regex confirm the rest.
+        for word in set(re.findall(r"\w+", content_lower)):
+            for norm_title, target_id in titles_by_first_word.get(word, ()):
+                if target_id == m_id:
                     continue
-                inserted = _insert_edge(
-                    conn,
-                    from_id=m_id,
-                    to_id=target_id,
-                    edge_type=EDGE_TYPE_CITES,
-                    confidence=0.7,
-                    created_by="cognify_edges",
-                )
-                if inserted:
-                    new_edges += 1
+                if norm_title not in content_lower:
+                    continue
+                if compiled[norm_title].search(content):
+                    if dry_run:
+                        new_edges += 1
+                        continue
+                    inserted = _insert_edge(
+                        conn,
+                        from_id=m_id,
+                        to_id=target_id,
+                        edge_type=EDGE_TYPE_CITES,
+                        confidence=0.7,
+                        created_by="cognify_edges",
+                    )
+                    if inserted:
+                        new_edges += 1
 
     return new_edges
 

--- a/factory/tests/test_cognify_edges_cites.py
+++ b/factory/tests/test_cognify_edges_cites.py
@@ -16,6 +16,9 @@ import uuid
 
 import pytest
 
+import random
+import re as _re
+
 from cognify.edges import (
     EDGE_TYPE_CITES,
     _detect_cites,
@@ -23,6 +26,29 @@ from cognify.edges import (
     _load_memories,
     _normalize_title,
 )
+
+
+def _reference_cites_edges(mems):
+    """The ORIGINAL O(N×T) cites logic, returning the set of (from, to)
+    string-id pairs. Used to prove the optimized _detect_cites is exactly
+    equivalent. `mems` is a list of dicts with str 'id', 'title', 'content'."""
+    title_index = {}
+    for m in mems:
+        if m["title"]:
+            norm = _normalize_title(m["title"])
+            if norm:
+                title_index[norm] = m["id"]
+    edges = set()
+    for m in mems:
+        content = m["content"] or ""
+        for norm_title, target_id in title_index.items():
+            if target_id == m["id"]:
+                continue
+            if _re.search(
+                r"\b" + _re.escape(norm_title) + r"\b", content, _re.IGNORECASE
+            ):
+                edges.add((m["id"], target_id))
+    return edges
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -263,3 +289,59 @@ def test_cites_shared_memories_snapshot_equivalent(conn, project_factory):
     )
 
     assert internal == shared >= 2
+
+
+@pytest.mark.db
+def test_cites_equivalence_vs_reference_random(conn, project_factory):
+    """The first-word-index _detect_cites must produce the EXACT same edge
+    set as the original O(N×T) regex scan, over randomized data that stresses
+    the tricky cases: word-bounded hits, case differences, multi-word titles,
+    titles glued inside a larger word (substring but no boundary → no edge),
+    and untitled source rows. Compares the real DB edges to a reference."""
+    rng = random.Random(20260625)
+    project = project_factory("cites_equiv_rand")
+
+    # Distinct titles (no normalized-title collisions → no last-wins ambiguity).
+    titles = [
+        "OAuthStrategy", "Auth", "Feature Flags", "DB-Migration", "retry logic",
+        "CacheLayer", "Cache", "Login Flow", "login", "RBAC",
+    ]
+    mems = []
+    # 10 titled rows (one per title) + 15 untitled rows; every row gets content
+    # that embeds random titles in random forms.
+    plan = [(t, True) for t in titles] + [(None, False) for _ in range(15)]
+    rng.shuffle(plan)
+    for title, _titled in plan:
+        parts = ["lorem ipsum dolor"]
+        for _ in range(rng.randint(0, 4)):
+            t = rng.choice(titles)
+            mode = rng.randint(0, 3)
+            if mode == 0:
+                parts.append(t)                       # word-bounded → edge
+            elif mode == 1:
+                parts.append(t.upper())               # case-insensitive → edge
+            elif mode == 2:
+                parts.append("xx" + t.replace(" ", "") + "yy")  # glued → no edge
+            else:
+                parts.append(t.lower())               # word-bounded lower → edge
+        content = " ".join(parts) + " the end."
+        mems.append({"title": title, "content": content})
+
+    for m in mems:
+        m["id"] = str(_insert_mem(conn, project["id"], m["title"], m["content"]))
+
+    _detect_cites(conn, project["id"])
+
+    ids = [m["id"] for m in mems]
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT from_memory_id, to_memory_id FROM devbrain.memory_dependencies "
+            "WHERE edge_type = %s AND from_memory_id = ANY(%s::uuid[])",
+            (EDGE_TYPE_CITES, ids),
+        )
+        actual = {(str(a), str(b)) for a, b in cur.fetchall()}
+
+    reference = _reference_cites_edges(mems)
+
+    assert actual == reference
+    assert reference  # sanity: the random data actually produced some edges


### PR DESCRIPTION
## Follow-up to #165
#165 killed the catastrophic regex-recompile thrash, but a timed dry-run on real BrightBrain data (84k rows × 21k titles) still pinned a core for **5:40+ without finishing** — the detector was still O(rows × all-titles): even the cheap C-level substring pre-filter runs rows×titles times, and the 58k long-content chunk rows dominate.

## Fix (exactly behavior-preserving)
Replace the all-titles inner scan with a **first-word inverted index**. A `\bTITLE\b` match is impossible unless TITLE's first word appears as a whole word in the content (the leading `\b` + the non-word char that follows the first word *inside* TITLE force it to be a maximal `\w`-run), so we only test titles whose first word is in the content's word set, then confirm with the same precompiled regex. → O(rows × content-words × small-bucket), identical edges.

## Test
A **randomized equivalence test** asserts the real `_detect_cites` edge set is byte-identical to a reference implementation of the original O(N×T) regex logic, over data stressing word-bounded hits, case-insensitivity, multi-word titles, glued-substring non-matches, and untitled source rows. Full cites suite green (15); contradicts/cap green (the one unrelated red — `test_llm_judge_returns_false_without_api_key` — fails identically on `main`, environmental: codex CLI answers without an API key).

Verified production timing on the Studio after merge (see PR thread / next deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)