### PR TITLE
fix(cognify): embed extracted/curated atoms (were invisible to deep_search)

### DIFF
--- a/factory/cognify/embedding.py
+++ b/factory/cognify/embedding.py
@@ -1,0 +1,64 @@
+"""Shared embedding helper for cognify/curator memory writers.
+
+Several memory-writing paths (extract atoms, curator lesson candidates,
+fan-out summaries) need to embed the row's text so `deep_search` (which
+filters `embedding IS NOT NULL`) can find it. They previously each either
+duplicated the Ollama call or — for atom inserts — skipped embedding
+entirely, which left ~22k decision/pattern atoms invisible to search
+(observed 2026-06-26). This is the single source of truth.
+
+`embed_text` degrades gracefully: if Ollama is unreachable it returns None
+so the caller still writes the row (sans vector), and a later reembed pass
+(`scripts/reembed_memory.py`) backfills the vector.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+
+def _ollama_config() -> tuple[str, str]:
+    # Resolve at call time so test envs can monkeypatch / override via env.
+    try:
+        from ingest.config import EMBED_MODEL, OLLAMA_URL  # noqa: PLC0415
+
+        return OLLAMA_URL, EMBED_MODEL
+    except ImportError:
+        import os  # noqa: PLC0415
+
+        return (
+            os.environ.get("DEVBRAIN_OLLAMA_URL", "http://localhost:11434"),
+            os.environ.get("DEVBRAIN_EMBEDDING_MODEL", "snowflake-arctic-embed2"),
+        )
+
+
+def embed_text(text: str) -> list[float] | None:
+    """Embed `text` via Ollama. Returns the vector, or None if Ollama is
+    unreachable / returns nothing (caller writes the row without an
+    embedding; a reembed pass can backfill it later)."""
+    if not text:
+        return None
+    try:
+        ollama_url, model = _ollama_config()
+        data = json.dumps({"model": model, "input": text}).encode()
+        req = urllib.request.Request(
+            f"{ollama_url}/api/embed",
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read())
+        emb = payload.get("embeddings", [None])[0]
+        return emb or None
+    except Exception as exc:  # noqa: BLE001 — graceful: row still written
+        logger.warning("embed_text: Ollama embed failed (%s); row written sans vector", exc)
+        return None
+
+
+def to_vector_literal(embedding: list[float]) -> str:
+    """Format a vector for a pgvector `%s::vector` parameter."""
+    return "[" + ",".join(str(x) for x in embedding) + "]"

--- a/factory/cognify/extract.py
+++ b/factory/cognify/extract.py
@@ -43,6 +43,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID
 
+from cognify.embedding import embed_text, to_vector_literal
 from cognify.orchestrator import CognifyPass, PassResult, register_pass
 from observability.pricing import (
     SONNET_4_6,
@@ -954,7 +955,18 @@ def _upsert_memory(
         session_id,
     ]
 
-    placeholders = ", ".join(["%s"] * len(cols))
+    # Embed the atom so deep_search (which filters embedding IS NOT NULL)
+    # can find it. Skipping this is what left ~22k decision/pattern atoms
+    # invisible to search. embed_text degrades to None if Ollama is down —
+    # the row is still written and a reembed pass backfills the vector.
+    placeholders_list = ["%s"] * len(cols)
+    emb = embed_text(f"{title}\n{content}" if title else content)
+    if emb is not None:
+        cols.append("embedding")
+        vals.append(to_vector_literal(emb))
+        placeholders_list.append("%s::vector")
+
+    placeholders = ", ".join(placeholders_list)
     with conn.cursor() as cur:
         cur.execute(
             f"INSERT INTO devbrain.memory ({', '.join(cols)}) "

--- a/factory/cognify/fanout.py
+++ b/factory/cognify/fanout.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID
 
+from cognify.embedding import embed_text
 from cognify.fanout_prompt import (
     SESSION_RELEVANCE_THRESHOLD,
     SUMMARY_MAX_CHARS,
@@ -611,32 +612,10 @@ def _embed_summary(text: str) -> list[float] | None:
 
     Returns None if Ollama is unreachable — the fan-out row is still
     written (sans embedding) so search via metadata/title still works;
-    a subsequent `cognify reembed` pass can backfill the vector.
+    a subsequent reembed pass can backfill the vector. Thin wrapper over
+    the shared cognify.embedding.embed_text (single source of truth).
     """
-    try:
-        import json
-        import urllib.request
-        # Re-resolve config at call-time so test envs can monkeypatch.
-        try:
-            from ingest.config import OLLAMA_URL, EMBED_MODEL  # noqa: PLC0415
-        except ImportError:
-            # Fallback: ingest package not on path (shouldn't happen under
-            # devbrain's standard installs, but be tolerant in CI).
-            import os  # noqa: PLC0415
-            OLLAMA_URL = os.environ.get("DEVBRAIN_OLLAMA_URL", "http://localhost:11434")
-            EMBED_MODEL = os.environ.get("DEVBRAIN_EMBEDDING_MODEL", "snowflake-arctic-embed2")
-        data = json.dumps({"model": EMBED_MODEL, "input": text}).encode()
-        req = urllib.request.Request(
-            f"{OLLAMA_URL}/api/embed",
-            data=data,
-            headers={"Content-Type": "application/json"},
-        )
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            payload = json.loads(resp.read())
-        return payload["embeddings"][0]
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("cognify_fanout: embedding failed (%s); writing row without vector", exc)
-        return None
+    return embed_text(text)
 
 
 def _json_dumps(obj: dict) -> str:

--- a/factory/curator/end_session.py
+++ b/factory/curator/end_session.py
@@ -42,6 +42,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from cognify.embedding import embed_text, to_vector_literal
+
 logger = logging.getLogger(__name__)
 
 
@@ -176,18 +178,37 @@ def handle_lesson_candidates(
         return
     with conn.cursor() as cur:
         for c in candidates:
-            cur.execute(
-                "INSERT INTO devbrain.memory "
-                "(project_id, kind, title, content, tier, strength, "
-                " applies_when) "
-                "VALUES (%s, 'pattern', %s, %s, 'lesson', 1.0, %s::jsonb)",
-                (
-                    session_project_id,
-                    c.title,
-                    c.content,
-                    _json.dumps(c.applies_when),
-                ),
-            )
+            # Embed so deep_search can find the lesson (it filters
+            # embedding IS NOT NULL). Graceful None if Ollama is down — the
+            # row is still written and a reembed pass backfills the vector.
+            emb = embed_text(f"{c.title}\n{c.content}" if c.title else c.content)
+            if emb is not None:
+                cur.execute(
+                    "INSERT INTO devbrain.memory "
+                    "(project_id, kind, title, content, tier, strength, "
+                    " applies_when, embedding) "
+                    "VALUES (%s, 'pattern', %s, %s, 'lesson', 1.0, %s::jsonb, %s::vector)",
+                    (
+                        session_project_id,
+                        c.title,
+                        c.content,
+                        _json.dumps(c.applies_when),
+                        to_vector_literal(emb),
+                    ),
+                )
+            else:
+                cur.execute(
+                    "INSERT INTO devbrain.memory "
+                    "(project_id, kind, title, content, tier, strength, "
+                    " applies_when) "
+                    "VALUES (%s, 'pattern', %s, %s, 'lesson', 1.0, %s::jsonb)",
+                    (
+                        session_project_id,
+                        c.title,
+                        c.content,
+                        _json.dumps(c.applies_when),
+                    ),
+                )
     conn.commit()
 
 

--- a/factory/tests/test_cognify_extract.py
+++ b/factory/tests/test_cognify_extract.py
@@ -43,6 +43,46 @@ def _insert_run_log(conn, project_id, *, started, completed, error=None):
 
 
 @pytest.mark.db
+def test_upsert_memory_embeds_atom(conn, project_factory, monkeypatch):
+    """Extracted atoms must be embedded so deep_search (which filters
+    embedding IS NOT NULL) can find them. Regression: _upsert_memory used
+    to insert decision/pattern rows with no vector, leaving ~22k atoms
+    invisible to search."""
+    import cognify.extract as ex
+
+    project = project_factory("extract_embed")
+    sid = str(uuid.uuid4())
+
+    # Ollama up → embedding present.
+    monkeypatch.setattr(ex, "embed_text", lambda text: [0.05] * 1024)
+    mid, was_new = ex._upsert_memory(
+        conn, project_id=project["id"], kind="decision",
+        title="Embed Me", content="a decision worth finding", session_id=sid,
+    )
+    assert was_new
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT embedding IS NOT NULL FROM devbrain.memory WHERE id = %s",
+            (mid,),
+        )
+        assert cur.fetchone()[0] is True
+
+    # Ollama down → row still written (graceful), just without a vector.
+    monkeypatch.setattr(ex, "embed_text", lambda text: None)
+    sid2 = str(uuid.uuid4())
+    mid2, _ = ex._upsert_memory(
+        conn, project_id=project["id"], kind="lesson",
+        title="No Ollama", content="written without a vector", session_id=sid2,
+    )
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT embedding IS NULL FROM devbrain.memory WHERE id = %s",
+            (mid2,),
+        )
+        assert cur.fetchone()[0] is True
+
+
+@pytest.mark.db
 def test_last_successful_run_ignores_in_progress_and_crashed(conn, project_factory):
     """The watermark must come only from COMPLETED, error-free runs.
 

--- a/scripts/reembed_memory.py
+++ b/scripts/reembed_memory.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Backfill embeddings for devbrain.memory rows that have none.
+
+Several writers used to insert atoms (decision/pattern/lesson) without an
+embedding, leaving them invisible to deep_search (which filters
+`embedding IS NOT NULL`). The code paths are fixed (cognify.embedding); this
+script backfills the rows that already exist.
+
+Idempotent + resumable: only touches rows where embedding IS NULL AND
+archived_at IS NULL. Re-run any time. Embeds `title\\ncontent` (matching how
+store()/extract embed atoms) in batches via the local Ollama model.
+
+Usage:
+    python scripts/reembed_memory.py [--project SLUG] [--batch 32] [--limit N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+# Make ingest + factory importable regardless of CWD.
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "ingest"))
+sys.path.insert(0, str(_ROOT / "factory"))
+
+import psycopg2  # noqa: E402
+
+from embeddings import embed_batch  # ingest/embeddings.py  # noqa: E402
+
+
+def _database_url() -> str:
+    url = os.environ.get("DEVBRAIN_DATABASE_URL")
+    if url:
+        return url
+    pw = os.environ["DEVBRAIN_DB_PASSWORD"]
+    host = os.environ.get("DEVBRAIN_DB_HOST", "127.0.0.1")
+    port = os.environ.get("DEVBRAIN_DB_HOST_PORT", "5433")
+    name = os.environ.get("DEVBRAIN_DB_NAME", "devbrain")
+    user = os.environ.get("DEVBRAIN_DB_USER", "devbrain")
+    return f"postgresql://{user}:{pw}@{host}:{port}/{name}"
+
+
+def _vec(emb: list[float]) -> str:
+    return "[" + ",".join(str(x) for x in emb) + "]"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--project", default=None, help="project slug to scope to")
+    ap.add_argument("--batch", type=int, default=32)
+    ap.add_argument("--limit", type=int, default=0, help="0 = all")
+    args = ap.parse_args()
+
+    conn = psycopg2.connect(_database_url())
+    conn.autocommit = False
+
+    where = "embedding IS NULL AND archived_at IS NULL"
+    params: list = []
+    if args.project:
+        with conn.cursor() as cur:
+            cur.execute("SELECT id FROM devbrain.projects WHERE slug = %s", (args.project,))
+            row = cur.fetchone()
+            if not row:
+                print(f"project {args.project!r} not found", file=sys.stderr)
+                return 2
+        where += " AND project_id = %s"
+        params.append(row[0])
+
+    with conn.cursor() as cur:
+        cur.execute(f"SELECT count(*) FROM devbrain.memory WHERE {where}", params)
+        total = cur.fetchone()[0]
+    print(f"{total} rows need embedding" + (f" (project={args.project})" if args.project else ""))
+    if total == 0:
+        return 0
+
+    done = 0
+    failed = 0
+    started = time.time()
+    while True:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT id, title, content FROM devbrain.memory WHERE {where} "
+                f"ORDER BY id LIMIT %s",
+                params + [args.batch],
+            )
+            rows = cur.fetchall()
+        if not rows:
+            break
+        texts = [
+            (f"{t}\n{c}" if t else (c or "")) for (_id, t, c) in rows
+        ]
+        try:
+            embs = embed_batch(texts)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  batch embed failed ({exc}); retrying one-by-one", file=sys.stderr)
+            embs = []
+            from embeddings import embed as _embed  # noqa: PLC0415
+            for tx in texts:
+                try:
+                    embs.append(_embed(tx))
+                except Exception:
+                    embs.append(None)
+        with conn.cursor() as cur:
+            for (mid, _t, _c), emb in zip(rows, embs):
+                if emb is None:
+                    failed += 1
+                    continue
+                cur.execute(
+                    "UPDATE devbrain.memory SET embedding = %s::vector WHERE id = %s",
+                    (_vec(emb), mid),
+                )
+                done += 1
+        conn.commit()
+        if args.limit and done >= args.limit:
+            break
+        rate = done / max(1e-6, time.time() - started)
+        print(f"  embedded {done}/{total} ({rate:.0f}/s), {failed} failed", flush=True)
+
+    print(f"done: embedded {done}, failed {failed}, elapsed {time.time()-started:.0f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Bug
`deep_search` filters `embedding IS NOT NULL`, but the atom-writing paths inserted decision/pattern/lesson rows with **no embedding** → invisible to semantic search. On BrightBrain: of 12,849 decisions only **62** were embedded; of 10,092 patterns only **24** (the embedded few came from `store()`). ~22k of the most valuable curated memories were unsearchable.

## Fix
- New `cognify/embedding.py` — single-source `embed_text` (graceful → None if Ollama down, row still written + backfillable) + `to_vector_literal`.
- `extract._upsert_memory` and `curator.handle_lesson_candidates` now embed `title\ncontent` and include it in the INSERT.
- `fanout._embed_summary` delegates to the shared helper (dedup).
- `scripts/reembed_memory.py` — idempotent backfill for existing NULL-embedding rows.
- Test: embeds when Ollama up, degrades gracefully when down.

Backfill of the ~22k existing rows runs separately (local Ollama, free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)