### PR TITLE
fix(cognify): Homebrew PATH in codex-using launchd plists (extract/fanout)

### DIFF
--- a/factory/cognify/launchd/com.devbrain.cognify-extract.plist
+++ b/factory/cognify/launchd/com.devbrain.cognify-extract.plist
@@ -32,6 +32,12 @@
         <string>${DEVBRAIN_HOME}</string>
         <key>PYTHONPATH</key>
         <string>${DEVBRAIN_HOME}/factory</string>
+        <!-- launchd's default PATH (/usr/bin:/bin:/usr/sbin:/sbin) omits      -->
+        <!-- Homebrew, so the codex CLI (a `#!/usr/bin/env node` script) fails -->
+        <!-- with "env: node: No such file or directory" (rc=127) under        -->
+        <!-- launchd, silently falling back to the rate-limited Anthropic path.-->
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <!-- @CREDENTIAL_ENV_BLOCK@ — installer emits ANTHROPIC_API_KEY or  -->
         <!-- CLAUDE_CODE_OAUTH_TOKEN here based on env at install time.    -->
     </dict>

--- a/factory/cognify/launchd/com.devbrain.cognify-fanout.plist
+++ b/factory/cognify/launchd/com.devbrain.cognify-fanout.plist
@@ -35,6 +35,12 @@
         <string>${DEVBRAIN_HOME}</string>
         <key>PYTHONPATH</key>
         <string>${DEVBRAIN_HOME}/factory</string>
+        <!-- launchd's default PATH omits Homebrew, so the codex CLI (a   -->
+        <!-- `#!/usr/bin/env node` script) fails with "env: node: No such -->
+        <!-- file or directory" under launchd and falls back to the       -->
+        <!-- rate-limited Anthropic path.                                 -->
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <!-- @CREDENTIAL_ENV_BLOCK@ — installer emits ANTHROPIC_API_KEY  -->
         <!-- or CLAUDE_CODE_OAUTH_TOKEN here based on env at install     -->
         <!-- time.                                                       -->


### PR DESCRIPTION
launchd's default PATH omits Homebrew, so the codex CLI (`#!/usr/bin/env node`) fails under launchd with `env: node: No such file or directory` (rc=127) → extract/fanout silently fall back to the rate-limited Anthropic path. So both codex passes were non-functional under launchd even after the model fix (#178).

Adds `PATH=/opt/homebrew/bin:...` to the extract + fanout plist templates (the codex users). decay/gc/strengthen are pure-Python; edges/resummarize use the Anthropic SDK — untouched.

Verified on the Studio: after applying PATH to the installed extract plist + reloading, a launchd kickstart runs codex (gpt-5.5) with **0 errors** (no node-not-found, no 429).

🤖 Generated with [Claude Code](https://claude.com/claude-code)