### PR TITLE
feat(cognify): per-(pass,project) advisory lock + slow-pass warning (#5/#6)

### DIFF
--- a/factory/cognify/orchestrator.py
+++ b/factory/cognify/orchestrator.py
@@ -19,8 +19,11 @@ No raw PHI from memory.content flows into cognify_run_log rows.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import os
+import time
 import traceback
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -157,9 +160,21 @@ def run_pass(
     pass_cls = _PASS_REGISTRY[pass_name]
     instance = pass_cls()
 
+    # Skip if another instance already holds this (pass, project) — keeps a
+    # manual run from racing the scheduled one and double-spending LLM. Dry
+    # runs are read-only, so they don't contend. No run-log row is written
+    # for a skipped run, so the watermark isn't touched.
+    if not dry_run and not _try_pass_lock(conn, pass_name, project_id):
+        logger.info(
+            "cognify pass %s (project=%s) already running elsewhere; skipping",
+            pass_name, project_id,
+        )
+        return PassResult(metadata={"pass": pass_name, "skipped": "lock_held"})
+
     log_id = _start_run_log(conn, pass_name, project_id)
     result = PassResult()
     error_text: str | None = None
+    started = time.monotonic()
 
     try:
         # Pass-specific kwargs: only forward optional flags to passes
@@ -179,6 +194,15 @@ def run_pass(
         logger.exception("cognify pass %s failed", pass_name)
     finally:
         _complete_run_log(conn, log_id, result, error_text, dry_run=dry_run)
+        elapsed = time.monotonic() - started
+        if elapsed > _SLOW_PASS_WARN_S:
+            logger.warning(
+                "cognify pass %s (project=%s) took %.0fs (> %ds) — it may be "
+                "starving its schedule; investigate",
+                pass_name, project_id, elapsed, _SLOW_PASS_WARN_S,
+            )
+        if not dry_run:
+            _release_pass_lock(conn, pass_name, project_id)
 
     if error_text:
         raise RuntimeError(
@@ -223,6 +247,42 @@ def run_all(
 
 
 # ── Run log helpers ──────────────────────────────────────────────────────
+
+
+# A cognify pass that runs longer than this logs a warning — with the
+# per-pass advisory lock, the next scheduled run skips while this one is
+# still going, so a silently-pegged pass starves its own cadence. Override
+# via env. (A hard kill would need a watchdog; this is observability.)
+_SLOW_PASS_WARN_S = int(os.environ.get("DEVBRAIN_COGNIFY_SLOW_WARN_S", "1800"))
+
+
+def _pass_lock_key(pass_name: str, project_id: Any) -> int:
+    """Stable 63-bit signed advisory-lock key for a (pass, project) pair."""
+    digest = hashlib.sha256(f"cognify:{pass_name}:{project_id}".encode()).digest()
+    return int.from_bytes(digest[:8], "big", signed=True)
+
+
+def _try_pass_lock(conn: Any, pass_name: str, project_id: Any) -> bool:
+    """Try to acquire the session advisory lock for this (pass, project).
+
+    Session-level (not xact) so it survives the run-log commits during the
+    pass; released explicitly in run_pass's finally, or on connection close
+    if the process dies. Prevents a manual `devbrain cognify` from running
+    concurrently with the scheduled one and double-spending LLM calls.
+    """
+    with conn.cursor() as cur:
+        cur.execute("SELECT pg_try_advisory_lock(%s)", (_pass_lock_key(pass_name, project_id),))
+        return bool(cur.fetchone()[0])
+
+
+def _release_pass_lock(conn: Any, pass_name: str, project_id: Any) -> None:
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_advisory_unlock(%s)", (_pass_lock_key(pass_name, project_id),)
+            )
+    except Exception:  # noqa: BLE001 — connection close releases it anyway
+        pass
 
 
 def _start_run_log(conn: Any, pass_name: str, project_id: Any) -> int:

--- a/factory/tests/test_cognify_advisory_lock.py
+++ b/factory/tests/test_cognify_advisory_lock.py
@@ -1,0 +1,68 @@
+"""The per-(pass, project) advisory lock keeps a manual cognify run from
+racing the scheduled one and double-spending LLM calls."""
+
+from __future__ import annotations
+
+import psycopg2
+import pytest
+
+from cognify.orchestrator import (
+    _release_pass_lock,
+    _try_pass_lock,
+    run_pass,
+)
+
+
+def _run_log_count(conn, pass_name, project_id):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM devbrain.cognify_run_log "
+            "WHERE pass_name = %s AND project_id = %s",
+            (pass_name, project_id),
+        )
+        return cur.fetchone()[0]
+
+
+@pytest.mark.db
+def test_pass_advisory_lock_blocks_concurrent_run(database_url, project_factory):
+    project = project_factory("cognify_lock")
+    pid = project["id"]
+    conn_a = psycopg2.connect(database_url)
+    conn_b = psycopg2.connect(database_url)
+    try:
+        # A acquires; B cannot.
+        assert _try_pass_lock(conn_a, "decay", pid) is True
+        assert _try_pass_lock(conn_b, "decay", pid) is False
+
+        # run_pass on B must skip without writing a run-log row (so the
+        # watermark/observability isn't touched by a no-op skip).
+        before = _run_log_count(conn_b, "decay", pid)
+        result = run_pass(conn_b, "decay", pid)
+        assert result.metadata.get("skipped") == "lock_held"
+        assert _run_log_count(conn_b, "decay", pid) == before
+
+        # After A releases, B can acquire.
+        _release_pass_lock(conn_a, "decay", pid)
+        assert _try_pass_lock(conn_b, "decay", pid) is True
+        _release_pass_lock(conn_b, "decay", pid)
+    finally:
+        conn_a.close()
+        conn_b.close()
+
+
+@pytest.mark.db
+def test_dry_run_does_not_contend_on_lock(database_url, project_factory):
+    """Dry runs are read-only and must not take or be blocked by the lock."""
+    project = project_factory("cognify_lock_dry")
+    pid = project["id"]
+    conn_a = psycopg2.connect(database_url)
+    conn_b = psycopg2.connect(database_url)
+    try:
+        assert _try_pass_lock(conn_a, "decay", pid) is True
+        # Even with the lock held, a dry run proceeds (it skips the lock).
+        result = run_pass(conn_b, "decay", pid, dry_run=True)
+        assert result.metadata.get("skipped") != "lock_held"
+        _release_pass_lock(conn_a, "decay", pid)
+    finally:
+        conn_a.close()
+        conn_b.close()


### PR DESCRIPTION
**#5 advisory lock** — `run_pass` takes a session advisory lock on (pass, project) before running. A manual `devbrain cognify` racing the scheduled run now skips (`{skipped: lock_held}`, no run-log row) instead of double-spending LLM. Released in finally / on connection close. Dry runs skip the lock.

**#6 slow-pass warning** — logs when a pass exceeds `DEVBRAIN_COGNIFY_SLOW_WARN_S` (default 1800s). Hard kill deferred (needs a watchdog; the cites O(N×T) fix already removed the known offender).

Tests: held lock blocks a concurrent run_pass and releases cleanly; dry runs don't contend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)