### PR TITLE
fix(mcp): with_graph silently dead + embed timeout

### DIFF
--- a/mcp-server/src/embeddings.ts
+++ b/mcp-server/src/embeddings.ts
@@ -2,11 +2,17 @@ import { getEmbeddingConfig } from './db.js'
 
 const { url: OLLAMA_URL, model: EMBED_MODEL } = getEmbeddingConfig()
 
+// Cap each Ollama request so a stalled embedding can't hang the tool call
+// indefinitely (deep_search/store/breadcrumb all await an embed). On timeout
+// fetch rejects with an AbortError, which propagates as a normal failure.
+const EMBED_TIMEOUT_MS = Number(process.env.DEVBRAIN_EMBED_TIMEOUT_MS ?? 30000)
+
 export async function embed(text: string): Promise<number[]> {
   const response = await fetch(`${OLLAMA_URL}/api/embed`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ model: EMBED_MODEL, input: text }),
+    signal: AbortSignal.timeout(EMBED_TIMEOUT_MS),
   })
 
   if (!response.ok) {
@@ -22,6 +28,7 @@ export async function embedBatch(texts: string[]): Promise<number[][]> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ model: EMBED_MODEL, input: texts }),
+    signal: AbortSignal.timeout(EMBED_TIMEOUT_MS),
   })
 
   if (!response.ok) {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -555,6 +555,11 @@ server.tool(
       top.map(async (cand) => {
         const r: Record<string, unknown> = {
           chunk_id: cand.chunk_id,
+          // memory_id surfaces the unified-table id (and is what with_graph
+          // seeds the graph walk from). Codebase fallback rows carry '' —
+          // the seed extraction filters those out by length. Without this
+          // field the with_graph seedIds were always empty (silently dead).
+          memory_id: cand.memory_id,
           content: cand.content,
           score: Number(cand.score.toFixed(4)),
           source_type: cand.source_type,


### PR DESCRIPTION
**with_graph** was a no-op: `deep_search` seeded the graph walk from `results.map(r => r.memory_id)`, but result objects only carried `chunk_id` — so `seedIds` was always empty and the enrichment subprocess never ran. Adds `memory_id` to each result (also useful to surface). Codebase rows carry `''` and are filtered out.

**embed timeout** — `embed()`/`embedBatch()` had no fetch timeout, so a stalled Ollama could hang the whole tool call. Adds `AbortSignal.timeout` (30s, `DEVBRAIN_EMBED_TIMEOUT_MS`).

Verified `tsc` builds clean (CI doesn't typecheck TS). Deploy = rebuild dist on the Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)