### PR TITLE
chore(migrations): track 042/043 (applied but uncommitted)

### DIFF
--- a/migrations/042_retrieval_miss_events.sql
+++ b/migrations/042_retrieval_miss_events.sql
@@ -1,0 +1,86 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 042: Retrieval-miss tracking
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- Records when a deep_search returns nothing useful, so we stop dropping
+-- the single most valuable recall-quality signal on the floor. Pairs with
+-- the weekly decay audit (043): query-time misses + temporal drift give two
+-- independent receipts on retrieval health.
+--
+-- Multi-dev: every row is scoped by project_id and attributed by dev_id
+-- (from DEVBRAIN_DEV_ID on the per-dev MCP process) + conversation_uuid
+-- (the start_session chain). Append-only inserts — no write contention on
+-- the shared Mac Studio DB.
+--
+-- Failure-class vocabulary is borrowed verbatim from engram-go so miss data
+-- stays comparable across systems.
+--
+-- top_score is the key field Open Brain lacks: it splits "genuine gap"
+-- (low/zero top_score → missing_content, write the memory) from "precision
+-- failure" (high top_score, wrong answer → stale_ranking, a ranking problem).
+--
+-- Idempotent (CREATE … IF NOT EXISTS). Re-running is a no-op.
+--
+-- Usage:
+--   docker exec -i devbrain-db psql -U devbrain -d devbrain < migrations/042_retrieval_miss_events.sql
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS devbrain.retrieval_miss_events (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    project_id          UUID NOT NULL REFERENCES devbrain.projects(id),
+    -- dev_id matches devbrain.devs.dev_id (VARCHAR(255)); nullable for
+    -- non-attributed callers. Sourced from DEVBRAIN_DEV_ID.
+    dev_id              VARCHAR(255) REFERENCES devbrain.devs(dev_id),
+    -- Chains to the start_session / breadcrumb conversation UUID so a miss
+    -- can be traced back to the session that hit it. No FK — the chain is a
+    -- loose pointer, same convention as memory.provenance_id.
+    conversation_uuid   UUID,
+    query               TEXT NOT NULL,
+    -- Re-embedded query (snowflake-arctic-embed2, 1024d) so repeated misses
+    -- on the same topic cluster — surfaces systemic gaps, not one-offs.
+    query_embedding     vector(1024),
+    filter_source_types TEXT[],
+    result_count        INTEGER NOT NULL DEFAULT 0,
+    -- Best cosine the failed search achieved. Distinguishes a genuine
+    -- content gap (low/zero) from a ranking/precision failure (high).
+    top_score           NUMERIC,
+    failure_class       TEXT NOT NULL CHECK (failure_class IN (
+                          'vocabulary_mismatch',
+                          'aggregation_failure',
+                          'stale_ranking',
+                          'missing_content',
+                          'scope_mismatch',
+                          'other')),
+    notes               TEXT,
+    -- dev_id of the human, or 'claude-code' when the agent self-logs.
+    logged_by           VARCHAR(255)
+);
+
+CREATE INDEX IF NOT EXISTS idx_miss_project_class
+    ON devbrain.retrieval_miss_events (project_id, failure_class);
+
+CREATE INDEX IF NOT EXISTS idx_miss_created
+    ON devbrain.retrieval_miss_events (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_miss_dev
+    ON devbrain.retrieval_miss_events (dev_id)
+    WHERE dev_id IS NOT NULL;
+
+-- Semantic clustering of repeated misses. lists=50 is sized for a table
+-- that grows far slower than devbrain.memory.
+CREATE INDEX IF NOT EXISTS idx_miss_embedding
+    ON devbrain.retrieval_miss_events
+    USING ivfflat (query_embedding vector_cosine_ops) WITH (lists = 50);
+
+COMMENT ON TABLE devbrain.retrieval_miss_events IS
+    'Migration 042: query-time recall failures, project-scoped + dev-attributed. '
+    'Powers the log_miss MCP tool and per-project/per-dev miss-distribution rollups. '
+    'Pairs with the 043 decay audit.';
+
+INSERT INTO devbrain.schema_migrations (filename)
+VALUES ('042_retrieval_miss_events.sql')
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/migrations/043_recall_audit.sql
+++ b/migrations/043_recall_audit.sql
@@ -1,0 +1,89 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 043: Recall decay audit — canonical queries + drift snapshots
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- Weekly regression test on retrieval quality. A per-project set of "golden"
+-- queries whose top results should NOT drift week to week is replayed through
+-- the real deep_search ranking path (runDeepSearchCore — shared with the MCP
+-- tool so the audit can't measure a fiction). Each run snapshots the top
+-- memory_ids + cosine scores per query and diffs against the prior snapshot.
+--
+-- Why tables, not committed JSON (the Open Brain design): on a shared
+-- multi-dev Mac Studio, git-committed snapshots are a merge-race generator.
+-- The DB is the source of truth; canonical queries live here so any dev can
+-- add a golden question without a commit.
+--
+-- Concurrency: UNIQUE (project_id, run_date) is the idempotency seal
+-- (migration-039 pattern). The runner additionally takes
+-- pg_advisory_xact_lock(hashtext('recall_audit:'||project_id)) so two
+-- devs/cron firing the same project audit on the same day is a no-op, not a
+-- double-write.
+--
+-- ivfflat caveat (documented for the runner, not enforced here): devbrain.memory
+-- uses an approximate ivfflat index (010, lists=100). The runner SHOULD
+-- `SET LOCAL ivfflat.probes = <high>` (or force exact scan) so the audit
+-- isolates genuine content/embedding drift from ANN probe jitter.
+--
+-- Idempotent (CREATE … IF NOT EXISTS). Re-running is a no-op.
+--
+-- Usage:
+--   docker exec -i devbrain-db psql -U devbrain -d devbrain < migrations/043_recall_audit.sql
+
+BEGIN;
+
+-- Golden queries whose top results should stay stable as the bank grows.
+CREATE TABLE IF NOT EXISTS devbrain.recall_canonical_queries (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id  UUID NOT NULL REFERENCES devbrain.projects(id),
+    query       TEXT NOT NULL,
+    hint        TEXT,
+    -- What this query is supposed to surface, in prose, for the human
+    -- reading a drift alert. e.g. "must surface the billing-codes SoT".
+    note        TEXT,
+    active      BOOLEAN NOT NULL DEFAULT true,
+    created_by  VARCHAR(255) REFERENCES devbrain.devs(dev_id),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_canonical_project_active
+    ON devbrain.recall_canonical_queries (project_id)
+    WHERE active;
+
+-- One snapshot per project per run-date.
+CREATE TABLE IF NOT EXISTS devbrain.recall_audit_snapshots (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id      UUID NOT NULL REFERENCES devbrain.projects(id),
+    run_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    run_date        DATE NOT NULL,
+    -- host / dev that triggered the run (audit trail; the audit itself is
+    -- a system-level metric, not per-dev).
+    run_by          VARCHAR(255),
+    query_set_size  INTEGER NOT NULL,
+    -- [{query, top_ids[], scores[], result_count, top_score, duration_ms}]
+    results         JSONB NOT NULL,
+    -- vs prior snapshot:
+    -- [{query, jaccard, mean_score_delta, added[], removed[]}]
+    -- jaccard = top-id set overlap (which memories drifted out);
+    -- mean_score_delta = confidence drift even when ids are unchanged
+    -- (the signal Open Brain's id-only Jaccard misses).
+    drift           JSONB,
+    CONSTRAINT uq_audit_per_day UNIQUE (project_id, run_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_project_date
+    ON devbrain.recall_audit_snapshots (project_id, run_date DESC);
+
+COMMENT ON TABLE devbrain.recall_canonical_queries IS
+    'Migration 043: per-project golden queries for the recall decay audit. '
+    'Shared/multi-dev: any dev adds a query via row insert, no git commit.';
+
+COMMENT ON TABLE devbrain.recall_audit_snapshots IS
+    'Migration 043: weekly recall-drift snapshots. UNIQUE(project_id,run_date) '
+    'is the idempotency seal; runner holds a per-project advisory lock. Drift '
+    'beyond threshold fires devbrain_notify rather than failing a CI build.';
+
+INSERT INTO devbrain.schema_migrations (filename)
+VALUES ('043_recall_audit.sql')
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
042_retrieval_miss_events and 043_recall_audit were applied to the live DBs (recorded in schema_migrations) but never committed — fresh clones/CI were missing those tables. Tracking them closes the gap. CI's bootstrap-schema step will now apply them in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)