### PR TITLE
feat(ingest): ChatGPT-desktop rollout support in the codex adapter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Run ingest adapter tests (no-DB)
+        run: |
+          cd ingest
+          python -m pytest tests/ -v --tb=short -p no:cacheprovider
+
       - name: Run pytest (no-DB unit subset)
         # Explicit allow-list of test files that genuinely don't touch
         # Postgres in setup OR teardown. Many "logic-only" tests (e.g.,

--- a/docs/MEMORY_PIPELINE.md
+++ b/docs/MEMORY_PIPELINE.md
@@ -31,6 +31,39 @@ The direct MCP tools (`store`, `start_session`, `breadcrumb`, `end_session`) byp
 ingest and write `memory` straight from the TS server (`mcp-server/src/index.ts`),
 its own `pg.Pool`, its own Ollama embed call.
 
+#### ChatGPT desktop / Codex rollouts (2026-07-10)
+
+OpenAI's unified ChatGPT desktop app (launched 2026-07-09, bundle
+`com.openai.codex`) is the Codex app rebranded — desktop **Work/Codex
+threads** are written as plaintext rollout JSONL to
+`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` (`originator: "Codex
+Desktop"`), which the `codex` adapter parses. Notes:
+
+- `~/.codex` is already in the codex adapter's `watch_paths`; desktop
+  threads ingest with zero config. Cloud "Chat" tab conversations do NOT
+  land locally (and ChatGPT Business has no Compliance/export API — that
+  is Enterprise-only), so local capture is the only automatable path.
+- Archived rollouts may be `*.jsonl.zst` (needs `zstandard`, in
+  requirements). `event_msg` user/agent messages are parsed as a
+  FALLBACK only — they duplicate `response_item` content in current
+  builds.
+- **Remote devs**: ship lighthouse-related rollouts to the Studio drop
+  zone under `ingest-incoming/<dev>/codex/…` (the codex adapter claims
+  that subtree; it is registered before claude_code so the greedy
+  ".jsonl under ingest-incoming" match can't steal these). Because
+  project attribution comes from `session_meta.cwd` (not the path),
+  sync scripts MUST content-filter to work sessions, e.g.:
+
+  ```bash
+  # sync only rollouts whose cwd is under ~/lighthouse (privacy boundary)
+  for f in $(grep -l '"cwd":"'"$HOME"'/lighthouse'       $HOME/.codex/sessions/*/*/*/rollout-*.jsonl 2>/dev/null); do
+    rsync -az "$f" brightbrain-studio:ingest-incoming/$USER/codex/
+  done
+  ```
+
+  The rollout format is undocumented and version-churny — parse
+  failures should be watched after Codex app updates.
+
 ### B. Cognify (knowledge maintenance)
 Seven scheduled launchd passes, orchestrated by `factory/cognify/orchestrator.py`
 (`PASS_ORDER`), each logged to `cognify_run_log` / `cognify_spend_log`:

--- a/ingest/adapters/codex.py
+++ b/ingest/adapters/codex.py
@@ -89,7 +89,19 @@ class CodexAdapter:
         # Remote-dev drop zone: ingest-incoming/<dev>/codex/… (must be
         # claimed here because ClaudeCodeAdapter matches ANY .jsonl under
         # ingest-incoming; pipeline ADAPTERS order puts codex first).
-        return "ingest-incoming" in s and "/codex/" in s
+        # Positional check — the "codex" segment must be the SECOND path
+        # segment after ingest-incoming (i.e. the per-dev source dir), so a
+        # dev whose drop-zone username happens to be "codex"
+        # (ingest-incoming/codex/projects/…) can't have their Claude Code
+        # transcripts captured-and-dropped here.
+        if "ingest-incoming" not in s:
+            return False
+        parts = file_path.parts
+        try:
+            idx = parts.index("ingest-incoming")
+        except ValueError:
+            return False
+        return len(parts) > idx + 2 and parts[idx + 2] == "codex"
 
     def detect_project(self, file_path: Path) -> str | None:
         """Infer project from session_meta cwd field.

--- a/ingest/adapters/codex.py
+++ b/ingest/adapters/codex.py
@@ -1,49 +1,114 @@
-"""Codex CLI transcript adapter.
+"""Codex / ChatGPT-desktop transcript adapter.
 
-Parses ~/.codex/sessions/**/*.jsonl session files into Universal Session Format.
+Parses ``~/.codex/sessions/**/rollout-*.jsonl`` session files into the
+Universal Session Format. As of 2026-07-09 OpenAI's unified ChatGPT
+desktop app (bundle ``com.openai.codex`` — Chat + Work + Codex tabs) IS
+the Codex app, and desktop Work/Codex threads land in the same rollout
+files (``originator: "Codex Desktop"``), so this one adapter covers both
+the CLI and the desktop app.
 
-Codex JSONL format:
-- type=session_meta: {id, timestamp, cwd, cli_version, model_provider, ...}
-- type=response_item: {type: "message", role: "user"|"assistant"|"developer", content: [{type, text}]}
-- type=event_msg: {type, turn_id, ...}
-- type=turn_context: {type, ...}
+Rollout JSONL line types (undocumented format — parse defensively,
+tolerate unknown types):
+
+- type=session_meta: {id|session_id, timestamp, cwd, originator,
+  cli_version, model_provider, ...}
+- type=response_item: {type: "message", role: user|assistant|developer,
+  content: [{type, text}]} plus function_call / function_call_output
+- type=event_msg: {type: user_message|agent_message|..., message: str}
+  — the chat-narrative stream; it OVERLAPS response_item messages, so it
+  is used only as a FALLBACK when a file yields no response_item
+  messages (guards against format drift between app versions).
+
+Archived sessions may be Zstandard-compressed (``*.jsonl.zst``);
+handled when the optional ``zstandard`` package is available.
+
+Drop-zone support: remote devs ship codex rollouts to the Studio under
+``~/ingest-incoming/<dev>/codex/…`` — detect() claims that subtree, and
+CodexAdapter is registered BEFORE ClaudeCodeAdapter in the pipeline so
+the latter's greedy ".jsonl under ingest-incoming" match can't steal
+these files.
 """
 
 from __future__ import annotations
 
+import io
 import json
+from collections.abc import Iterator
 from pathlib import Path
 
 from .base import UniversalMessage, UniversalSession
 from .claude_code import _lookup_slug
 
 
+def _is_rollout_file(file_path: Path) -> bool:
+    name = file_path.name
+    return name.endswith(".jsonl") or name.endswith(".jsonl.zst")
+
+
+def _open_text(file_path: Path):
+    """Open a rollout file as text, transparently decompressing .zst."""
+    if file_path.name.endswith(".jsonl.zst"):
+        try:
+            import zstandard
+        except ImportError:
+            print(f"  Skipping {file_path}: zstandard not installed")
+            return None
+        fh = open(file_path, "rb")
+        stream = zstandard.ZstdDecompressor().stream_reader(fh)
+        return io.TextIOWrapper(stream, encoding="utf-8")
+    return open(file_path, encoding="utf-8")
+
+
+def _iter_entries(file_path: Path) -> Iterator[dict]:
+    f = _open_text(file_path)
+    if f is None:
+        return
+    with f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(entry, dict):
+                yield entry
+
+
 class CodexAdapter:
     app_name = "codex"
-    file_patterns = ["*.jsonl"]
+    file_patterns = ["*.jsonl", "*.jsonl.zst"]
 
     def detect(self, file_path: Path) -> bool:
-        return file_path.suffix == ".jsonl" and ".codex" in str(file_path)
+        if not _is_rollout_file(file_path):
+            return False
+        s = str(file_path)
+        if ".codex" in s:
+            return True
+        # Remote-dev drop zone: ingest-incoming/<dev>/codex/… (must be
+        # claimed here because ClaudeCodeAdapter matches ANY .jsonl under
+        # ingest-incoming; pipeline ADAPTERS order puts codex first).
+        return "ingest-incoming" in s and "/codex/" in s
 
     def detect_project(self, file_path: Path) -> str | None:
         """Infer project from session_meta cwd field.
 
-        Looks up cwd in ingest.project_mappings from devbrain.yaml.
+        Looks up cwd in ingest.project_mappings / auto_project_roots.
         """
         try:
-            with open(file_path, encoding="utf-8") as f:
-                for line in f:
-                    entry = json.loads(line.strip())
-                    if entry.get("type") == "session_meta":
-                        cwd = entry.get("payload", {}).get("cwd", "")
-                        return _lookup_slug(cwd)
+            for entry in _iter_entries(file_path):
+                if entry.get("type") == "session_meta":
+                    cwd = (entry.get("payload") or {}).get("cwd", "")
+                    return _lookup_slug(cwd)
         except Exception:
             pass
         return None
 
     def parse(self, file_path: Path) -> UniversalSession | None:
-        """Parse a Codex CLI JSONL session file."""
+        """Parse a Codex / ChatGPT-desktop rollout file."""
         messages: list[UniversalMessage] = []
+        event_messages: list[UniversalMessage] = []
         session_id: str | None = None
         model: str | None = None
         first_ts: str | None = None
@@ -51,89 +116,101 @@ class CodexAdapter:
         files_changed: set[str] = set()
 
         try:
-            with open(file_path, encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        entry = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
+            for entry in _iter_entries(file_path):
+                ts = entry.get("timestamp")
+                if ts:
+                    if first_ts is None:
+                        first_ts = ts
+                    last_ts = ts
 
-                    ts = entry.get("timestamp")
-                    if ts:
-                        if first_ts is None:
-                            first_ts = ts
-                        last_ts = ts
+                entry_type = entry.get("type", "")
+                payload = entry.get("payload", {})
+                if not isinstance(payload, dict):
+                    continue
 
-                    entry_type = entry.get("type", "")
-                    payload = entry.get("payload", {})
+                if entry_type == "session_meta":
+                    session_id = payload.get("id") or payload.get("session_id")
+                    model = payload.get("model_provider")
 
-                    if entry_type == "session_meta":
-                        session_id = payload.get("id")
-                        model = payload.get("model_provider")
+                elif entry_type == "response_item":
+                    role = payload.get("role", "")
+                    if role == "developer":
+                        continue  # Skip system/developer messages
 
-                    elif entry_type == "response_item" and isinstance(payload, dict):
-                        role = payload.get("role", "")
-                        if role == "developer":
-                            continue  # Skip system/developer messages
+                    content_parts: list[str] = []
+                    tool_calls: list[dict] = []
+                    raw_content = payload.get("content", [])
 
-                        content_parts: list[str] = []
-                        tool_calls: list[dict] = []
-                        raw_content = payload.get("content", [])
+                    if isinstance(raw_content, list):
+                        for block in raw_content:
+                            if not isinstance(block, dict):
+                                continue
+                            block_type = block.get("type", "")
+                            if block_type in ("input_text", "output_text", "text"):
+                                text = block.get("text", "")
+                                if text:
+                                    content_parts.append(text)
+                            elif block_type == "function_call":
+                                tool_calls.append({
+                                    "tool": block.get("name", ""),
+                                    "args": block.get("arguments", ""),
+                                })
+                            elif block_type == "function_call_output":
+                                output = block.get("output", "")
+                                if output:
+                                    content_parts.append(
+                                        f"[tool_result] {str(output)[:500]}"
+                                    )
+                    elif isinstance(raw_content, str):
+                        content_parts.append(raw_content)
 
-                        if isinstance(raw_content, list):
-                            for block in raw_content:
-                                if not isinstance(block, dict):
-                                    continue
-                                block_type = block.get("type", "")
-                                if block_type in ("input_text", "output_text", "text"):
-                                    text = block.get("text", "")
-                                    if text:
-                                        content_parts.append(text)
-                                elif block_type == "function_call":
-                                    tool_calls.append({
-                                        "tool": block.get("name", ""),
-                                        "args": block.get("arguments", ""),
-                                    })
-                                elif block_type == "function_call_output":
-                                    output = block.get("output", "")
-                                    if output:
-                                        content_parts.append(f"[tool_result] {str(output)[:500]}")
-                        elif isinstance(raw_content, str):
-                            content_parts.append(raw_content)
+                    # Map codex roles to standard roles
+                    std_role = "user" if role == "user" else "assistant"
 
-                        # Map codex roles to standard roles
-                        std_role = "user" if role == "user" else "assistant"
+                    content = "\n".join(content_parts).strip()
+                    if content or tool_calls:
+                        messages.append(UniversalMessage(
+                            role=std_role,
+                            timestamp=ts,
+                            content=content,
+                            tool_calls=tool_calls,
+                        ))
 
-                        content = "\n".join(content_parts).strip()
-                        if content or tool_calls:
-                            messages.append(UniversalMessage(
-                                role=std_role,
-                                timestamp=ts,
-                                content=content,
-                                tool_calls=tool_calls,
-                            ))
+                        # Track file paths from tool calls
+                        for tc in tool_calls:
+                            args = tc.get("args", "")
+                            if isinstance(args, str):
+                                try:
+                                    args = json.loads(args)
+                                except (json.JSONDecodeError, TypeError):
+                                    pass
+                            if isinstance(args, dict):
+                                for key in ("file_path", "path", "file"):
+                                    val = args.get(key)
+                                    if isinstance(val, str) and "/" in val:
+                                        files_changed.add(val)
 
-                            # Track file paths from tool calls
-                            for tc in tool_calls:
-                                args = tc.get("args", "")
-                                if isinstance(args, str):
-                                    try:
-                                        args = json.loads(args)
-                                    except (json.JSONDecodeError, TypeError):
-                                        pass
-                                if isinstance(args, dict):
-                                    for key in ("file_path", "path", "file"):
-                                        val = args.get(key)
-                                        if isinstance(val, str) and "/" in val:
-                                            files_changed.add(val)
+                elif entry_type == "event_msg":
+                    # Chat-narrative stream (desktop app). Collected
+                    # separately — response_item stays authoritative; this
+                    # is the fallback if a future format drops it.
+                    msg_type = payload.get("type", "")
+                    text = payload.get("message", "")
+                    if msg_type in ("user_message", "agent_message") and text:
+                        event_messages.append(UniversalMessage(
+                            role="user"
+                            if msg_type == "user_message"
+                            else "assistant",
+                            timestamp=ts,
+                            content=str(text),
+                        ))
 
         except Exception as e:
             print(f"  Error parsing {file_path}: {e}")
             return None
 
+        if not messages:
+            messages = event_messages
         if not messages:
             return None
 

--- a/ingest/main.py
+++ b/ingest/main.py
@@ -100,7 +100,7 @@ def scan_all():
                 size = path.stat().st_size
             except OSError:
                 continue
-            if size < 1024:
+            if size < (256 if path.name.endswith(".jsonl.zst") else 1024):
                 continue
 
             total += 1
@@ -150,7 +150,7 @@ class SessionFileHandler(FileSystemEventHandler):
                 size = path.stat().st_size
             except OSError:
                 return  # file vanished before we could stat it (transient temp)
-            if size < 1024:
+            if size < (256 if path.name.endswith(".jsonl.zst") else 1024):
                 return
 
             print(f"\n[watch] Detected: {path.name}")

--- a/ingest/main.py
+++ b/ingest/main.py
@@ -87,6 +87,7 @@ def scan_all():
         print(f"\nScanning {watch_dir}...")
         for path in sorted(
             list(watch_dir.rglob("*.jsonl"))
+            + list(watch_dir.rglob("*.jsonl.zst"))
             + list(watch_dir.rglob("session-*.json"))
             + list(watch_dir.rglob("*.md"))
         ):
@@ -136,7 +137,7 @@ class SessionFileHandler(FileSystemEventHandler):
         # silently stops all ingestion (KeepAlive won't fire — the process is
         # still alive, just deaf). So the entire body is exception-safe.
         try:
-            if path.suffix not in (".jsonl", ".json", ".md"):
+            if path.suffix not in (".jsonl", ".json", ".md") and not path.name.endswith(".jsonl.zst"):
                 return
             if path.suffix == ".json" and not path.name.startswith("session-"):
                 return

--- a/ingest/pipeline.py
+++ b/ingest/pipeline.py
@@ -18,7 +18,10 @@ from chunker import chunk_text
 from db import delete_chunks_for_session, get_connection, get_or_create_project_id, get_existing_session_id, insert_chunk, insert_raw_session, session_exists, update_session_summary
 from embeddings import embed, embed_batch
 
-ADAPTERS = [ClaudeCodeAdapter(), OpenClawAdapter(), CodexAdapter(), GeminiAdapter(), MarkdownMemoryAdapter()]
+# CodexAdapter MUST precede ClaudeCodeAdapter: both match .jsonl, and
+# claude_code's detect() greedily claims anything under ingest-incoming —
+# codex drop-zone files (ingest-incoming/<dev>/codex/…) would be stolen.
+ADAPTERS = [CodexAdapter(), ClaudeCodeAdapter(), OpenClawAdapter(), GeminiAdapter(), MarkdownMemoryAdapter()]
 
 
 def file_hash(path: Path) -> str:

--- a/ingest/requirements.txt
+++ b/ingest/requirements.txt
@@ -1,3 +1,4 @@
 psycopg2-binary>=2.9.0
 watchdog>=4.0.0
 pyyaml>=6.0
+zstandard

--- a/ingest/tests/test_codex_adapter.py
+++ b/ingest/tests/test_codex_adapter.py
@@ -1,0 +1,179 @@
+"""Codex / ChatGPT-desktop adapter tests (no DB, no network).
+
+Run from the ingest/ directory: ``cd ingest && python -m pytest tests/``
+(the adapters import ``config`` from the ingest root).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from adapters.codex import CodexAdapter
+from pipeline import ADAPTERS, detect_adapter
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Pad with a trailing comment-ish entry so files clear any size floor.
+    with open(path, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+    return path
+
+
+def _session_meta(**overrides) -> dict:
+    payload = {
+        "id": "sess-123",
+        "cwd": "/Users/dev/lighthouse/brightbot",
+        "originator": "Codex Desktop",
+        "cli_version": "0.142.5",
+        "model_provider": "openai",
+    }
+    payload.update(overrides)
+    return {"timestamp": "2026-07-10T12:00:00Z", "type": "session_meta", "payload": payload}
+
+
+def _response_item(role: str, text: str) -> dict:
+    return {
+        "timestamp": "2026-07-10T12:01:00Z",
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": role,
+            "content": [
+                {"type": "input_text" if role == "user" else "output_text", "text": text}
+            ],
+        },
+    }
+
+
+def _event_msg(msg_type: str, message: str) -> dict:
+    return {
+        "timestamp": "2026-07-10T12:01:00Z",
+        "type": "event_msg",
+        "payload": {"type": msg_type, "message": message},
+    }
+
+
+# ─── detect() ────────────────────────────────────────────────────────
+
+
+def test_detects_codex_home_files():
+    a = CodexAdapter()
+    assert a.detect(Path("/Users/x/.codex/sessions/2026/07/10/rollout-a.jsonl"))
+    assert a.detect(Path("/Users/x/.codex/archived_sessions/rollout-b.jsonl.zst"))
+
+
+def test_detects_drop_zone_codex_subdir_only():
+    a = CodexAdapter()
+    assert a.detect(Path("/Users/lhtdev/ingest-incoming/mark/codex/rollout-a.jsonl"))
+    assert not a.detect(
+        Path("/Users/lhtdev/ingest-incoming/mark/projects/-Users-mark-lighthouse-brightbot/x.jsonl")
+    )
+    assert not a.detect(Path("/Users/x/somewhere/random.jsonl"))
+
+
+def test_pipeline_order_codex_wins_drop_zone():
+    """Codex must precede claude_code or drop-zone codex files are stolen."""
+    names = [type(a).__name__ for a in ADAPTERS]
+    assert names.index("CodexAdapter") < names.index("ClaudeCodeAdapter")
+
+    picked = detect_adapter(
+        Path("/Users/lhtdev/ingest-incoming/mark/codex/rollout-a.jsonl")
+    )
+    assert type(picked).__name__ == "CodexAdapter"
+    # Claude Code drop-zone files still go to claude_code.
+    picked = detect_adapter(
+        Path("/Users/lhtdev/ingest-incoming/mark/projects/-p/x.jsonl")
+    )
+    assert type(picked).__name__ == "ClaudeCodeAdapter"
+
+
+# ─── parse() ─────────────────────────────────────────────────────────
+
+
+def test_parses_response_item_messages(tmp_path):
+    fp = _write_jsonl(
+        tmp_path / ".codex" / "sessions" / "rollout-x.jsonl",
+        [
+            _session_meta(),
+            _response_item("user", "How do I run the tests?"),
+            _response_item("assistant", "Use pytest from the repo root."),
+        ],
+    )
+    s = CodexAdapter().parse(fp)
+    assert s is not None
+    assert s.session_id == "sess-123"
+    assert [m.role for m in s.messages] == ["user", "assistant"]
+    assert s.messages[0].content == "How do I run the tests?"
+
+
+def test_event_msg_is_fallback_not_duplicate(tmp_path):
+    """Desktop rollouts carry messages in BOTH streams — no duplication."""
+    fp = _write_jsonl(
+        tmp_path / ".codex" / "sessions" / "rollout-dup.jsonl",
+        [
+            _session_meta(),
+            _response_item("user", "question text"),
+            _event_msg("user_message", "question text"),
+            _response_item("assistant", "answer text"),
+            _event_msg("agent_message", "answer text"),
+        ],
+    )
+    s = CodexAdapter().parse(fp)
+    assert s is not None
+    assert len(s.messages) == 2  # response_item authoritative
+
+
+def test_event_msg_fallback_when_no_response_items(tmp_path):
+    fp = _write_jsonl(
+        tmp_path / ".codex" / "sessions" / "rollout-em.jsonl",
+        [
+            _session_meta(session_id="sess-456", id=None),
+            _event_msg("user_message", "only in event stream"),
+            _event_msg("agent_message", "reply in event stream"),
+            _event_msg("token_count", ""),  # ignored type
+        ],
+    )
+    s = CodexAdapter().parse(fp)
+    assert s is not None
+    assert s.session_id == "sess-456"  # payload.session_id fallback
+    assert [m.role for m in s.messages] == ["user", "assistant"]
+    assert s.messages[1].content == "reply in event stream"
+
+
+def test_unknown_line_types_tolerated(tmp_path):
+    fp = _write_jsonl(
+        tmp_path / ".codex" / "sessions" / "rollout-unk.jsonl",
+        [
+            _session_meta(),
+            {"timestamp": "t", "type": "world_state", "payload": {"x": 1}},
+            {"timestamp": "t", "type": "inter_agent_communication_metadata", "payload": {}},
+            _response_item("user", "hello"),
+            "not-a-dict-line",
+        ],
+    )
+    s = CodexAdapter().parse(fp)
+    assert s is not None and len(s.messages) == 1
+
+
+def test_empty_file_returns_none(tmp_path):
+    fp = _write_jsonl(tmp_path / ".codex" / "sessions" / "rollout-empty.jsonl", [_session_meta()])
+    assert CodexAdapter().parse(fp) is None
+
+
+def test_zst_rollout_parses_when_zstandard_available(tmp_path):
+    zstandard = pytest.importorskip("zstandard")
+    raw = b"".join(
+        (json.dumps(e) + "\n").encode()
+        for e in [_session_meta(), _response_item("user", "compressed q")]
+    )
+    fp = tmp_path / ".codex" / "archived_sessions" / "rollout-z.jsonl.zst"
+    fp.parent.mkdir(parents=True, exist_ok=True)
+    fp.write_bytes(zstandard.ZstdCompressor().compress(raw))
+    s = CodexAdapter().parse(fp)
+    assert s is not None
+    assert s.messages[0].content == "compressed q"

--- a/ingest/tests/test_codex_adapter.py
+++ b/ingest/tests/test_codex_adapter.py
@@ -74,6 +74,15 @@ def test_detects_drop_zone_codex_subdir_only():
         Path("/Users/lhtdev/ingest-incoming/mark/projects/-Users-mark-lighthouse-brightbot/x.jsonl")
     )
     assert not a.detect(Path("/Users/x/somewhere/random.jsonl"))
+    # A dev whose drop-zone username is "codex" must NOT be claimed — their
+    # files are Claude Code transcripts (positional segment check).
+    assert not a.detect(
+        Path("/Users/lhtdev/ingest-incoming/codex/projects/-Users-c-lighthouse-x/y.jsonl")
+    )
+    # Deeper nesting under the codex source dir still matches.
+    assert a.detect(
+        Path("/Users/lhtdev/ingest-incoming/mark/codex/2026/07/rollout-b.jsonl.zst")
+    )
 
 
 def test_pipeline_order_codex_wins_drop_zone():

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ anthropic>=0.40
 pytest>=8.0
 pytest-asyncio>=0.23
 pytest-cov>=4.0
+zstandard


### PR DESCRIPTION
## ChatGPT Work app transcript ingest (BYOA epic, PR C)

**Verified on Patrick's machine:** the new unified ChatGPT desktop app (launched 2026-07-09) is the Codex app rebranded (`com.openai.codex`, v26.707.x) and writes desktop **Work/Codex threads** as plaintext rollout JSONL to `~/.codex/sessions/` (`originator: "Codex Desktop"`). The existing codex adapter already parses these; this PR closes the gaps:

- `event_msg` (`user_message`/`agent_message`) parsed as **fallback only** — verified they duplicate `response_item` messages in current builds, so parsing both would double-ingest; the fallback guards against future format drift.
- `.jsonl.zst` archived sessions supported (adapter/watcher/scan + `zstandard` dep).
- `session_meta.payload.session_id` fallback (current builds carry both `id` and `session_id`).
- **Drop-zone collision fix:** remote devs will ship rollouts to `ingest-incoming/<dev>/codex/…`; ClaudeCodeAdapter greedily claims any `.jsonl` under `ingest-incoming`, so CodexAdapter now precedes it in `ADAPTERS` with a narrow match (regression-tested).
- Docs: MEMORY_PIPELINE.md section incl. the **cwd-filtered team sync** pattern (only sessions with `cwd` under `~/lighthouse` ship — same privacy boundary as the Claude Code sync). Note: cloud "Chat" conversations don't land locally, and ChatGPT **Business has no Compliance/export API** (Enterprise-only) — local capture is the only automatable path.

### Tests
9 new no-DB adapter tests in `ingest/tests/` (detect rules, adapter ordering, response_item parsing, no-duplication, event_msg fallback, unknown-type tolerance, zst) — added as a CI step.

Post-merge ops: Studio `git pull` + restart ingest watcher; add `~/.codex` to the Studio's watch_paths if remote-dev codex capture is wanted (laptop already watches it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124s55wpoideRDQDCkirBh9