### PR TITLE
perf(db): switch embedding index ivfflat → HNSW (equal recall, smaller index)

### DIFF
--- a/factory/import_memory.py
+++ b/factory/import_memory.py
@@ -494,11 +494,11 @@ def import_from_dict(
                     if inserted >= max(1000, total // 20):
                         logger.info(
                             "[import] %d rows inserted (%d total) — "
-                            "rebuilding ivfflat index + ANALYZE",
+                            "rebuilding embedding index + ANALYZE",
                             inserted, total,
                         )
                         cur.execute(
-                            "REINDEX INDEX devbrain.idx_memory_embedding"
+                            "REINDEX INDEX devbrain.idx_memory_embedding_hnsw"
                         )
                         cur.execute("ANALYZE devbrain.memory")
                 conn.commit()

--- a/factory/tests/test_memory_table.py
+++ b/factory/tests/test_memory_table.py
@@ -232,7 +232,7 @@ def test_memory_embedding_dim(db):
 def test_memory_indexes_exist(db):
     expected = {
         "idx_memory_project_kind",
-        "idx_memory_embedding",
+        "idx_memory_embedding_hnsw",  # was idx_memory_embedding (ivfflat) until migration 046
         "idx_memory_strength",
         "idx_memory_applies_when",
         "idx_memory_provenance",

--- a/migrations/046_embedding_hnsw_index.sql
+++ b/migrations/046_embedding_hnsw_index.sql
@@ -1,0 +1,35 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 046: Switch the embedding ANN index from ivfflat to HNSW
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- Context (2026-06-26): replace the ivfflat embedding index with HNSW.
+-- Measured on the live BrightBrain data (65k embedded rows) both indexes
+-- give identical retrieval quality — tie-robust distance-recall@10 = 1.000
+-- at ivfflat probes=10 AND hnsw ef_search=40, both ~1ms p50. (An earlier
+-- id-overlap metric mis-read tied/duplicate embeddings as recall misses;
+-- it was a measurement artifact, NOT a real recall gap.) HNSW is chosen
+-- for the marginal wins: ~half the on-disk size (337 MB vs 656 MB at this
+-- row count) and no probes tuning to maintain — equal recall/latency.
+--
+-- Build notes:
+--   * `max_parallel_maintenance_workers = 0` — pgvector's PARALLEL HNSW
+--     build allocates a large shared-memory segment that overflows a
+--     containerized Postgres's small /dev/shm (observed: "could not resize
+--     shared memory segment ... No space left on device"). A single-threaded
+--     build uses private backend memory instead. Harmless on bare-metal too.
+--   * On the Studio the HNSW index was already built CONCURRENTLY (a
+--     migration can't use CONCURRENTLY — it runs in a transaction), so the
+--     CREATE here is a no-op there (IF NOT EXISTS) and only the ivfflat DROP
+--     applies. On fresh/small installs (laptop, CI) this builds HNSW in the
+--     migration transaction — fast at those row counts.
+--   * The partial `WHERE archived_at IS NULL` matches deep_search's filter
+--     (mirrors how the queries are written) so the index stays usable.
+
+SET max_parallel_maintenance_workers = 0;
+SET maintenance_work_mem = '2GB';
+
+CREATE INDEX IF NOT EXISTS idx_memory_embedding_hnsw
+    ON devbrain.memory USING hnsw (embedding vector_cosine_ops)
+    WHERE archived_at IS NULL;
+
+DROP INDEX IF EXISTS devbrain.idx_memory_embedding;


### PR DESCRIPTION
## What & why
Switch `idx_memory_embedding` from ivfflat to HNSW.

**Honest framing:** on live BrightBrain data (65k embedded rows), ivfflat (probes=10) and HNSW (ef_search=40) measure **identical** tie-robust distance-recall@10 = **1.000** at ~**1ms** p50. An earlier id-overlap metric had mis-read tied/duplicate embeddings (intentional divergent-provenance dups + zero-vector embed fallbacks) as recall misses — a measurement artifact, *not* a real recall gap. Retrieval was never broken; the "stale by 75 days" symptom was 100% the duplicate-chunk problem (fixed in #164/045).

HNSW is kept for the marginal wins at **equal recall/latency**: ~half the on-disk size (337 MB vs 656 MB at this row count) and no `probes` tuning to maintain.

## Migration 046
- Creates HNSW (partial `WHERE archived_at IS NULL`, matching deep_search's filter), drops the ivfflat index.
- `max_parallel_maintenance_workers = 0` so pgvector's parallel build can't overflow a containerized Postgres's small `/dev/shm` (observed that error during the first build attempt).
- On the Studio the HNSW index was pre-built `CONCURRENTLY` (migrations can't use CONCURRENTLY), so the CREATE is a no-op there and only the DROP applies. Fresh/small installs (laptop, CI) build it in-migration — fast at those row counts. Verified on the laptop: ivfflat dropped, HNSW created, index-presence test green.

## Cross-refs updated
- `import_memory.py` REINDEXes the new `idx_memory_embedding_hnsw` after large imports.
- `test_memory_table.py` expects the new index name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)