### PR TITLE
fix(cognify): extract watermark self-poisoning — pass was a silent no-op

### DIFF
--- a/factory/cognify/extract.py
+++ b/factory/cognify/extract.py
@@ -433,11 +433,25 @@ def extract_from_session(
 
 
 def _last_successful_run(conn: Any, pass_name: str, project_id: Any):
-    """Return the started_at of the most recent successful extract run, or None."""
+    """Return the started_at of the most recent *completed* successful run, or None.
+
+    Must require `completed_at IS NOT NULL`, not just `error IS NULL`. The
+    orchestrator inserts+commits the run-log row at pass START (error and
+    completed_at both NULL), so an `error IS NULL` filter alone matches the
+    CURRENT in-progress run — extract would read its own row, get
+    since=now, and process zero sessions every time (observed 2026-06-26:
+    extract had been a silent no-op, rows_processed=0 every hour). It also
+    matches a crashed run that never recorded its error, which would
+    advance the watermark past sessions it never extracted (silent loss).
+    Requiring a non-NULL completed_at restricts the watermark to runs that
+    actually finished cleanly; re-extraction is idempotent (ON CONFLICT),
+    so a slightly-too-old watermark only costs harmless reprocessing.
+    """
     with conn.cursor() as cur:
         cur.execute(
             "SELECT started_at FROM devbrain.cognify_run_log "
-            "WHERE pass_name = %s AND project_id = %s AND error IS NULL "
+            "WHERE pass_name = %s AND project_id = %s "
+            "  AND completed_at IS NOT NULL AND error IS NULL "
             "ORDER BY started_at DESC LIMIT 1",
             (pass_name, project_id),
         )

--- a/factory/tests/test_cognify_extract.py
+++ b/factory/tests/test_cognify_extract.py
@@ -19,11 +19,73 @@ from cognify.extract import (
     ExtractPass,
     ExtractResult,
     _archive_prior_extracts,
+    _last_successful_run,
     _sessions_since,
     _upsert_memory,
     extract_from_session,
     run_extract_pass,
 )
+
+
+def _insert_run_log(conn, project_id, *, started, completed, error=None):
+    """Insert a cognify_run_log row for the extract pass with explicit
+    started/completed timestamps (strings or None)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO devbrain.cognify_run_log "
+            "(pass_name, project_id, started_at, completed_at, error) "
+            "VALUES ('extract', %s, %s, %s, %s) RETURNING id",
+            (project_id, started, completed, error),
+        )
+        rid = cur.fetchone()[0]
+    conn.commit()
+    return rid
+
+
+@pytest.mark.db
+def test_last_successful_run_ignores_in_progress_and_crashed(conn, project_factory):
+    """The watermark must come only from COMPLETED, error-free runs.
+
+    Regression for the silent no-op bug: the orchestrator commits the
+    run-log row at pass START (completed_at + error both NULL), so an
+    `error IS NULL` filter alone made extract read its own in-progress row
+    (since=now → zero sessions every run). A crashed run (no completed_at,
+    no error) must likewise not advance the watermark."""
+    from datetime import timedelta
+
+    project = project_factory("extract_watermark")
+    pid = project["id"]
+    now = datetime.now(timezone.utc)
+
+    # A genuinely completed, successful run two hours ago.
+    _insert_run_log(
+        conn, pid,
+        started=now - timedelta(hours=2),
+        completed=now - timedelta(hours=2),
+    )
+    # A LATER in-progress run (mimics the orchestrator's start-of-pass insert).
+    _insert_run_log(conn, pid, started=now, completed=None)
+    # A LATER crashed run (completed_at NULL, error NULL).
+    _insert_run_log(conn, pid, started=now - timedelta(minutes=1), completed=None)
+
+    since = _last_successful_run(conn, "extract", pid)
+    assert since is not None, "should fall back to the completed run"
+    # It must be the 2-hours-ago completed run, not the ~now in-progress one.
+    assert since < now - timedelta(minutes=30)
+
+    # And a session created 1 hour ago (AFTER the completed run, BEFORE the
+    # poisoning now() rows) must still be a candidate — proving the later
+    # in-progress/crashed rows didn't advance the watermark.
+    sid = str(uuid.uuid4())
+    _insert_chunk(conn, pid, sid, "content from 1 hour ago")
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE devbrain.memory SET created_at = now() - interval '1 hour' "
+            "WHERE provenance_id = %s",
+            (sid,),
+        )
+    conn.commit()
+    assert sid in _sessions_since(conn, pid, since)
 
 
 def _count_lessons(conn, project_id, session_id):


### PR DESCRIPTION
## Severity: the scheduled `extract` pass had **never** worked
`_last_successful_run` filtered `cognify_run_log` on `error IS NULL` only. But the orchestrator commits the run-log row at pass **start** (`completed_at` + `error` both NULL), so that filter matched the **current in-progress run** → extract read its own row → `since = now` → `_sessions_since(now)` returned nothing → **0 sessions processed every run.**

Confirmed on BrightBrain: every hourly extract row is `rows_processed=0`, and `max(rows_processed)` over *all* history is NULL — the pass never once produced a row. (The decision/pattern atoms that exist came from `end_session`/curator + manual `cognify-bulk`, not this pass.) Same filter also let a **crashed** run (completed_at NULL, no recorded error) advance the watermark past sessions it never extracted — silent loss.

## Fix
Require `completed_at IS NOT NULL AND error IS NULL` — only cleanly-finished runs set the watermark. Re-extraction is idempotent (`ON CONFLICT`), so a slightly-old watermark only costs harmless reprocessing. Adds a regression test (in-progress + crashed rows must not advance the watermark).

## Follow-up (not in this PR)
This restores forward function. ~6,662 BrightBot sessions went un-atomized while the pass was broken — a separate `cognify-bulk --project=brightbot` catch-up (codex backend = no token cost, resumable). Flagged for a go/no-go since it's a multi-hour job on the shared Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)