### PR TITLE
perf(ingest): one transaction per session (atomic raw_session + chunks)

### DIFF
--- a/factory/tests/test_dual_write.py
+++ b/factory/tests/test_dual_write.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import uuid
 from pathlib import Path
 
 import pytest
@@ -29,7 +30,7 @@ sys.path.insert(
     0, str(Path(__file__).resolve().parent.parent.parent / "ingest")
 )
 
-from db import delete_session, insert_chunk  # noqa: E402  (ingest/db.py)
+from db import delete_session, insert_chunk, insert_raw_session  # noqa: E402  (ingest/db.py)
 from memory_writer import record_memory  # noqa: E402  (ingest/memory_writer.py)
 from state_machine import FactoryDB  # noqa: E402
 
@@ -715,3 +716,61 @@ def test_delete_session_is_safe_when_session_missing(db):
     nonexistent = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
     result = delete_session(nonexistent)
     assert result == {"memory": 0, "chunks": 0, "raw_sessions": 0}
+
+
+def test_session_ingest_transaction_is_atomic(db):
+    """insert_raw_session + insert_chunk share a caller cursor and commit
+    together. A rolled-back ingest leaves NOTHING — so the source-hash gate
+    re-ingests the session cleanly instead of stranding a half-indexed one."""
+    pid = _devbrain_project_id(db)
+    shash = f"atomic_test_{uuid.uuid4().hex}"
+    content = f"{TEST_CONTENT_PREFIX}atomic chunk"
+
+    def _ingest(commit: bool) -> str:
+        conn = db._conn()
+        try:
+            with conn.cursor() as cur:
+                sid = insert_raw_session(
+                    project_id=pid, source_app="claude_code",
+                    source_path="test://atomic", source_hash=shash,
+                    session_id=None, model_used=None, started_at=None,
+                    ended_at=None, message_count=1,
+                    raw_content=f"{TEST_CONTENT_PREFIX}raw", summary=None,
+                    files_touched=[], cur=cur,
+                )
+                assert sid
+                insert_chunk(
+                    project_id=pid, source_type="session", source_id=sid,
+                    source_line_start=0, source_line_end=1, content=content,
+                    embedding=[0.1] * 1024, token_count=3, cur=cur,
+                )
+            conn.commit() if commit else conn.rollback()
+            return sid
+        finally:
+            conn.close()
+
+    # Rolled back → nothing in any of the three tables.
+    _ingest(commit=False)
+    with db._conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM devbrain.raw_sessions WHERE source_hash=%s", (shash,)
+        )
+        assert cur.fetchone()[0] == 0
+        cur.execute("SELECT count(*) FROM devbrain.memory WHERE content=%s", (content,))
+        assert cur.fetchone()[0] == 0
+
+    # Committed → raw_session + chunk + dual-written memory all land together.
+    sid = _ingest(commit=True)
+    try:
+        with db._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM devbrain.memory WHERE content=%s AND kind='chunk'",
+                (content,),
+            )
+            assert cur.fetchone()[0] == 1
+            cur.execute(
+                "SELECT count(*) FROM devbrain.raw_sessions WHERE source_hash=%s", (shash,)
+            )
+            assert cur.fetchone()[0] == 1
+    finally:
+        delete_session(sid)

--- a/ingest/db.py
+++ b/ingest/db.py
@@ -80,59 +80,148 @@ def insert_raw_session(
     raw_content: str,
     summary: str | None,
     files_touched: list[str],
+    cur=None,
 ) -> str:
-    with get_connection() as conn, conn.cursor() as cur:
-        # Check if this session already exists (by session_id, not hash)
-        # If so, UPDATE it instead of creating a duplicate
-        existing_id = None
-        if session_id:
-            cur.execute(
-                "SELECT id FROM devbrain.raw_sessions WHERE source_app = %s AND session_id = %s ORDER BY created_at DESC LIMIT 1",
-                (source_app, session_id),
-            )
-            row = cur.fetchone()
-            existing_id = row[0] if row else None
+    """Insert or update the raw_sessions row. When `cur` is given, runs on the
+    caller's cursor without committing (so raw_session + chunks land in one
+    transaction); otherwise self-manages a connection + commit."""
+    if cur is not None:
+        return _insert_raw_session_on_cursor(
+            cur, project_id=project_id, source_app=source_app,
+            source_path=source_path, source_hash=source_hash,
+            session_id=session_id, model_used=model_used,
+            started_at=started_at, ended_at=ended_at,
+            message_count=message_count, raw_content=raw_content,
+            summary=summary, files_touched=files_touched,
+        )
+    with get_connection() as conn, conn.cursor() as own_cur:
+        result = _insert_raw_session_on_cursor(
+            own_cur, project_id=project_id, source_app=source_app,
+            source_path=source_path, source_hash=source_hash,
+            session_id=session_id, model_used=model_used,
+            started_at=started_at, ended_at=ended_at,
+            message_count=message_count, raw_content=raw_content,
+            summary=summary, files_touched=files_touched,
+        )
+        own_cur.connection.commit()
+        return result
 
-        if existing_id:
-            # Update existing session with new content
-            cur.execute(
-                """
-                UPDATE devbrain.raw_sessions
-                SET source_hash = %s, source_path = %s, message_count = %s,
-                    raw_content = %s, ended_at = %s, files_touched = %s::jsonb
-                WHERE id = %s
-                RETURNING id
-                """,
-                (
-                    source_hash, source_path, message_count,
-                    raw_content, ended_at, psycopg2.extras.Json(files_touched),
-                    existing_id,
-                ),
-            )
-            row = cur.fetchone()
-            conn.commit()
-            return str(row[0]) if row else ""
-        else:
-            # Insert new session
-            cur.execute(
-                """
-                INSERT INTO devbrain.raw_sessions
-                    (project_id, source_app, source_path, source_hash, session_id,
-                     model_used, started_at, ended_at, message_count, raw_content,
-                     summary, files_touched)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
-                ON CONFLICT (source_app, source_hash) DO NOTHING
-                RETURNING id
-                """,
-                (
-                    project_id, source_app, source_path, source_hash, session_id,
-                    model_used, started_at, ended_at, message_count, raw_content,
-                    summary, psycopg2.extras.Json(files_touched),
-                ),
-            )
-            row = cur.fetchone()
-            conn.commit()
-            return str(row[0]) if row else ""
+
+def _insert_raw_session_on_cursor(
+    cur,
+    *,
+    project_id: str | None,
+    source_app: str,
+    source_path: str,
+    source_hash: str,
+    session_id: str | None,
+    model_used: str | None,
+    started_at: str | None,
+    ended_at: str | None,
+    message_count: int,
+    raw_content: str,
+    summary: str | None,
+    files_touched: list[str],
+) -> str:
+    """raw_sessions insert-or-update on a caller-owned cursor (no commit)."""
+    # Check if this session already exists (by session_id, not hash).
+    # If so, UPDATE it instead of creating a duplicate.
+    existing_id = None
+    if session_id:
+        cur.execute(
+            "SELECT id FROM devbrain.raw_sessions WHERE source_app = %s AND session_id = %s ORDER BY created_at DESC LIMIT 1",
+            (source_app, session_id),
+        )
+        row = cur.fetchone()
+        existing_id = row[0] if row else None
+
+    if existing_id:
+        # Update existing session with new content
+        cur.execute(
+            """
+            UPDATE devbrain.raw_sessions
+            SET source_hash = %s, source_path = %s, message_count = %s,
+                raw_content = %s, ended_at = %s, files_touched = %s::jsonb
+            WHERE id = %s
+            RETURNING id
+            """,
+            (
+                source_hash, source_path, message_count,
+                raw_content, ended_at, psycopg2.extras.Json(files_touched),
+                existing_id,
+            ),
+        )
+        row = cur.fetchone()
+        return str(row[0]) if row else ""
+    else:
+        # Insert new session
+        cur.execute(
+            """
+            INSERT INTO devbrain.raw_sessions
+                (project_id, source_app, source_path, source_hash, session_id,
+                 model_used, started_at, ended_at, message_count, raw_content,
+                 summary, files_touched)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+            ON CONFLICT (source_app, source_hash) DO NOTHING
+            RETURNING id
+            """,
+            (
+                project_id, source_app, source_path, source_hash, session_id,
+                model_used, started_at, ended_at, message_count, raw_content,
+                summary, psycopg2.extras.Json(files_touched),
+            ),
+        )
+        row = cur.fetchone()
+        return str(row[0]) if row else ""
+
+
+def _insert_chunk_on_cursor(
+    cur,
+    *,
+    project_id: str | None,
+    source_type: str,
+    source_id: str | None,
+    source_line_start: int | None,
+    source_line_end: int | None,
+    content: str,
+    vector_str: str,
+    token_count: int,
+) -> str:
+    """INSERT the chunk + dual-write its memory row on the given cursor.
+    Does NOT commit — the caller owns the transaction."""
+    cur.execute(
+        """
+        INSERT INTO devbrain.chunks
+            (project_id, source_type, source_id, source_line_start,
+             source_line_end, content, embedding, token_count)
+        VALUES (%s, %s, %s, %s, %s, %s, %s::vector, %s)
+        RETURNING id
+        """,
+        (
+            project_id, source_type, source_id, source_line_start,
+            source_line_end, content, vector_str, token_count,
+        ),
+    )
+    row = cur.fetchone()
+    chunk_id = str(row[0]) if row else ""
+    # P2.b dual-write: skip when project_id is None (chunks.project_id
+    # is nullable but devbrain.memory.project_id is NOT NULL). The
+    # SAVEPOINT inside record_memory keeps a memory failure from
+    # poisoning this transaction's commit of the legacy chunk row.
+    if chunk_id and project_id is not None:
+        # provenance_id = the SOURCE session's UUID (chunks.source_id),
+        # not the chunk row's own UUID (migration 032). When source_id is
+        # None (markdown imports), we pass None — the partial unique index
+        # on (provenance_id, kind) excludes NULL.
+        record_memory(
+            cur,
+            project_id=project_id,
+            kind="chunk",
+            content=content,
+            embedding_sql=vector_str,
+            provenance_id=source_id,
+        )
+    return chunk_id
 
 
 def insert_chunk(
@@ -145,56 +234,41 @@ def insert_chunk(
     content: str,
     embedding: list[float],
     token_count: int,
+    cur=None,
 ) -> str:
+    """Insert a chunk + dual-write its memory row.
+
+    When `cur` is given, runs on the caller's cursor without committing so a
+    whole session can be ingested in one transaction (a crash then leaves the
+    session atomically absent rather than half-indexed, which the source-hash
+    gate would otherwise never re-complete). When `cur` is None, manages its
+    own connection + commit (the legacy per-chunk-durable behavior used by the
+    standalone importers)."""
     vector_str = f"[{','.join(str(v) for v in embedding)}]"
-    with get_connection() as conn, conn.cursor() as cur:
-        cur.execute(
-            """
-            INSERT INTO devbrain.chunks
-                (project_id, source_type, source_id, source_line_start,
-                 source_line_end, content, embedding, token_count)
-            VALUES (%s, %s, %s, %s, %s, %s, %s::vector, %s)
-            RETURNING id
-            """,
-            (
-                project_id, source_type, source_id, source_line_start,
-                source_line_end, content, vector_str, token_count,
-            ),
-        )
-        row = cur.fetchone()
-        chunk_id = str(row[0]) if row else ""
-        # P2.b dual-write: skip when project_id is None (chunks.project_id
-        # is nullable but devbrain.memory.project_id is NOT NULL). The
-        # SAVEPOINT inside record_memory keeps a memory failure from
-        # poisoning this transaction's commit of the legacy chunk row.
-        if chunk_id and project_id is not None:
-            # provenance_id = the SOURCE session's UUID (chunks.source_id),
-            # not the chunk row's own UUID. Migration 032 fixed the
-            # historical bug where this was chunk_id; that broke
-            # session-grouped atomization in factory/cognify/. When
-            # source_id is None (e.g. migrate_openclaw_memory.py imports
-            # of pre-chunked markdown), we pass None — the partial
-            # unique index on (provenance_id, kind) excludes NULL.
-            record_memory(
-                cur,
-                project_id=project_id,
-                kind="chunk",
-                content=content,
-                embedding_sql=vector_str,
-                provenance_id=source_id,
-            )
+    kw = dict(
+        project_id=project_id, source_type=source_type, source_id=source_id,
+        source_line_start=source_line_start, source_line_end=source_line_end,
+        content=content, vector_str=vector_str, token_count=token_count,
+    )
+    if cur is not None:
+        return _insert_chunk_on_cursor(cur, **kw)
+    with get_connection() as conn, conn.cursor() as own_cur:
+        chunk_id = _insert_chunk_on_cursor(own_cur, **kw)
         conn.commit()
         return chunk_id
 
 
-def delete_chunks_for_session(session_id: str) -> int:
-    """Delete all chunks for a session (before re-embedding on update)."""
-    with get_connection() as conn, conn.cursor() as cur:
-        cur.execute(
-            "DELETE FROM devbrain.chunks WHERE source_id = %s",
-            (session_id,),
+def delete_chunks_for_session(session_id: str, cur=None) -> int:
+    """Delete all chunks for a session (before re-embedding on update).
+    Runs on the caller's cursor (no commit) when `cur` is given."""
+    if cur is not None:
+        cur.execute("DELETE FROM devbrain.chunks WHERE source_id = %s", (session_id,))
+        return cur.rowcount
+    with get_connection() as conn, conn.cursor() as own_cur:
+        own_cur.execute(
+            "DELETE FROM devbrain.chunks WHERE source_id = %s", (session_id,)
         )
-        count = cur.rowcount
+        count = own_cur.rowcount
         conn.commit()
         return count
 

--- a/ingest/pipeline.py
+++ b/ingest/pipeline.py
@@ -15,7 +15,7 @@ from adapters.gemini import GeminiAdapter
 from adapters.markdown_memory import MarkdownMemoryAdapter
 from adapters.openclaw import OpenClawAdapter
 from chunker import chunk_text
-from db import delete_chunks_for_session, get_or_create_project_id, get_existing_session_id, insert_chunk, insert_raw_session, session_exists, update_session_summary
+from db import delete_chunks_for_session, get_connection, get_or_create_project_id, get_existing_session_id, insert_chunk, insert_raw_session, session_exists, update_session_summary
 from embeddings import embed, embed_batch
 
 ADAPTERS = [ClaudeCodeAdapter(), OpenClawAdapter(), CodexAdapter(), GeminiAdapter(), MarkdownMemoryAdapter()]
@@ -65,6 +65,27 @@ def ingest_file(path: Path, *, force: bool = False) -> bool:
     return _process_session(session, path, fhash, is_update=is_update)
 
 
+def _embed_chunks(chunks) -> list[list[float]]:
+    """Embed all chunk texts (batched, with per-text fallback) BEFORE the write
+    transaction, so the slow Ollama calls hold no DB locks. A failed embed
+    falls back to a zero vector so one bad chunk doesn't abort the whole
+    session (a reembed pass backfills it)."""
+    embeddings: list[list[float]] = []
+    batch_size = 10
+    for i in range(0, len(chunks), batch_size):
+        texts = [c.content for c in chunks[i : i + batch_size]]
+        try:
+            embeddings.extend(embed_batch(texts))
+        except Exception as e:  # noqa: BLE001
+            print(f"  Embedding batch failed, falling back to individual: {e}")
+            for text in texts:
+                try:
+                    embeddings.append(embed(text))
+                except Exception:  # noqa: BLE001
+                    embeddings.append([0.0] * 1024)
+    return embeddings
+
+
 def _process_session(session: UniversalSession, source_path: Path, source_hash: str, *, is_update: bool = False) -> bool:
     """Store raw session, chunk, embed, and store chunks."""
     # Resolve project — adapters only emit slugs from explicit mappings or
@@ -83,58 +104,43 @@ def _process_session(session: UniversalSession, source_path: Path, source_hash: 
 
     print(f"  {'Updating' if is_update else 'Storing'} raw session ({session.message_count} messages, {len(raw_json)} chars JSON)...")
 
-    # Store or update raw session — raw_content gets the structured JSON
-    session_db_id = insert_raw_session(
-        project_id=project_id,
-        source_app=session.source_app,
-        source_path=str(source_path),
-        source_hash=source_hash,
-        session_id=session.session_id,
-        model_used=session.model,
-        started_at=session.started_at,
-        ended_at=session.ended_at,
-        message_count=session.message_count,
-        raw_content=raw_json,
-        summary=None,  # Summarization handled separately
-        files_touched=session.files_changed,
-    )
-
-    if not session_db_id:
-        print(f"  Already exists (hash collision), skipping.")
-        return False
-
-    # If updating, delete old chunks so we re-embed the full session
-    if is_update:
-        delete_chunks_for_session(session_db_id)
-        print(f"  Cleared old chunks for re-embedding")
-
-    # Chunk the text
+    # Chunk + embed BEFORE opening the write transaction so the (slow) Ollama
+    # calls hold no DB locks.
     chunks = chunk_text(raw_text)
     print(f"  Chunking: {len(chunks)} chunks")
+    embeddings = _embed_chunks(chunks)
 
-    if not chunks:
-        return True
-
-    # Embed chunks in batches
-    batch_size = 10
+    # One transaction per session: raw_session + chunks + their memory
+    # dual-writes commit together. A crash mid-ingest then leaves the session
+    # atomically ABSENT (the source-hash gate re-ingests it cleanly on the next
+    # scan) instead of committing raw_session first and stranding a
+    # half-indexed session the hash gate would never re-complete.
+    session_db_id = ""
     total_stored = 0
-
-    for i in range(0, len(chunks), batch_size):
-        batch = chunks[i : i + batch_size]
-        texts = [c.content for c in batch]
-
-        try:
-            embeddings = embed_batch(texts)
-        except Exception as e:
-            print(f"  Embedding batch failed, falling back to individual: {e}")
-            embeddings = []
-            for text in texts:
-                try:
-                    embeddings.append(embed(text))
-                except Exception:
-                    embeddings.append([0.0] * 1024)
-
-        for chunk, emb in zip(batch, embeddings):
+    with get_connection() as conn, conn.cursor() as cur:
+        session_db_id = insert_raw_session(
+            project_id=project_id,
+            source_app=session.source_app,
+            source_path=str(source_path),
+            source_hash=source_hash,
+            session_id=session.session_id,
+            model_used=session.model,
+            started_at=session.started_at,
+            ended_at=session.ended_at,
+            message_count=session.message_count,
+            raw_content=raw_json,
+            summary=None,  # Summarization handled separately
+            files_touched=session.files_changed,
+            cur=cur,
+        )
+        if not session_db_id:
+            print(f"  Already exists (hash collision), skipping.")
+            return False
+        # If updating, delete old chunks so we re-embed the full session.
+        if is_update:
+            delete_chunks_for_session(session_db_id, cur=cur)
+            print(f"  Cleared old chunks for re-embedding")
+        for chunk, emb in zip(chunks, embeddings):
             insert_chunk(
                 project_id=project_id,
                 source_type="session",
@@ -144,8 +150,10 @@ def _process_session(session: UniversalSession, source_path: Path, source_hash: 
                 content=chunk.content,
                 embedding=emb,
                 token_count=chunk.token_count,
+                cur=cur,
             )
             total_stored += 1
+        conn.commit()
 
     print(f"  Stored {total_stored} embedded chunks")
 


### PR DESCRIPTION
Ingestion committed the raw_session first then each chunk separately. A crash mid-session left the raw_session row (with the source_hash) committed but chunks partial — and the hash gate then **skips that file forever**, stranding a permanently half-indexed session (deep_search under-returns it; cognify extracts from incomplete content).

Now embeds all chunks up front (outside the txn), then writes raw_session + chunks + memory dual-writes in **one transaction**. A crash leaves the session atomically absent → the hash gate re-ingests it cleanly. Session-size profile (max 660 chunks, none >1000) makes a single per-session txn trivially safe.

- `db.py`: insert_chunk / insert_raw_session / delete_chunks_for_session take an optional `cur` (caller-owned txn); `cur=None` keeps legacy self-committing behavior for standalone importers.
- `pipeline._process_session` rewritten around one transaction; `_embed_chunks` does the batched embed up front.
- Test: rolled-back ingest leaves nothing; committed lands raw_session + chunk + memory together. (14/14 dual_write suite green.)

Deploy note: the ingest watcher is a long-lived process — needs a restart to pick up new pipeline code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)