### PR TITLE
fix(backfill): backfill_chunks ON CONFLICT (race-safe under 045 index)

### DIFF
--- a/factory/backfill_memory.py
+++ b/factory/backfill_memory.py
@@ -67,9 +67,14 @@ logger = logging.getLogger(__name__)
 # ingest/memory_writer.py:record_memory):
 #   * atoms (pattern/decision/lesson/issue) — unique on (provenance_id, kind, title)
 #   * session_summary                       — unique on (provenance_id, kind)
-#   * chunks                                — NO unique index (many chunks share a
-#       session's provenance_id post-migration-032); de-dup on re-run is handled
-#       by the NOT EXISTS guard in backfill_chunks' SELECT, not ON CONFLICT.
+#   * chunks                                — unique on (provenance_id, kind,
+#       md5(content)) since migration 045 (a session's chunks share its
+#       provenance_id post-032, so the content hash is the distinguishing key).
+#       The NOT EXISTS guard in backfill_chunks' SELECT is the cheap pre-filter;
+#       the ON CONFLICT below is the race-safe backstop and is REQUIRED now that
+#       the unique index exists — otherwise a concurrent insert between the
+#       NOT EXISTS check and this INSERT raises a unique violation and the
+#       batch-failure path discards the whole batch's good inserts.
 _INSERT_BASE_SQL = """
     INSERT INTO devbrain.memory
         (project_id, kind, title, content, embedding, provenance_id,
@@ -77,7 +82,11 @@ _INSERT_BASE_SQL = """
     VALUES (%s, %s, %s, %s, %s::vector, %s, %s, %s::jsonb)
 """
 
-_INSERT_CHUNK_SQL = _INSERT_BASE_SQL  # chunks: no ON CONFLICT (see note above)
+_INSERT_CHUNK_SQL = _INSERT_BASE_SQL + """
+    ON CONFLICT (provenance_id, kind, md5(content))
+    WHERE provenance_id IS NOT NULL AND kind = 'chunk'
+    DO NOTHING
+"""
 
 _INSERT_ATOM_SQL = _INSERT_BASE_SQL + """
     ON CONFLICT (provenance_id, kind, title)

--- a/factory/tests/test_backfill_memory.py
+++ b/factory/tests/test_backfill_memory.py
@@ -519,3 +519,31 @@ def test_backfill_all_then_rerun_inserts_zero(db):
     backfill_memory.backfill_all(db, batch_size=200)
     second = backfill_memory.backfill_all(db, batch_size=200)
     assert second["TOTAL"]["inserted"] == 0
+
+
+def test_insert_chunk_sql_idempotent(db):
+    """The chunk INSERT must be idempotent on (provenance_id, kind,
+    md5(content)) via ON CONFLICT DO NOTHING — required since migration 045's
+    unique index, so a re-run or a race can't raise a unique violation that
+    discards a whole backfill batch. Focused on the SQL, not the slow
+    whole-table backfill scan."""
+    pid = _devbrain_project_id(db)
+    prov = str(uuid.uuid4())
+    content = f"{TEST_CONTENT_PREFIX}chunk idempotency body"
+    emb = _embedding_sql(0.1)
+
+    def _ins(c: str) -> int:
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                backfill_memory._INSERT_CHUNK_SQL,
+                (pid, "chunk", None, c, emb, prov,
+                 datetime.now(timezone.utc), None),
+            )
+            rc = cur.rowcount
+            conn.commit()
+        return rc
+
+    assert _ins(content) == 1          # first insert
+    assert _ins(content) == 0          # same key → ON CONFLICT DO NOTHING
+    # Different content under the SAME provenance is a distinct chunk.
+    assert _ins(content + " TWO") == 1


### PR DESCRIPTION
Since migration 045 added the chunk unique index, `backfill_chunks`' plain INSERT raises a unique violation on dups and the batch-failure path discards the whole batch's good inserts. Adds `ON CONFLICT (provenance_id, kind, md5(content)) DO NOTHING` (matches the live record_memory path). Focused idempotency test drives the SQL directly (not the slow whole-table scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)