### PR TITLE
fix(cognify): explicit codex model (default retired for ChatGPT accounts)

### DIFF
--- a/factory/cognify/extract.py
+++ b/factory/cognify/extract.py
@@ -95,6 +95,16 @@ _CODEX_BIN = os.environ.get("DEVBRAIN_CODEX_BIN") or shutil.which("codex") \
     or "/opt/homebrew/bin/codex"
 _CODEX_TIMEOUT_S = int(os.environ.get("DEVBRAIN_CODEX_TIMEOUT_S", "240"))
 
+# Model passed to `codex exec` when the extract model is the "codex" sentinel.
+# We must pass an EXPLICIT -m: as of 2026-06-02 OpenAI retired the
+# `-codex`-suffixed models (gpt-5.x-codex) for ChatGPT-account auth, and the
+# codex CLI's built-in default is one of those — so letting codex pick its
+# default 400s with "model is not supported when using Codex with a ChatGPT
+# account" on every call. gpt-5.4-mini is the current ChatGPT-account-eligible
+# model (verified working on the Studio); gpt-5.5 needs a newer codex CLI.
+# Override via env when the slug rotates again.
+_CODEX_DEFAULT_MODEL = os.environ.get("DEVBRAIN_CODEX_MODEL", "gpt-5.4-mini")
+
 # JSON Schema for the extractor's final response — same shape the Anthropic
 # path parses ({lessons:[{title,content}], decisions:[...]}).
 _CODEX_OUTPUT_SCHEMA = {
@@ -571,9 +581,12 @@ def _codex_extract(content: str, *, model: str | None = None) -> dict:
             "--output-schema", schema_path,
             "-o", out_path,
         ]
-        # An explicit OpenAI model id (gpt-5/o3/…) overrides codex's default.
-        if model and model.lower() != "codex":
-            cmd += ["-m", model]
+        # Always pass an explicit -m. A caller-supplied OpenAI id wins;
+        # otherwise the "codex" sentinel maps to _CODEX_DEFAULT_MODEL rather
+        # than codex's built-in default (a retired -codex model that 400s for
+        # ChatGPT-account auth — see _CODEX_DEFAULT_MODEL).
+        codex_model = model if (model and model.lower() != "codex") else _CODEX_DEFAULT_MODEL
+        cmd += ["-m", codex_model]
         cmd.append(prompt)
 
         try:

--- a/factory/tests/test_cognify_extract.py
+++ b/factory/tests/test_cognify_extract.py
@@ -42,6 +42,46 @@ def _insert_run_log(conn, project_id, *, started, completed, error=None):
     return rid
 
 
+def test_codex_extract_always_passes_explicit_model(monkeypatch):
+    """codex exec must get an explicit -m. The 'codex' sentinel maps to
+    _CODEX_DEFAULT_MODEL, NOT codex's built-in default (a retired -codex
+    model that 400s for ChatGPT-account auth). Regression for the
+    2026-06-26 'not supported when using Codex with a ChatGPT account'
+    outage that made extract fail every session."""
+    import subprocess
+
+    import cognify.extract as ex
+
+    captured = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        # Write the schema-shaped output the caller reads back.
+        for i, tok in enumerate(cmd):
+            if tok == "-o":
+                with open(cmd[i + 1], "w") as fh:
+                    fh.write('{"lessons": [], "decisions": []}')
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    # Sentinel "codex" → must pass the configured default, not nothing.
+    ex._codex_extract("some session text", model="codex")
+    cmd = captured["cmd"]
+    assert "-m" in cmd, "codex exec must always receive an explicit -m"
+    assert cmd[cmd.index("-m") + 1] == ex._CODEX_DEFAULT_MODEL
+
+    # An explicit model id wins over the sentinel default.
+    ex._codex_extract("some session text", model="gpt-5.5")
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("-m") + 1] == "gpt-5.5"
+
+
 @pytest.mark.db
 def test_upsert_memory_embeds_atom(conn, project_factory, monkeypatch):
     """Extracted atoms must be embedded so deep_search (which filters


### PR DESCRIPTION
OpenAI retired the `-codex`-suffixed models for ChatGPT-account auth on 2026-06-02. The codex CLI defaults to one, and extract passed no `-m` for the `codex` sentinel → every call 400'd ("not supported when using Codex with a ChatGPT account"), then fell back to the rate-limited Anthropic path → **zero atoms**.

Fix: always pass explicit `-m` — caller's id wins, else sentinel → `_CODEX_DEFAULT_MODEL` (env `DEVBRAIN_CODEX_MODEL`, default `gpt-5.4-mini`, verified working on the Studio: 2 sessions → 22 atoms via the free ChatGPT path; `gpt-5.5` needs a newer codex CLI). Unit test locks in the explicit-`-m` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)