### PR TITLE
Add local-first resilience and optional remote medic support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,32 @@
 # Summarization / NL-query model.
 # DEVBRAIN_SUMMARY_MODEL=qwen2.5:7b
 
+# ─── Host resilience (all optional) ──────────────────────────────────────────
+
+# The local watchdog/self-heal profile needs none of these values. Configure
+# them only when enabling the corresponding installer option.
+#
+# Generic outbound heartbeat. The URL must be HTTPS. The token is loaded from
+# this mode-0600 .env at runtime and is never written into launchd/systemd
+# service definitions or the install manifest.
+# DEVBRAIN_HEARTBEAT_URL=https://monitor.example.com/devbrain/heartbeat
+# DEVBRAIN_HEARTBEAT_TOKEN=
+
+# Existing services the watchdog may check. A VPS is not required; omit the
+# tunnel label for local-only operation.
+# DEVBRAIN_TUNNEL_LABEL=com.example.devbrain-tunnel
+# DEVBRAIN_AGENT_BUS_HEALTH_URL=http://127.0.0.1:18900/healthz
+
+# Backup freshness is opt-in because DevBrain does not install a generic backup
+# scheduler. Set this only when an existing job produces files at this path.
+# DEVBRAIN_BACKUP_PATH=/absolute/path/to/backups
+
+# Signed medic. These paths contain PUBLIC keys only. Generate and retain the
+# matching private keys on a separate operator machine.
+# DEVBRAIN_INSTANCE_ID=my-devbrain-studio
+# DEVBRAIN_MEDIC_PRIMARY_PUBLIC_KEY_FILE=/path/to/operator-primary.pub
+# DEVBRAIN_MEDIC_CONFIRM_PUBLIC_KEY_FILE=/path/to/operator-confirm.pub
+
 # ─── Anthropic credentials (cognify LLM-cost passes) ─────────────────────────
 
 # Cognify (extract + edges) calls the Anthropic Messages API to derive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resilience-macos:
+    name: resilience installer (macOS)
+    runs-on: macos-14
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Validate macOS installer and resilience tests
+        run: |
+          /bin/bash -n scripts/install.sh scripts/install-resilience.sh scripts/reinstall.sh
+          cd factory
+          python -m pytest \
+            tests/test_resilience_core.py \
+            tests/test_resilience_install.py \
+            tests/test_resilience_medic.py \
+            tests/test_resilience_medic_install.py \
+            tests/test_resilience_surfaces.py \
+            -p no:cacheprovider --tb=short -q
+
   pytest:
     name: pytest (no-DB subset)
     runs-on: ubuntu-latest
@@ -73,6 +104,11 @@ jobs:
             tests/test_port_registry.py \
             tests/test_seed_ports.py \
             tests/test_compose_env.py \
+            tests/test_resilience_core.py \
+            tests/test_resilience_install.py \
+            tests/test_resilience_medic.py \
+            tests/test_resilience_medic_install.py \
+            tests/test_resilience_surfaces.py \
             -p no:cacheprovider --tb=short -q
 
   pytest-db:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -502,7 +502,7 @@ Smoke-test the server by hand:
 # Exits immediately on EOF; confirms the binary is runnable.
 ```
 
-### 5.1 Optional: Agent Bus
+### 5.1 Optional: PKRelay browser bridge
 
 DevBrain integrates with **PKRelay**, a companion browser bus that lets
 agents see and interact with web pages over MCP. Skip if you only need
@@ -519,6 +519,10 @@ native-messaging host, and exposes browser tools (page snapshots,
 clicks, form fills) to any MCP client. The DevBrain installer offers
 the same flow under "PKRelay (optional)" — opt out with
 `--no-pkrelay` if scripting an unattended install.
+
+Agent-bus is a separate remote-orchestration companion. DevBrain contains its
+MCP client, but does not vendor or silently install the daemon. An existing
+agent-bus endpoint can be monitored by the optional host-resilience profile.
 
 ### 5.2 Multi-dev setup
 
@@ -578,6 +582,24 @@ re-run, locally-customized channels preserved on the destination.
 See [docs/MIGRATING.md](docs/MIGRATING.md) for the full operator
 playbook including pre-flight schema checks, scoped exports
 (`--project SLUG`), and troubleshooting.
+
+### 5.4 Optional host resilience and signed medic
+
+An always-on host can install a bounded watchdog that checks the container
+runtime, database container, Ollama, ingest, disk space, and configured
+companions. Local recovery requires no VPS:
+
+```bash
+devbrain setup resilience
+# or:
+./scripts/install-resilience.sh --profile studio --container-runtime colima
+```
+
+Workstation/studio profiles, heartbeat configuration, tunnel and agent-bus
+checks, opt-in monitoring for an existing backup producer, signed medic key
+setup, recovery policy, fire drills, and exact manifest-based uninstall are
+documented in
+[docs/HOST_OPERATIONS.md](docs/HOST_OPERATIONS.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ This single command:
 2. Installs every dependency (Homebrew/apt, Docker, Ollama, Node,
    Python, gh, psql)
 3. Starts PostgreSQL, pulls Ollama models (~10 GB, one-time)
-4. Builds the MCP server, optionally installs the launchd ingest
-   service and PKRelay
+4. Builds the MCP server; optionally installs ingest, host resilience,
+   and PKRelay
 5. Runs `devbrain doctor` to verify
 6. Installs `devbrain` and `install-devbrain` as global commands
 7. Auto-launches the interactive setup wizard for projects,
@@ -79,6 +79,23 @@ curl -fsSL https://raw.githubusercontent.com/nooma-stack/devbrain/main/scripts/i
 
 **Manual install** — if you'd rather follow each step yourself, see
 [**INSTALL.md**](INSTALL.md).
+
+### Optional host resilience
+
+Always-on hosts can add bounded local self-healing without a VPS:
+
+```bash
+./scripts/install.sh --profile=studio
+# or on an existing install:
+devbrain setup resilience
+```
+
+The `workstation` profile remains the default and does not silently install
+the service under `--yes`. The `studio` profile enables it and defaults to
+Colima. Outbound heartbeat, an existing tunnel check, agent-bus health, and
+the signed medic are separate opt-ins. Backup freshness is also opt-in and
+requires an existing backup producer plus an explicit output path. See
+[Host resilience and medic operations](docs/HOST_OPERATIONS.md).
 
 ---
 

--- a/bin/devbrain
+++ b/bin/devbrain
@@ -12,11 +12,12 @@ while [[ -L "$_target" ]]; do
 done
 DEVBRAIN_DIR="$(cd "$(dirname "$_target")/.." && pwd)"
 
-# ─── Auto-update on `devbrain setup` ───────────────────────────────────────
+# ─── Auto-update before setup/upgrade Python starts ─────────────────────────
 # Pull the latest main before the wizard runs, so users always get the newest
-# setup code (fixes, new prompts, etc.) without having to cd and git pull.
+# setup/upgrade code (fixes, migrations, dependency steps, etc.) without
+# running stale Python after an in-process pull.
 # Skipped if:
-#   - first arg isn't "setup"
+#   - first arg isn't "setup" or "upgrade"
 #   - DEVBRAIN_NO_UPDATE=1 is set
 #   - not on the 'main' branch (user is testing a feature branch)
 #   - working tree has uncommitted changes
@@ -54,7 +55,15 @@ _auto_update() {
     echo ""
 }
 
-if [[ "${1:-}" == "setup" ]] && [[ "${DEVBRAIN_NO_UPDATE:-}" != "1" ]]; then
+_skip_auto_update=false
+for _arg in "$@"; do
+    if [[ "$_arg" == "--no-pull" ]]; then
+        _skip_auto_update=true
+    fi
+done
+if [[ "${1:-}" =~ ^(setup|upgrade)$ ]] \
+   && [[ "${DEVBRAIN_NO_UPDATE:-}" != "1" ]] \
+   && ! $_skip_auto_update; then
     _auto_update
 fi
 

--- a/docs/HOST_OPERATIONS.md
+++ b/docs/HOST_OPERATIONS.md
@@ -1,0 +1,279 @@
+# DevBrain host resilience
+
+DevBrain can install an optional host watchdog for an always-on workstation or
+Studio. Local recovery is fully functional without a VPS, cloud account, or
+inbound network port.
+
+## Profiles
+
+| Profile | Service | Interval | Default behavior |
+|---|---|---:|---|
+| `workstation` | User LaunchAgent / user systemd unit | 5 minutes | Opt-in; Docker Desktop recovery on macOS |
+| `studio` | macOS system LaunchDaemon running as the non-root install user, or user systemd | 1 minute | Enabled by the main installer; Colima recovery on macOS |
+
+Both profiles check the container runtime, `devbrain-db`, Ollama, disk space,
+and any explicitly selected integrations. Ingest is also checked on macOS; it
+is disabled on Linux because the currently documented ingest daemon is a
+privileged system unit. Recovery has a failure threshold, cooldown, and
+maximum-attempt circuit breaker.
+
+Docker checks and Compose recovery are pinned to the selected backend context
+(`colima`, `desktop-linux`, `orbstack`, or `default`) so another running Docker
+backend cannot satisfy the wrong profile.
+
+## Install choices
+
+Local-only workstation:
+
+```bash
+./scripts/install-resilience.sh \
+  --profile workstation \
+  --container-runtime docker-desktop
+```
+
+Local-only Studio (no VPS):
+
+```bash
+./scripts/install-resilience.sh \
+  --profile studio \
+  --container-runtime colima
+```
+
+On Linux, use `--container-runtime docker-engine`. Runtime availability is
+monitored there, but restarting the privileged Docker daemon is intentionally
+left to the host's service policy.
+
+Linux uses a user systemd unit. The `studio` installer enables user lingering
+so the unit runs without an interactive login. Uninstall leaves lingering
+enabled because other user services may depend on it.
+
+The full DevBrain installer exposes the same choices:
+
+```bash
+./scripts/install.sh --profile=studio
+./scripts/install.sh --profile=workstation --with-resilience
+```
+
+Or use the guided flow:
+
+```bash
+devbrain setup resilience
+```
+
+### Optional outbound heartbeat
+
+Set these in the repository's mode-0600 `.env`:
+
+```dotenv
+DEVBRAIN_HEARTBEAT_URL=https://monitor.example.com/devbrain/heartbeat
+DEVBRAIN_HEARTBEAT_TOKEN=replace-with-random-secret
+```
+
+Then install with `--with-heartbeat`. Heartbeats are outbound HTTPS POSTs and
+the token is required: DevBrain signs the canonical JSON body with HMAC-SHA256.
+The token must live in the repository's `.env` so the background service can
+load it after reboot. Secret values are not copied into the service definition
+or install manifest.
+
+The receiving monitor is responsible for its own dead-man timer. A missing or
+late request should alert independently of the monitored host.
+
+### Optional tunnel and agent-bus checks
+
+These checks do not install a VPS, tunnel, or agent-bus daemon. They monitor
+services the operator has already installed:
+
+```bash
+DEVBRAIN_TUNNEL_LABEL=com.example.devbrain-tunnel \
+./scripts/install-resilience.sh \
+  --profile studio \
+  --container-runtime colima \
+  --with-tunnel-check
+
+./scripts/install-resilience.sh \
+  --profile studio \
+  --container-runtime colima \
+  --with-agent-bus-check \
+  --agent-bus-url http://127.0.0.1:18900/healthz
+```
+
+The agent-bus health probe is TCP-only. DevBrain does not copy or expose an
+agent-bus credential.
+
+### Optional backup-freshness check
+
+DevBrain does not currently install or schedule a generic backup producer.
+Enable freshness monitoring only when another job is already writing backups,
+and name that output path explicitly:
+
+```bash
+./scripts/install-resilience.sh \
+  --profile studio \
+  --container-runtime colima \
+  --with-backup-check \
+  --backup-path /absolute/path/to/backups
+```
+
+`DEVBRAIN_BACKUP_PATH` can supply the path instead. A normal Studio install
+does not add this check, so it cannot report a permanent failure for a backup
+job that was never configured.
+
+## Recovery matrix
+
+| Check | Automatic recovery |
+|---|---|
+| Docker-compatible runtime | Start configured Colima, Docker Desktop, or OrbStack; Linux Docker Engine is detection-only |
+| `devbrain-db` | `docker compose up -d devbrain-db` in the configured repository |
+| Ollama | Start the Homebrew service on macOS; detection-only on Linux |
+| Ingest | Kick-start the exact launchd label on macOS; disabled by default on Linux because the documented daemon is a privileged system unit |
+| Configured tunnel | Kick-start/restart its exact declared service |
+| Disk space | Detection only; DevBrain never auto-deletes data |
+| Backup freshness | Detection only; a stale backup never triggers deletion or overwrite |
+| Agent bus | Detection only |
+
+The runtime has no generic command or shell recovery type. Configuration keys
+such as `command`, `cmd`, `argv`, and `shell` are rejected.
+
+## Signed medic (advanced)
+
+The medic is an optional filesystem queue. It does not expose a listener and
+does not require a VPS. Health and queue schedules are independent, and it
+checks at most one queued task every 10 seconds so a backlog is never processed
+as an unbounded batch. Status and diagnosis tasks require one primary signature.
+A heal task requires:
+
+1. Two distinct authorized Ed25519 keys (`primary` and `confirm`).
+2. Signatures over the same complete canonical task body.
+3. A matching instance ID.
+4. An unexpired task and unused nonce.
+5. A check explicitly listed in the host's medic allowlist.
+6. A typed recovery already declared in the local watchdog configuration.
+7. A fresh failed health check plus the same failure-threshold, cooldown, and
+   maximum-attempt policy used by automatic recovery.
+
+There is no shell, reboot, arbitrary configuration write, screenshot, or
+AI-generated command action.
+
+Generate the keys on an operator machine—not on the Studio:
+
+```bash
+devbrain ops medic keygen \
+  --private ~/.config/devbrain-medic/primary.key \
+  --public ~/.config/devbrain-medic/primary.pub
+
+devbrain ops medic keygen \
+  --private ~/.config/devbrain-medic/confirm.key \
+  --public ~/.config/devbrain-medic/confirm.pub
+```
+
+Back up both private files securely. Copy only the `.pub` files to the host,
+then choose diagnosis-only mode:
+
+```bash
+./scripts/install-resilience.sh \
+  --profile studio \
+  --container-runtime colima \
+  --with-medic diagnose \
+  --medic-instance-id nooma-studio \
+  --medic-primary-public-key /path/to/primary.pub
+```
+
+Or explicitly enable selected heal actions:
+
+```bash
+./scripts/install-resilience.sh \
+  --profile studio \
+  --container-runtime colima \
+  --with-medic heal \
+  --medic-instance-id nooma-studio \
+  --medic-primary-public-key /path/to/primary.pub \
+  --medic-confirm-public-key /path/to/confirm.pub \
+  --medic-allow-check postgres \
+  --medic-allow-check ollama
+```
+
+Create a short-lived task on the operator machine:
+
+```bash
+devbrain ops medic task \
+  --instance-id nooma-studio \
+  --action heal \
+  --check postgres \
+  --sign operator-primary=~/.config/devbrain-medic/primary.key \
+  --sign operator-confirm=~/.config/devbrain-medic/confirm.key \
+  --output heal-postgres.json
+```
+
+Deliver the JSON file through an operator-controlled channel into:
+
+```text
+~/.devbrain/resilience/medic-queue/inbox/
+```
+
+Deliver it under a non-`.json` temporary name, then rename it to `.json` on the
+same filesystem. That atomic handoff prevents the watcher from claiming a
+partially copied file.
+
+That channel can be local copy, LAN SSH, an existing secure file-sync system,
+or a separately managed tunnel. DevBrain deliberately does not create an
+internet-facing medic endpoint.
+
+Medic result and archive files are local audit records, not host-signed
+attestations; authenticate any transport used to retrieve them. Disabling,
+re-keying, or uninstalling the medic atomically moves pending inbox/processing
+content under `medic-queue/quarantine/`. Outbox, archive, rejected, replay, and
+quarantine history are retained intentionally for audit and are never executed.
+
+## Status, fire drill, and uninstall
+
+```bash
+devbrain ops status
+devbrain ops run-once
+devbrain devdoctor
+```
+
+Recommended fire drill:
+
+1. Record a healthy `devbrain ops status`.
+2. Stop one non-destructive test target, such as Ollama.
+3. Run two foreground cycles (the default failure threshold is two).
+4. Confirm the typed recovery and a new healthy heartbeat.
+5. Confirm any external dead-man monitor receives heartbeats.
+
+The installer writes an exact artifact manifest at:
+
+```text
+~/.devbrain/resilience/install-manifest.json
+```
+
+The main installer also records the selected container runtime and exact
+Docker context at `~/.devbrain/install-target.json`, even when resilience is
+disabled. Idempotent installer reruns preserve that target and refuse to
+switch runtimes without a separate database migration.
+
+`scripts/reinstall.sh` uses the recorded target so it cannot silently clean
+the ambient Docker context while leaving the real DevBrain database behind.
+Explicit target flags must agree with existing metadata. For an older install
+without metadata, pass both
+`--container-runtime` and `--docker-context`; reinstall fails closed if it
+cannot resolve the target.
+
+`devbrain upgrade` refreshes the root Python requirements and, when this
+manifest exists, restarts the installed resilience service without replacing
+its runtime configuration. Password-rotation container recreation is pinned
+to the recorded Docker context (or to the single context where `devbrain-db`
+can be proven to exist for a legacy install). The command wrapper updates
+before loading the upgrade Python code. For an installation that predates
+that wrapper behavior, bootstrap it once with:
+
+```bash
+cd ~/devbrain
+git pull --ff-only
+./bin/devbrain upgrade --no-pull
+```
+
+Uninstall removes only paths named by that manifest:
+
+```bash
+./scripts/install-resilience.sh --uninstall --yes
+```

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import subprocess
 import sys
 import time
 import urllib.request
@@ -948,6 +949,7 @@ def setup_cmd(section):
       devbrain setup channels     — notification channels (tmux, Slack, Telegram, ...)
       devbrain setup mcp          — auto-configure MCP for installed AI CLIs
       devbrain setup factory-permissions  — set factory CLI permissions tier
+      devbrain setup resilience   — local self-healing (VPS checks are optional)
       devbrain setup pkrelay      — install optional PKRelay browser bridge
       devbrain setup devdoctor    — run devbrain devdoctor (health check)
       devbrain setup updates      — check for and pull DevBrain updates
@@ -960,6 +962,269 @@ def setup_cmd(section):
     """
     from setup import run_setup
     run_setup(section=section)
+
+
+def _ensure_resilience_import_path() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_root_text = str(repo_root)
+    if repo_root_text not in sys.path:
+        sys.path.insert(0, repo_root_text)
+
+
+def _load_resilience_cli():
+    _ensure_resilience_import_path()
+    from ops.resilience.__main__ import main as resilience_main
+
+    return resilience_main
+
+
+def _resolve_devbrain_docker_context() -> str:
+    """Resolve the one Docker context that owns the live DevBrain container."""
+
+    safe_context = re.compile(r"^[A-Za-z0-9][-A-Za-z0-9._+]*$")
+    safe_container_id = re.compile(r"^[a-f0-9]{12,64}$")
+
+    def run_docker(args: list[str]) -> subprocess.CompletedProcess:
+        try:
+            return subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise click.ClickException(f"Docker probe failed: {exc}") from exc
+
+    target_path = Path.home() / ".devbrain" / "install-target.json"
+    recorded_context = None
+    if target_path.is_symlink() or (
+        target_path.exists() and not target_path.is_file()
+    ):
+        raise click.ClickException(
+            f"container target metadata is not a regular file: {target_path}"
+        )
+    if target_path.is_file():
+        try:
+            metadata = json.loads(target_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise click.ClickException(
+                f"container target metadata is unreadable: {exc}"
+            ) from exc
+        expected = {
+            "schema_version",
+            "generated_by",
+            "profile",
+            "container_runtime",
+            "docker_context",
+        }
+        if (
+            not isinstance(metadata, dict)
+            or set(metadata) != expected
+            or metadata.get("schema_version") != 2
+            or metadata.get("generated_by") != "devbrain-installer"
+            or metadata.get("profile") not in {"workstation", "studio"}
+            or metadata.get("container_runtime")
+            not in {"colima", "docker-desktop", "docker-engine", "orbstack"}
+            or not isinstance(metadata.get("docker_context"), str)
+            or not safe_context.fullmatch(metadata["docker_context"])
+        ):
+            raise click.ClickException(
+                f"container target metadata is invalid: {target_path}"
+            )
+        recorded_context = metadata["docker_context"]
+
+    def devbrain_container_id(context: str) -> str | None:
+        probe = run_docker(
+            [
+                "docker",
+                "--context",
+                context,
+                "container",
+                "ls",
+                "--all",
+                "--no-trunc",
+                "--filter",
+                "name=^/devbrain-db$",
+                "--format",
+                "{{.ID}}",
+            ]
+        )
+        if probe.returncode != 0:
+            raise click.ClickException(
+                f"Docker context {context!r} is unavailable; refusing container "
+                "recreation"
+            )
+        container_ids = {
+            container_id.strip()
+            for container_id in probe.stdout.splitlines()
+            if container_id.strip()
+        }
+        if not container_ids:
+            return None
+        if len(container_ids) != 1 or not all(
+            safe_container_id.fullmatch(container_id)
+            for container_id in container_ids
+        ):
+            raise click.ClickException(
+                f"Docker context {context!r} returned an invalid devbrain-db "
+                "identity; refusing container recreation"
+            )
+        return next(iter(container_ids))
+
+    if recorded_context is not None:
+        if devbrain_container_id(recorded_context) is None:
+            raise click.ClickException(
+                f"recorded Docker context {recorded_context!r} does not contain "
+                "devbrain-db"
+            )
+        return recorded_context
+
+    contexts = run_docker(["docker", "context", "ls", "--format", "{{.Name}}"])
+    if contexts.returncode != 0:
+        raise click.ClickException(
+            "cannot list Docker contexts and no install target is recorded"
+        )
+    matches: dict[str, list[str]] = {}
+    for context in contexts.stdout.splitlines():
+        context = context.strip()
+        if not context:
+            continue
+        if not safe_context.fullmatch(context):
+            raise click.ClickException(
+                f"Docker returned an unsupported context name {context!r}; "
+                "refusing legacy target discovery"
+            )
+        container_id = devbrain_container_id(context)
+        if container_id is not None:
+            matches.setdefault(container_id, []).append(context)
+    if len(matches) != 1:
+        raise click.ClickException(
+            "no install target is recorded and DevBrain was found in "
+            f"{len(matches)} distinct Docker backends; refusing "
+            "ambient-context recreation"
+        )
+    aliases = next(iter(matches.values()))
+    preference = {"desktop-linux": 0, "colima": 1, "orbstack": 2, "default": 3}
+    return min(aliases, key=lambda item: (preference.get(item, 4), item))
+
+
+@cli.group(name="ops")
+def ops_cmd():
+    """Inspect and operate the optional host resilience service."""
+
+
+@ops_cmd.command(name="status")
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(path_type=Path),
+    default=lambda: Path.home() / ".devbrain" / "resilience" / "config.json",
+    show_default=True,
+)
+def ops_status(config_path: Path) -> None:
+    """Show the last local watchdog heartbeat."""
+
+    code = _load_resilience_cli()(
+        ["--config", str(config_path.expanduser().resolve()), "status"]
+    )
+    if code:
+        raise click.exceptions.Exit(code)
+
+
+@ops_cmd.command(name="run-once")
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(path_type=Path),
+    default=lambda: Path.home() / ".devbrain" / "resilience" / "config.json",
+    show_default=True,
+)
+def ops_run_once(config_path: Path) -> None:
+    """Run one typed check/recovery cycle in the foreground."""
+
+    code = _load_resilience_cli()(
+        ["--config", str(config_path.expanduser().resolve()), "run-once"]
+    )
+    if code:
+        raise click.exceptions.Exit(code)
+
+
+@ops_cmd.group(name="medic")
+def ops_medic_cmd():
+    """Create off-host medic keys and signed task envelopes."""
+
+
+@ops_medic_cmd.command(name="keygen")
+@click.option("--private", "private_path", type=click.Path(path_type=Path), required=True)
+@click.option("--public", "public_path", type=click.Path(path_type=Path), required=True)
+def ops_medic_keygen(private_path: Path, public_path: Path) -> None:
+    """Generate one Ed25519 keypair; keep the private file off the Studio."""
+
+    _ensure_resilience_import_path()
+    from ops.resilience.medic_tools import main as medic_tools_main
+
+    code = medic_tools_main(
+        [
+            "keygen",
+            "--private",
+            str(private_path),
+            "--public",
+            str(public_path),
+        ]
+    )
+    if code:
+        raise click.exceptions.Exit(code)
+
+
+@ops_medic_cmd.command(name="task")
+@click.option("--instance-id", required=True)
+@click.option(
+    "--action",
+    type=click.Choice(["status", "diagnose", "heal"]),
+    required=True,
+)
+@click.option("--check", default=None)
+@click.option(
+    "--sign",
+    "signers",
+    multiple=True,
+    required=True,
+    metavar="KEY_ID=PRIVATE_KEY_PATH",
+)
+@click.option("--output", type=click.Path(path_type=Path), required=True)
+@click.option("--ttl-seconds", type=click.IntRange(1, 900), default=300)
+def ops_medic_task(
+    instance_id: str,
+    action: str,
+    check: str | None,
+    signers: tuple[str, ...],
+    output: Path,
+    ttl_seconds: int,
+) -> None:
+    """Create a short-lived signed task for a configured medic inbox."""
+
+    _ensure_resilience_import_path()
+    from ops.resilience.medic_tools import main as medic_tools_main
+
+    argv = [
+        "task",
+        "--instance-id",
+        instance_id,
+        "--action",
+        action,
+        "--ttl-seconds",
+        str(ttl_seconds),
+        "--output",
+        str(output),
+    ]
+    if check:
+        argv.extend(["--check", check])
+    for signer in signers:
+        argv.extend(["--sign", signer])
+    code = medic_tools_main(argv)
+    if code:
+        raise click.exceptions.Exit(code)
 
 
 @cli.command(name="dashboard")
@@ -1482,7 +1747,91 @@ def _run_devdoctor_checks() -> list[dict]:
             add(f"ai_cli_logged_in:{_ai_cli}", True,
                 "probe timed out (treating as authed)", warn=True)
 
-    # 10. Env vars (informational — never fails, just reports overrides)
+    # 10. Optional host resilience service. Absence is not a warning because
+    # workstation installs intentionally keep this opt-in.
+    resilience_manifest = (
+        Path.home() / ".devbrain" / "resilience" / "install-manifest.json"
+    )
+    if resilience_manifest.exists():
+        try:
+            manifest = json.loads(resilience_manifest.read_text(encoding="utf-8"))
+            service = manifest["service"]
+            manager = service["manager"]
+            if manager == "launchd":
+                label = service["label"]
+                domain = (
+                    "system"
+                    if service["scope"] == "system"
+                    else f"gui/{service['uid']}"
+                )
+                probe = _subprocess.run(
+                    ["launchctl", "print", f"{domain}/{label}"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    check=False,
+                )
+            elif manager == "systemd-user":
+                probe = _subprocess.run(
+                    [
+                        "systemctl",
+                        "--user",
+                        "is-active",
+                        "--quiet",
+                        "--",
+                        service["unit"],
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    check=False,
+                )
+            else:
+                raise ValueError(f"unsupported service manager: {manager}")
+            add(
+                "resilience_service",
+                probe.returncode == 0,
+                f"{manager} service active"
+                if probe.returncode == 0
+                else f"{manager} service is not active",
+            )
+
+            repo_root_text = str(DEVBRAIN_HOME)
+            if repo_root_text not in sys.path:
+                sys.path.insert(0, repo_root_text)
+            from ops.resilience.core import load_config, read_heartbeat
+
+            resilience_config = load_config(manifest["config_path"])
+            heartbeat = read_heartbeat(resilience_config)
+            generated = float(heartbeat["generated_at_epoch"])
+            age = max(0.0, time.time() - generated)
+            maximum_age = max(180.0, resilience_config.interval_seconds * 3)
+            heartbeat_ok = age <= maximum_age and heartbeat.get("healthy") is True
+            add(
+                "resilience_heartbeat",
+                heartbeat_ok,
+                (
+                    f"healthy, {age:.0f}s old"
+                    if heartbeat_ok
+                    else f"stale/unhealthy, {age:.0f}s old"
+                ),
+            )
+            if resilience_config.medic_config_path is not None:
+                from ops.resilience.medic_service import load_medic_config
+
+                medic = load_medic_config(
+                    resilience_config.medic_config_path,
+                    runtime_config=resilience_config,
+                )
+                add(
+                    "resilience_medic",
+                    True,
+                    f"{medic.mode} mode; {len(medic.authorized_keys)} public key(s)",
+                )
+        except Exception as exc:
+            add("resilience_config", False, f"{exc}")
+
+    # 11. Env vars (informational — never fails, just reports overrides)
     overrides = sorted(k for k in os.environ if k.startswith("DEVBRAIN_"))
     add(
         "env_overrides",
@@ -1962,6 +2311,10 @@ def rotate_db_password(
         click.echo("Aborted.")
         return
 
+    docker_context = (
+        _resolve_devbrain_docker_context() if recreate else None
+    )
+
     # Verify the current password actually works before generating a new one.
     # Use keyword form (host=, port=, ...) so the password never appears in
     # the connection string libpq echoes back in OperationalError messages.
@@ -2077,52 +2430,48 @@ def rotate_db_password(
     # loopback-only port binding) take effect. Password rotation alone
     # doesn't require this — ALTER USER already applied it.
     if recreate:
-        if subprocess.run(
-            ["docker", "--version"], capture_output=True
-        ).returncode != 0:
+        assert docker_context is not None
+        docker = ["docker", "--context", docker_context]
+        click.echo(
+            f"→ Recreating devbrain-db in Docker context {docker_context!r}..."
+        )
+        compose_dir = str(DEVBRAIN_HOME)
+        down_rc = subprocess.call(
+            [*docker, "compose", "down"], cwd=compose_dir
+        )
+        if down_rc != 0:
             click.echo(
-                "⚠️  docker not available — skipping container recreate.",
+                "⚠️  'docker compose down' returned non-zero. Continuing.",
                 err=True,
             )
-        else:
-            click.echo("→ Recreating devbrain-db container...")
-            compose_dir = str(DEVBRAIN_HOME)
-            down_rc = subprocess.call(
-                ["docker", "compose", "down"], cwd=compose_dir
+        up_rc = subprocess.call(
+            [*docker, "compose", "up", "-d", "devbrain-db"],
+            cwd=compose_dir,
+        )
+        if up_rc != 0:
+            raise click.ClickException(
+                "'docker compose up -d devbrain-db' failed. The new "
+                "password is already in .env/yaml and stored in Postgres "
+                "— fix docker-compose errors and bring the container up "
+                "manually."
             )
-            if down_rc != 0:
-                click.echo(
-                    "⚠️  'docker compose down' returned non-zero. Continuing.",
-                    err=True,
-                )
-            up_rc = subprocess.call(
-                ["docker", "compose", "up", "-d", "devbrain-db"],
-                cwd=compose_dir,
-            )
-            if up_rc != 0:
-                raise click.ClickException(
-                    "'docker compose up -d devbrain-db' failed. The new "
-                    "password is already in .env/yaml and stored in Postgres "
-                    "— fix docker-compose errors and bring the container up "
-                    "manually."
-                )
 
-            # Poll until Postgres accepts connections again
-            click.echo("→ Waiting for Postgres to accept connections...", nl=False)
-            for _ in range(30):
-                try:
-                    psycopg2.connect(**new_conn_kwargs, connect_timeout=1).close()
-                    click.echo(" ✅")
-                    break
-                except psycopg2.Error:
-                    time.sleep(1)
-            else:
-                click.echo(" ⚠️")
-                click.echo(
-                    "Container is up but Postgres didn't accept connections "
-                    "within 30s. Check 'docker logs devbrain-db'.",
-                    err=True,
-                )
+        # Poll until Postgres accepts connections again
+        click.echo("→ Waiting for Postgres to accept connections...", nl=False)
+        for _ in range(30):
+            try:
+                psycopg2.connect(**new_conn_kwargs, connect_timeout=1).close()
+                click.echo(" ✅")
+                break
+            except psycopg2.Error:
+                time.sleep(1)
+        else:
+            click.echo(" ⚠️")
+            click.echo(
+                "Container is up but Postgres didn't accept connections "
+                "within 30s. Check the recorded Docker context logs.",
+                err=True,
+            )
 
     click.echo()
     click.echo("✅ Rotation complete.")
@@ -2147,14 +2496,16 @@ def upgrade(
 ) -> None:
     """Migrate an existing install to the latest defaults.
 
-    Chains five steps:
+    Chains seven steps:
 
     \b
       1. git pull --ff-only           (skip with --no-pull)
-      2. Rebuild the MCP server       (skip with --no-rebuild)
-      3. Rotate DB password if weak   (skip with --no-rotate)
-      4. Set factory tier if unsafe   (skip with --no-tier)
-      5. Run devdoctor for verification
+      2. Refresh Python requirements
+      3. Rebuild the MCP server       (skip with --no-rebuild)
+      4. Rotate DB password if weak   (skip with --no-rotate)
+      5. Set factory tier if unsafe   (skip with --no-tier)
+      6. Restart installed resilience
+      7. Run devdoctor for verification
 
     Intended for existing DevBrain installs that pre-date newer defaults
     (random DB password, loopback-only Postgres binding, factory
@@ -2176,10 +2527,12 @@ def upgrade(
     click.echo()
     click.echo("Steps:")
     click.echo("  1. git pull --ff-only")
-    click.echo("  2. Rebuild MCP server (npm install + build)")
-    click.echo("  3. Rotate DB password if still on the old devbrain-local default")
-    click.echo("  4. Prompt for factory permissions tier if set to 3 / unset")
-    click.echo("  5. Run devdoctor")
+    click.echo("  2. Refresh Python requirements")
+    click.echo("  3. Rebuild MCP server (npm install + build)")
+    click.echo("  4. Rotate DB password if still on the old devbrain-local default")
+    click.echo("  5. Prompt for factory permissions tier if set to 3 / unset")
+    click.echo("  6. Restart the resilience service if it is installed")
+    click.echo("  7. Run devdoctor")
     click.echo()
     click.secho(
         "⚠️  Restart any running Claude Code sessions after this finishes —",
@@ -2197,7 +2550,7 @@ def upgrade(
 
     # ─── Step 1: git pull ────────────────────────────────────────────────
     click.echo()
-    click.secho("[1/5] git pull --ff-only", bold=True)
+    click.secho("[1/7] git pull --ff-only", bold=True)
     if no_pull:
         click.echo("   (skipped via --no-pull)")
     else:
@@ -2209,9 +2562,40 @@ def upgrade(
                 "git pull failed — resolve manually, then re-run 'devbrain upgrade'."
             )
 
-    # ─── Step 2: rebuild MCP ─────────────────────────────────────────────
+    # ─── Step 2: Python requirements ─────────────────────────────────────
     click.echo()
-    click.secho("[2/5] Rebuild MCP server", bold=True)
+    click.secho("[2/7] Refresh Python requirements", bold=True)
+    requirements_path = DEVBRAIN_HOME / "requirements.txt"
+    venv_python = DEVBRAIN_HOME / ".venv" / "bin" / "python"
+    if not requirements_path.is_file():
+        raise click.ClickException(
+            f"requirements file is missing: {requirements_path}"
+        )
+    if not venv_python.is_file():
+        raise click.ClickException(
+            f"DevBrain virtualenv is missing: {venv_python}. "
+            "Re-run the installer to repair it."
+        )
+    rc = subprocess.call(
+        [
+            str(venv_python),
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "-q",
+            "-r",
+            str(requirements_path),
+        ],
+        cwd=str(DEVBRAIN_HOME),
+    )
+    if rc != 0:
+        raise click.ClickException("Python requirements update failed")
+    click.echo("   ✓ requirements current")
+
+    # ─── Step 3: rebuild MCP ─────────────────────────────────────────────
+    click.echo()
+    click.secho("[3/7] Rebuild MCP server", bold=True)
     if no_rebuild:
         click.echo("   (skipped via --no-rebuild)")
     else:
@@ -2232,9 +2616,9 @@ def upgrade(
                 raise click.ClickException("MCP rebuild failed")
             click.echo("   ✓ rebuilt")
 
-    # ─── Step 3: DB password ────────────────────────────────────────────
+    # ─── Step 4: DB password ────────────────────────────────────────────
     click.echo()
-    click.secho("[3/5] Check DB password", bold=True)
+    click.secho("[4/7] Check DB password", bold=True)
     if no_rotate:
         click.echo("   (skipped via --no-rotate)")
     else:
@@ -2264,9 +2648,9 @@ def upgrade(
         else:
             click.echo("   ✓ custom password in use")
 
-    # ─── Step 4: factory tier ───────────────────────────────────────────
+    # ─── Step 5: factory tier ───────────────────────────────────────────
     click.echo()
-    click.secho("[4/5] Check factory permissions tier", bold=True)
+    click.secho("[5/7] Check factory permissions tier", bold=True)
     if no_tier:
         click.echo("   (skipped via --no-tier)")
     else:
@@ -2283,9 +2667,35 @@ def upgrade(
             from setup import run_setup
             run_setup(section="factory-permissions")
 
-    # ─── Step 5: devdoctor ──────────────────────────────────────────────
+    # ─── Step 6: resilience service ─────────────────────────────────────
     click.echo()
-    click.secho("[5/5] Final health check", bold=True)
+    click.secho("[6/7] Restart resilience service", bold=True)
+    resilience_manifest = (
+        Path.home() / ".devbrain" / "resilience" / "install-manifest.json"
+    )
+    if not resilience_manifest.is_file():
+        click.echo("   (not installed — skipped)")
+    else:
+        resilience_installer = DEVBRAIN_HOME / "scripts" / "install-resilience.sh"
+        if not resilience_installer.is_file():
+            raise click.ClickException(
+                "resilience is installed, but its manifest-aware installer is "
+                f"missing: {resilience_installer}"
+            )
+        rc = subprocess.call(
+            ["bash", str(resilience_installer), "--restart"],
+            cwd=str(DEVBRAIN_HOME),
+        )
+        if rc != 0:
+            raise click.ClickException(
+                "resilience restart failed; the existing manifest and service "
+                "files were preserved for repair"
+            )
+        click.echo("   ✓ restarted")
+
+    # ─── Step 7: devdoctor ──────────────────────────────────────────────
+    click.echo()
+    click.secho("[7/7] Final health check", bold=True)
     try:
         ctx.invoke(devdoctor, as_json=False, fix=False)
     except SystemExit as exc:

--- a/factory/setup.py
+++ b/factory/setup.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -1882,6 +1883,222 @@ def setup_pkrelay() -> None:
         _info("Install manually from github.com/nooma-stack/pkrelay")
 
 
+def setup_resilience() -> None:
+    """Interactively install or reconfigure the local resilience service."""
+    _header("Resilience / self-healing (optional)")
+    _desc(
+        "The local service checks the container runtime, PostgreSQL, Ollama,",
+        "ingest, and disk space, then performs bounded recovery actions.",
+        "It works without a VPS and does not expose DevBrain to the internet.",
+    )
+    click.echo()
+    _desc("Optional integrations (all disabled unless you select them):")
+    _desc("  • Heartbeat — sends signed health reports to an HTTPS endpoint")
+    _desc("  • Tunnel check — watches an existing launchd/systemd tunnel")
+    _desc("  • Agent-bus check — probes an existing local or remote agent-bus")
+    _desc("  • Backup freshness — watches output from an existing backup job")
+    _desc("  • Signed medic — accepts expiring status/diagnose tasks; healing")
+    _desc("    additionally requires two distinct signatures and named checks")
+    _desc("You can use local self-healing without configuring any of these.")
+    click.echo()
+
+    script = DEVBRAIN_HOME / "scripts" / "install-resilience.sh"
+    if not script.exists():
+        _warn(f"Cannot find {script}")
+        _info("Update DevBrain, then re-run 'devbrain setup resilience'.")
+        return
+
+    manifest = Path.home() / ".devbrain" / "resilience" / "install-manifest.json"
+    verb = "Reconfigure" if manifest.exists() else "Install"
+    if not _confirm(f"{verb} the resilience service?", default=True):
+        _info("Skipped. No resilience settings were changed.")
+        return
+
+    profile_default = "workstation"
+    runtime_default = ""
+    if manifest.exists():
+        try:
+            existing = json.loads(manifest.read_text())
+            if existing.get("profile") in {"workstation", "studio"}:
+                profile_default = existing["profile"]
+            if existing.get("container_runtime") in {
+                "colima", "docker-desktop", "docker-engine", "orbstack"
+            }:
+                runtime_default = existing["container_runtime"]
+        except (OSError, json.JSONDecodeError):
+            _warn("Existing manifest is unreadable; using safe defaults.")
+
+    profile = _prompt(
+        "Deployment profile",
+        default=profile_default,
+        type=click.Choice(["workstation", "studio"], case_sensitive=False),
+    )
+    if not runtime_default:
+        if platform.system() != "Darwin":
+            runtime_default = "docker-engine"
+        elif profile == "studio":
+            runtime_default = "colima"
+        elif Path("/Applications/OrbStack.app").exists():
+            runtime_default = "orbstack"
+        elif shutil.which("colima"):
+            runtime_default = "colima"
+        else:
+            runtime_default = "docker-desktop"
+    runtime = _prompt(
+        "Container runtime",
+        default=runtime_default,
+        type=click.Choice(
+            ["docker-desktop", "docker-engine", "colima", "orbstack"],
+            case_sensitive=False,
+        ),
+    )
+
+    args = [
+        "bash",
+        str(script),
+        "--profile", profile,
+        "--container-runtime", runtime,
+    ]
+
+    if _confirm("Enable an external heartbeat?", default=False):
+        heartbeat_url = _prompt(
+            "Heartbeat HTTPS URL",
+            default=os.environ.get("DEVBRAIN_HEARTBEAT_URL", ""),
+        ).strip()
+        if not heartbeat_url:
+            raise click.ClickException(
+                "A heartbeat URL is required when heartbeat is enabled."
+            )
+        heartbeat_secret_env = _prompt(
+            "Heartbeat HMAC token environment-variable name",
+            default="DEVBRAIN_HEARTBEAT_TOKEN",
+        ).strip()
+        args.extend([
+            "--with-heartbeat",
+            "--heartbeat-url", heartbeat_url,
+            "--heartbeat-secret-env", heartbeat_secret_env,
+        ])
+
+    if _confirm("Monitor an existing VPS/reverse-tunnel service?", default=False):
+        tunnel_label = _prompt(
+            "Tunnel launchd label or systemd user unit",
+            default=os.environ.get("DEVBRAIN_TUNNEL_LABEL", ""),
+        ).strip()
+        if not tunnel_label:
+            raise click.ClickException(
+                "A tunnel label is required when tunnel monitoring is enabled."
+            )
+        args.extend(["--with-tunnel-check", "--tunnel-label", tunnel_label])
+
+    if _confirm("Monitor an existing agent-bus health endpoint?", default=False):
+        agent_bus_url = _prompt(
+            "Agent-bus health URL",
+            default=os.environ.get(
+                "DEVBRAIN_AGENT_BUS_HEALTH_URL",
+                "http://localhost:18900/healthz",
+            ),
+        ).strip()
+        if not agent_bus_url:
+            raise click.ClickException(
+                "An agent-bus health URL is required when its check is enabled."
+            )
+        args.extend([
+            "--with-agent-bus-check",
+            "--agent-bus-url", agent_bus_url,
+        ])
+
+    if _confirm("Monitor output from an existing backup job?", default=False):
+        backup_path = _prompt(
+            "Backup file or directory",
+            default=os.environ.get("DEVBRAIN_BACKUP_PATH", ""),
+        ).strip()
+        if not backup_path:
+            raise click.ClickException(
+                "A backup path is required when freshness monitoring is enabled."
+            )
+        args.extend([
+            "--with-backup-check",
+            "--backup-path", backup_path,
+        ])
+
+    if _confirm("Enable the signed medic queue?", default=False):
+        _desc(
+            "Generate keys on an operator machine with:",
+            "  python -m ops.resilience.medic_tools keygen ...",
+            "Copy only the .pub files here. Private keys must remain off-host.",
+        )
+        medic_mode = _prompt(
+            "Medic mode",
+            default="diagnose",
+            type=click.Choice(["diagnose", "heal"], case_sensitive=False),
+        )
+        primary_key = _prompt(
+            "Primary public-key file",
+            default=os.environ.get(
+                "DEVBRAIN_MEDIC_PRIMARY_PUBLIC_KEY_FILE", ""
+            ),
+        ).strip()
+        if not primary_key:
+            raise click.ClickException(
+                "The medic requires a primary public-key file."
+            )
+        args.extend([
+            "--with-medic", medic_mode,
+            "--medic-primary-public-key", primary_key,
+        ])
+        instance_id = _prompt(
+            "Stable medic instance ID",
+            default=os.environ.get("DEVBRAIN_INSTANCE_ID", platform.node()),
+        ).strip()
+        if instance_id:
+            args.extend(["--medic-instance-id", instance_id])
+        if medic_mode == "heal":
+            confirm_key = _prompt(
+                "Confirm public-key file (must be a different key)",
+                default=os.environ.get(
+                    "DEVBRAIN_MEDIC_CONFIRM_PUBLIC_KEY_FILE", ""
+                ),
+            ).strip()
+            if not confirm_key:
+                raise click.ClickException(
+                    "Medic heal mode requires a confirm public-key file."
+                )
+            allowed_raw = _prompt(
+                "Allowed recovery checks (comma-separated)",
+                default=(
+                    "postgres"
+                    if runtime == "docker-engine"
+                    else "container_runtime,postgres,ollama,ingest"
+                ),
+            )
+            allowed = [
+                check.strip() for check in allowed_raw.split(",") if check.strip()
+            ]
+            if not allowed:
+                raise click.ClickException(
+                    "Medic heal mode requires at least one allowed check."
+                )
+            args.extend(["--medic-confirm-public-key", confirm_key])
+            for check in allowed:
+                args.extend(["--medic-allow-check", check])
+
+    click.echo()
+    _info("Installing resilience service with explicit, secret-free arguments...")
+    try:
+        completed = subprocess.run(args, check=False)
+    except OSError as exc:
+        raise click.ClickException(
+            f"Could not start the resilience installer: {exc}"
+        ) from exc
+    if completed.returncode != 0:
+        raise click.ClickException(
+            f"Resilience installer exited with status {completed.returncode}."
+        )
+
+    _ok(f"Resilience service configured ({profile}, {runtime})")
+    _info("Re-run 'devbrain setup resilience' anytime to change optional checks.")
+
+
 def print_post_actions() -> None:
     if not POST_ACTIONS:
         return
@@ -2416,6 +2633,8 @@ MENU_SECTIONS: list[tuple[str, str, callable]] = [
     ("MCP client config (Claude Code, Codex, Gemini)", "mcp", setup_mcp_client),
     ("Factory CLI permissions tier (read-only / guarded / unrestricted)",
      "factory-permissions", setup_factory_permissions),
+    ("Resilience / self-healing (local; remote checks optional)",
+     "resilience", setup_resilience),
     ("PKRelay browser extension (optional)",   "pkrelay",  setup_pkrelay),
     ("Run DevDoctor (health check + offered fixes)", "devdoctor", run_verification),
     ("Check for DevBrain updates",             "updates",  check_for_updates),
@@ -2437,6 +2656,7 @@ def _run_full_setup() -> None:
     setup_projects()
     setup_notifications(dev_id)
     setup_mcp_client()
+    setup_resilience()
     setup_pkrelay()
     run_verification()
     print_post_actions()
@@ -2498,7 +2718,7 @@ def run_setup(section: str | None = None) -> None:
       - section='full'    → run all sections linearly (first-time-user flow)
 
     Valid section keys: github, ai-clis, identity, multi-dev, projects,
-    channels, mcp, pkrelay, verify, actions, full.
+    channels, mcp, resilience, pkrelay, verify, actions, full.
     """
     _ensure_tty_stdin()
 

--- a/factory/tests/test_resilience_core.py
+++ b/factory/tests/test_resilience_core.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+from collections import namedtuple
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from ops.resilience.__main__ import (  # noqa: E402
+    load_dotenv_no_override,
+    main as resilience_main,
+    watch_forever,
+)
+from ops.resilience.core import (  # noqa: E402
+    ActionResult,
+    CheckResult,
+    ConfigError,
+    Monitor,
+    ProcessResult,
+    execute_recovery,
+    load_config,
+    run_check,
+    send_webhook,
+)
+
+
+def _base_config(tmp_path: Path, *, checks=None, heartbeat=None) -> dict:
+    return {
+        "schema_version": 1,
+        "profile": "workstation",
+        "host": "test-studio",
+        "state_path": str(tmp_path / "state.json"),
+        "heartbeat_path": str(tmp_path / "heartbeat.json"),
+        "interval_seconds": 60,
+        "failure_threshold": 2,
+        "cooldown_seconds": 300,
+        "max_attempts": 2,
+        "executables": {
+            name: "/bin/echo"
+            for name in (
+                "brew",
+                "colima",
+                "docker",
+                "launchctl",
+                "open",
+                "systemctl",
+            )
+        },
+        "checks": checks
+        or [
+            {
+                "id": "runtime",
+                "type": "docker_runtime",
+                "enabled": True,
+                "required": True,
+                "timeout_seconds": 5,
+                "settings": {
+                    "recovery": {
+                        "type": "runtime_start",
+                        "runtime": "colima",
+                    }
+                },
+            }
+        ],
+        "heartbeat": heartbeat,
+    }
+
+
+def _load(tmp_path: Path, *, checks=None, heartbeat=None):
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps(_base_config(tmp_path, checks=checks, heartbeat=heartbeat))
+    )
+    return load_config(path)
+
+
+def test_loader_normalizes_typed_config_and_rejects_shell_escape(tmp_path):
+    config = _load(tmp_path)
+    assert config.state_path.is_absolute()
+    assert config.heartbeat_path.is_absolute()
+    assert config.checks[0]["settings"]["recovery"] == {
+        "type": "runtime_start",
+        "runtime": "colima",
+        "timeout_seconds": 60.0,
+    }
+
+    raw = _base_config(tmp_path)
+    raw["checks"][0]["settings"]["command"] = "touch /tmp/not-allowed"
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(raw))
+    with pytest.raises(ConfigError, match="forbidden"):
+        load_config(path)
+
+
+def test_all_check_primitives_use_injected_non_shell_dependencies(tmp_path):
+    checks = [
+        {
+            "id": "runtime",
+            "type": "docker_runtime",
+            "enabled": True,
+            "required": True,
+            "timeout_seconds": 5,
+            "settings": {},
+        },
+        {
+            "id": "container",
+            "type": "docker_container",
+            "enabled": True,
+            "required": True,
+            "timeout_seconds": 5,
+            "settings": {"container": "devbrain-db", "require_healthcheck": True},
+        },
+        {
+            "id": "http",
+            "type": "http",
+            "enabled": True,
+            "required": True,
+            "timeout_seconds": 5,
+            "settings": {"url": "http://127.0.0.1:11434/api/tags"},
+        },
+        {
+            "id": "tcp",
+            "type": "tcp",
+            "enabled": True,
+            "required": False,
+            "timeout_seconds": 5,
+            "settings": {"host": "127.0.0.1", "port": 18900},
+        },
+        {
+            "id": "launchd",
+            "type": "launchd_label",
+            "enabled": True,
+            "required": False,
+            "timeout_seconds": 5,
+            "settings": {
+                "label": "com.devbrain.ingest",
+                "domain": "gui/501",
+            },
+        },
+        {
+            "id": "systemd",
+            "type": "systemd_user_unit",
+            "enabled": True,
+            "required": False,
+            "timeout_seconds": 5,
+            "settings": {"unit": "devbrain-ingest.service"},
+        },
+        {
+            "id": "disk",
+            "type": "disk",
+            "enabled": True,
+            "required": True,
+            "timeout_seconds": 5,
+            "settings": {
+                "path": str(tmp_path),
+                "min_free_percent": 5,
+                "min_free_bytes": 100,
+            },
+        },
+        {
+            "id": "backup",
+            "type": "file_freshness",
+            "enabled": True,
+            "required": False,
+            "timeout_seconds": 5,
+            "settings": {
+                "path": str(tmp_path / "backups"),
+                "pattern": "*.dump",
+                "max_age_seconds": 3600,
+                "minimum_matches": 1,
+            },
+        },
+    ]
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    (backup_dir / "latest.dump").write_text("test")
+    config = _load(tmp_path, checks=checks)
+    process_calls = []
+
+    def process_runner(argv, timeout, cwd):
+        process_calls.append((argv, timeout, cwd))
+        if "inspect" in argv:
+            return ProcessResult(
+                0,
+                json.dumps(
+                    {
+                        "Running": True,
+                        "Status": "running",
+                        "Health": {"Status": "healthy"},
+                    }
+                ),
+                "",
+            )
+        if "print" in argv:
+            return ProcessResult(0, "state = running\n", "")
+        return ProcessResult(0, "25.0.0\n", "")
+
+    class Response:
+        status = 204
+
+        def close(self):
+            return None
+
+    class Connection:
+        def close(self):
+            return None
+
+    DiskUsage = namedtuple("DiskUsage", "total used free")
+    results = []
+    for check in config.checks:
+        results.append(
+            run_check(
+                config,
+                check,
+                process_runner=process_runner,
+                urlopen=lambda *_a, **_k: Response(),
+                socket_connector=lambda *_a, **_k: Connection(),
+                disk_usage=lambda _path: DiskUsage(1_000, 100, 900),
+                time_fn=lambda: (backup_dir / "latest.dump").stat().st_mtime + 30,
+            )
+        )
+
+    assert all(result.ok for result in results)
+    assert any("inspect" in call[0] for call in process_calls)
+    assert any("print" in call[0] for call in process_calls)
+    assert any("--context" in call[0] for call in process_calls)
+    assert all(not isinstance(call[0], str) for call in process_calls)
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_tail", "cwd"),
+    [
+        (
+            {"type": "runtime_start", "runtime": "colima", "timeout_seconds": 5},
+            ["start"],
+            None,
+        ),
+        (
+            {
+                "type": "docker_compose_up",
+                "context": "colima",
+                "project_dir": "/tmp/devbrain-test",
+                "services": ["devbrain-db"],
+                "timeout_seconds": 5,
+            },
+            ["--context", "colima", "compose", "up", "-d", "devbrain-db"],
+            Path("/tmp/devbrain-test"),
+        ),
+        (
+            {
+                "type": "launchd_kickstart",
+                "domain": "gui/501",
+                "label": "com.devbrain.ingest",
+                "timeout_seconds": 5,
+            },
+            ["kickstart", "-k", "gui/501/com.devbrain.ingest"],
+            None,
+        ),
+        (
+            {
+                "type": "systemd_restart",
+                "unit": "devbrain-ingest.service",
+                "timeout_seconds": 5,
+            },
+            ["--user", "restart", "--", "devbrain-ingest.service"],
+            None,
+        ),
+        (
+            {
+                "type": "homebrew_service_start",
+                "service": "ollama",
+                "timeout_seconds": 5,
+            },
+            ["services", "start", "ollama"],
+            None,
+        ),
+    ],
+)
+def test_recovery_actions_are_fixed_argv(action, expected_tail, cwd, tmp_path):
+    config = _load(tmp_path)
+    calls = []
+
+    def runner(argv, timeout, actual_cwd):
+        calls.append((argv, timeout, actual_cwd))
+        return ProcessResult(0, "", "")
+
+    result = execute_recovery(
+        config,
+        config.checks[0],
+        action,
+        process_runner=runner,
+    )
+
+    assert result.ok
+    assert calls[0][0][1:] == expected_tail
+    assert calls[0][2] == cwd
+
+
+def test_monitor_damps_recovery_and_persists_state_and_heartbeat(tmp_path):
+    config = _load(tmp_path)
+    now = [1_000.0]
+    recoveries = []
+
+    def failed_check(_config, check):
+        return CheckResult(check["id"], check["type"], False, "down")
+
+    def recover(_config, check, action):
+        recoveries.append((check["id"], action["type"], now[0]))
+        return ActionResult(check["id"], action["type"], True, "started")
+
+    monitor = Monitor(
+        config,
+        check_executor=failed_check,
+        action_executor=recover,
+        webhook_sender=lambda *_: type(
+            "Webhook", (), {"as_dict": lambda self: {}, "detail": "off"}
+        )(),
+        time_fn=lambda: now[0],
+    )
+    assert monitor.run_cycle().heartbeat["recoveries"] == []
+    now[0] += 1
+    assert len(monitor.run_cycle().heartbeat["recoveries"]) == 1
+    now[0] += 1
+    assert monitor.run_cycle().heartbeat["recoveries"] == []
+    now[0] += 301
+    assert len(monitor.run_cycle().heartbeat["recoveries"]) == 1
+    now[0] += 301
+    assert monitor.run_cycle().heartbeat["recoveries"] == []
+
+    assert len(recoveries) == 2
+    assert (
+        json.loads(config.state_path.read_text())["checks"]["runtime"][
+            "recovery_attempts"
+        ]
+        == 2
+    )
+    heartbeat = json.loads(config.heartbeat_path.read_text())
+    assert heartbeat["healthy"] is False
+    assert heartbeat["checks"]["runtime"]["detail"] == "down"
+
+
+def test_targeted_recovery_requires_failure_and_respects_local_policy(tmp_path):
+    config = _load(tmp_path)
+    now = [2_000.0]
+    healthy = [False]
+    recoveries = []
+
+    def check(_config, item):
+        return CheckResult(
+            item["id"],
+            item["type"],
+            healthy[0],
+            "up" if healthy[0] else "down",
+        )
+
+    def recover(_config, item, action):
+        recoveries.append((item["id"], now[0]))
+        return ActionResult(item["id"], action["type"], True, "started")
+
+    monitor = Monitor(
+        config,
+        check_executor=check,
+        action_executor=recover,
+        time_fn=lambda: now[0],
+    )
+
+    first = monitor.run_targeted_recovery("runtime")
+    second = monitor.run_targeted_recovery("runtime")
+    now[0] += 1
+    cooldown = monitor.run_targeted_recovery("runtime")
+    healthy[0] = True
+    reset = monitor.run_targeted_recovery("runtime")
+    healthy[0] = False
+    after_reset = monitor.run_targeted_recovery("runtime")
+
+    assert not first.ok and "threshold" in first.detail
+    assert second.ok
+    assert not cooldown.ok and "cooldown" in cooldown.detail
+    assert not reset.ok and "healthy" in reset.detail
+    assert not after_reset.ok and "threshold" in after_reset.detail
+    assert recoveries == [("runtime", 2_000.0)]
+
+
+def test_webhook_uses_hmac_and_never_embeds_secret_in_body(tmp_path, monkeypatch):
+    config = _load(
+        tmp_path,
+        heartbeat={
+            "url": "https://monitor.example.invalid/heartbeat",
+            "secret_env": "DEVBRAIN_TEST_HEARTBEAT_SECRET",
+        },
+    )
+    monkeypatch.setenv("DEVBRAIN_TEST_HEARTBEAT_SECRET", "top-secret")
+    captured = {}
+
+    class Response:
+        status = 202
+
+        def close(self):
+            return None
+
+    def urlopen(request, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return Response()
+
+    heartbeat = {"healthy": True, "host": "test-studio"}
+    result = send_webhook(config, heartbeat, urlopen=urlopen)
+
+    body = captured["request"].data
+    expected = hmac.new(b"top-secret", body, hashlib.sha256).hexdigest()
+    assert result.delivered
+    assert captured["request"].headers["X-devbrain-signature"] == (f"sha256={expected}")
+    assert b"top-secret" not in body
+
+
+def test_cli_status_returns_health_exit_code(tmp_path, capsys):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(_base_config(tmp_path)))
+    heartbeat_path = tmp_path / "heartbeat.json"
+    heartbeat_path.write_text(json.dumps({"version": 1, "healthy": True, "checks": {}}))
+
+    assert resilience_main(["--config", str(config_path), "status"]) == 0
+    assert '"healthy": true' in capsys.readouterr().out
+
+
+def test_dotenv_loader_never_evaluates_shell_and_preserves_environment(
+    tmp_path, monkeypatch
+):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "EXISTING=from-file\n"
+        "PLAIN=value\n"
+        "QUOTED='hello world'\n"
+        "NOT_EXECUTED=$(touch /tmp/devbrain-resilience-should-not-exist)\n"
+    )
+    monkeypatch.setenv("EXISTING", "from-caller")
+    marker = Path("/tmp/devbrain-resilience-should-not-exist")
+    marker.unlink(missing_ok=True)
+
+    load_dotenv_no_override(env_file)
+
+    assert __import__("os").environ["EXISTING"] == "from-caller"
+    assert __import__("os").environ["PLAIN"] == "value"
+    assert __import__("os").environ["QUOTED"] == "hello world"
+    assert __import__("os").environ["NOT_EXECUTED"].startswith("$(")
+    assert not marker.exists()
+
+
+def test_watch_schedules_medic_independently_from_health_interval():
+    clock = [0.0]
+    monitor_times = []
+    medic_times = []
+
+    class Config:
+        interval_seconds = 30
+
+    class Cycle:
+        heartbeat = {"healthy": True, "recoveries": []}
+        webhook = type("Webhook", (), {"detail": "off"})()
+
+    class FakeMonitor:
+        config = Config()
+
+        def run_cycle(self):
+            monitor_times.append(clock[0])
+            return Cycle()
+
+    class MedicConfig:
+        poll_interval_seconds = 10
+
+    class FakeMedic:
+        medic_config = MedicConfig()
+
+        def process_once(self):
+            medic_times.append(clock[0])
+            return []
+
+    def sleep(seconds):
+        clock[0] += seconds
+
+    watch_forever(
+        FakeMonitor(),
+        FakeMedic(),
+        monotonic=lambda: clock[0],
+        sleep=sleep,
+        max_wakeups=7,
+    )
+
+    assert monitor_times == [0.0, 30.0, 60.0]
+    assert medic_times == [0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0]

--- a/factory/tests/test_resilience_install.py
+++ b/factory/tests/test_resilience_install.py
@@ -1,0 +1,691 @@
+"""Tests for the cross-platform resilience service installer."""
+
+from __future__ import annotations
+
+import json
+import plistlib
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from ops.resilience.install import (  # noqa: E402
+    InstallError,
+    SERVICE_LABEL,
+    SYSTEMD_UNIT,
+    _reject_incompatible_args,
+    build_parser,
+    build_plan,
+    create_request,
+    install,
+    restart,
+    uninstall,
+)
+from ops.resilience.core import load_config  # noqa: E402
+
+
+class RecordingRunner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple[str, ...], dict]] = []
+
+    def __call__(self, args, **kwargs):
+        self.calls.append((tuple(args), dict(kwargs)))
+        returncode = 0
+        if "print" in args:
+            returncode = 113
+        elif "is-active" in args:
+            returncode = 3
+        return subprocess.CompletedProcess(
+            args,
+            returncode,
+            "",
+            "",
+        )
+
+
+def _request(tmp_path: Path, **overrides):
+    values = {
+        "profile": "workstation",
+        "platform_name": "macos",
+        "repo_root": REPO_ROOT,
+        "home": tmp_path,
+        "username": "alice",
+        "uid": 501,
+        "python_executable": Path("/usr/bin/python3"),
+    }
+    values.update(overrides)
+    return create_request(**values)
+
+
+def _check(plan, check_id: str) -> dict:
+    return next(item for item in plan.config["checks"] if item["id"] == check_id)
+
+
+def test_workstation_renders_user_launchagent_with_local_only_defaults(tmp_path):
+    request = _request(tmp_path)
+    plan = build_plan(request)
+
+    assert request.service_scope == "user"
+    assert request.service_path == (
+        tmp_path / "Library" / "LaunchAgents" / f"{SERVICE_LABEL}.plist"
+    )
+    assert "<key>UserName</key>" not in plan.service_text
+    assert "<string>watch</string>" in plan.service_text
+    assert "http://localhost:11434/api/tags" in plan.config_text
+    assert plan.config["heartbeat"] is None
+    assert _check(plan, "tunnel")["enabled"] is False
+    assert _check(plan, "agent_bus")["enabled"] is False
+    assert all(check["id"] != "backup" for check in plan.config["checks"])
+    assert plan.config["state_path"] == str(request.state_dir / "state.json")
+    assert plan.config["heartbeat_path"] == str(request.state_dir / "heartbeat.json")
+    assert request.container_runtime == "docker_desktop"
+    assert request.docker_context == "desktop-linux"
+    assert plan.manifest["container_runtime"] == "docker-desktop"
+    assert plan.manifest["docker_context"] == "desktop-linux"
+    assert _check(plan, "container_runtime")["settings"]["context"] == (
+        "desktop-linux"
+    )
+    assert _check(plan, "postgres")["settings"]["recovery"]["context"] == (
+        "desktop-linux"
+    )
+    assert "72.60." not in plan.config_text + plan.service_text
+    assert "2.24." not in plan.config_text + plan.service_text
+    assert "127.0.0.1" not in plan.config_text + plan.service_text
+
+
+def test_studio_renders_system_launchdaemon_as_invoking_nonroot_user(tmp_path):
+    request = _request(tmp_path, profile="studio")
+    plan = build_plan(request)
+
+    assert request.service_scope == "system"
+    assert request.service_path == Path(f"/Library/LaunchDaemons/{SERVICE_LABEL}.plist")
+    assert "<key>UserName</key>" in plan.service_text
+    assert "<string>alice</string>" in plan.service_text
+    assert "<string>root</string>" not in plan.service_text
+    assert plan.config["profile"] == "studio"
+    assert plan.config["interval_seconds"] == 60
+    assert request.container_runtime == "colima"
+    assert request.docker_context == "colima"
+    assert all(check["id"] != "backup" for check in plan.config["checks"])
+    assert plan.manifest["backup_path"] is None
+    # Studio is useful without any public VPS or remote-control companion.
+    assert _check(plan, "tunnel")["enabled"] is False
+    assert _check(plan, "agent_bus")["enabled"] is False
+    assert plan.config["heartbeat"] is None
+    parsed = plistlib.loads(plan.service_text.encode())
+    assert parsed["UserName"] == "alice"
+    assert parsed["ProgramArguments"][-1] == "watch"
+    assert parsed["Umask"] == 0o77
+
+
+def test_docker_context_accepts_docker_supported_plus_character(tmp_path):
+    request = _request(tmp_path, docker_context="nooma+studio")
+    plan = build_plan(request)
+
+    assert request.docker_context == "nooma+studio"
+    assert plan.manifest["docker_context"] == "nooma+studio"
+    assert _check(plan, "container_runtime")["settings"]["context"] == (
+        "nooma+studio"
+    )
+
+
+def test_backup_freshness_requires_explicit_opt_in_and_path(tmp_path):
+    with pytest.raises(InstallError, match="requires --backup-path"):
+        _request(tmp_path / "missing", profile="studio", with_backup_check=True)
+
+    with pytest.raises(InstallError, match="requires --with-backup-check"):
+        _request(
+            tmp_path / "unselected",
+            profile="studio",
+            backup_path=tmp_path / "backups",
+        )
+
+    backup_path = tmp_path / "external-backups"
+    request = _request(
+        tmp_path / "enabled",
+        profile="studio",
+        with_backup_check=True,
+        backup_path=backup_path,
+    )
+    plan = build_plan(request)
+    backup = _check(plan, "backup")
+
+    assert backup["required"] is False
+    assert backup["settings"] == {
+        "path": str(backup_path.resolve()),
+        "pattern": "*",
+        "max_age_seconds": 172800,
+        "minimum_matches": 1,
+    }
+    assert plan.manifest["backup_path"] == str(backup_path.resolve())
+
+
+def test_linux_uses_user_systemd_for_both_profiles(tmp_path):
+    for profile in ("workstation", "studio"):
+        request = _request(
+            tmp_path / profile,
+            profile=profile,
+            platform_name="linux",
+        )
+        plan = build_plan(request)
+        assert request.service_manager == "systemd-user"
+        assert request.service_scope == "user"
+        assert request.service_path == (
+            tmp_path / profile / ".config" / "systemd" / "user" / SYSTEMD_UNIT
+        )
+        assert "systemctl" not in plan.service_text
+        assert "ops.resilience" in plan.service_text
+        assert " watch" in plan.service_text
+        assert "UMask=0077" in plan.service_text
+
+
+def test_optional_checks_are_disabled_unless_explicitly_enabled(tmp_path):
+    baseline = build_plan(_request(tmp_path / "baseline"))
+    assert _check(baseline, "tunnel")["enabled"] is False
+    assert _check(baseline, "agent_bus")["enabled"] is False
+
+    enabled = build_plan(
+        _request(
+            tmp_path / "enabled",
+            with_tunnel_check=True,
+            tunnel_label="com.example.safe-tunnel",
+            with_agent_bus_check=True,
+            agent_bus_url="http://localhost:18900/healthz",
+        )
+    )
+    assert _check(enabled, "tunnel")["enabled"] is True
+    assert _check(enabled, "tunnel")["settings"]["label"] == "com.example.safe-tunnel"
+    assert _check(enabled, "agent_bus")["enabled"] is True
+    assert _check(enabled, "agent_bus")["settings"]["host"] == "localhost"
+    assert _check(enabled, "agent_bus")["settings"]["port"] == 18900
+
+
+def test_heartbeat_references_secret_env_name_but_never_secret_value(
+    tmp_path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".env").write_text(
+        "MY_HEARTBEAT_SECRET=never-write-this-secret\n"
+    )
+    monkeypatch.setenv("MY_HEARTBEAT_SECRET", "never-write-this-secret")
+    request = _request(
+        tmp_path,
+        repo_root=repo,
+        with_heartbeat=True,
+        heartbeat_url="https://health.example.invalid/v1/ping",
+        heartbeat_secret_env="MY_HEARTBEAT_SECRET",
+    )
+    plan = build_plan(request)
+    combined = plan.config_text + plan.service_text + plan.manifest_text
+
+    assert plan.config["heartbeat"] == {
+        "url": "https://health.example.invalid/v1/ping",
+        "secret_env": "MY_HEARTBEAT_SECRET",
+    }
+    assert "MY_HEARTBEAT_SECRET" in plan.config_text
+    assert "never-write-this-secret" not in combined
+    assert "MY_HEARTBEAT_SECRET" not in plan.service_text
+    assert "MY_HEARTBEAT_SECRET" not in plan.manifest_text
+
+
+def test_optional_values_load_from_dotenv_without_shell_evaluation(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    marker = tmp_path / "must-not-exist"
+    (repo / ".env").write_text(
+        "\n".join(
+            [
+                "DEVBRAIN_HEARTBEAT_URL=https://health.example.invalid/ping",
+                "DEVBRAIN_HEARTBEAT_TOKEN=secret-stays-in-dotenv",
+                "DEVBRAIN_TUNNEL_LABEL=com.example.tunnel",
+                "DEVBRAIN_AGENT_BUS_HEALTH_URL=http://127.0.0.1:18900/healthz",
+                f'IGNORED_SHELL="$(touch {marker})"',
+            ]
+        )
+    )
+
+    request = _request(
+        tmp_path / "home",
+        repo_root=repo,
+        env={},
+        with_heartbeat=True,
+        with_tunnel_check=True,
+        with_agent_bus_check=True,
+    )
+
+    assert request.heartbeat_url == "https://health.example.invalid/ping"
+    assert request.tunnel_label == "com.example.tunnel"
+    assert request.agent_bus_url == "http://127.0.0.1:18900/healthz"
+    assert not marker.exists()
+
+
+def test_heartbeat_url_rejects_embedded_credentials(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".env").write_text("HEARTBEAT_TOKEN=test-secret\n")
+    with pytest.raises(InstallError, match="must not contain embedded credentials"):
+        _request(
+            tmp_path,
+            repo_root=repo,
+            with_heartbeat=True,
+            heartbeat_url="https://user:secret@example.invalid/ping",
+            heartbeat_secret_env="HEARTBEAT_TOKEN",
+        )
+
+
+def test_heartbeat_url_requires_https(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".env").write_text("HEARTBEAT_TOKEN=test-secret\n")
+    with pytest.raises(InstallError, match="absolute HTTPS URL"):
+        _request(
+            tmp_path,
+            repo_root=repo,
+            with_heartbeat=True,
+            heartbeat_url="http://health.example.invalid/ping",
+            heartbeat_secret_env="HEARTBEAT_TOKEN",
+        )
+
+
+def test_heartbeat_requires_runtime_token_in_repository_dotenv(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".env").write_text(
+        "DEVBRAIN_HEARTBEAT_URL=https://health.example.invalid/ping\n"
+    )
+
+    with pytest.raises(InstallError, match="must be set"):
+        _request(
+            tmp_path,
+            repo_root=repo,
+            env={},
+            with_heartbeat=True,
+        )
+
+
+def test_container_runtime_default_and_explicit_override(tmp_path):
+    assert _request(tmp_path / "workstation").container_runtime == "docker_desktop"
+    assert _request(tmp_path / "studio", profile="studio").container_runtime == "colima"
+    overridden = _request(
+        tmp_path / "override",
+        profile="studio",
+        container_runtime="docker-desktop",
+    )
+    assert overridden.container_runtime == "docker_desktop"
+    recovery = _check(build_plan(overridden), "container_runtime")["settings"][
+        "recovery"
+    ]
+    assert recovery == {"type": "runtime_start", "runtime": "docker_desktop"}
+    linux = _request(tmp_path / "linux", platform_name="linux")
+    assert linux.container_runtime == "docker_engine"
+    assert linux.docker_context == "default"
+    linux_plan = build_plan(linux)
+    assert linux_plan.manifest["container_runtime"] == "docker-engine"
+    linux_runtime = _check(linux_plan, "container_runtime")
+    assert "recovery" not in linux_runtime["settings"]
+
+
+def test_service_preserves_virtualenv_python_symlink(tmp_path):
+    interpreter = tmp_path / "python-real"
+    interpreter.touch()
+    venv_python = tmp_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(interpreter)
+
+    request = _request(tmp_path, python_executable=venv_python)
+    plan = build_plan(request)
+    parsed = plistlib.loads(plan.service_text.encode())
+
+    assert request.python_executable == venv_python
+    assert request.python_executable.resolve() == interpreter
+    assert parsed["ProgramArguments"][0] == str(venv_python)
+
+
+def test_tunnel_check_requires_explicit_valid_label(tmp_path):
+    with pytest.raises(InstallError, match="requires a valid --tunnel-label"):
+        _request(tmp_path, with_tunnel_check=True)
+    with pytest.raises(InstallError, match="requires a valid --tunnel-label"):
+        _request(
+            tmp_path,
+            with_tunnel_check=True,
+            tunnel_label="not a launchd label!",
+        )
+
+
+def test_service_rejects_root_identity(tmp_path):
+    with pytest.raises(InstallError, match="non-root"):
+        _request(tmp_path, username="root", uid=0)
+
+
+def test_owned_artifact_paths_must_be_distinct(tmp_path):
+    collision = tmp_path / ".devbrain" / "resilience" / "state.json"
+    with pytest.raises(InstallError, match="fixed per-user"):
+        _request(tmp_path, config_path=collision)
+
+
+def test_dry_run_renders_without_writing_or_running_commands(tmp_path):
+    runner = RecordingRunner()
+    request = _request(tmp_path)
+    plan = install(request, dry_run=True, runner=runner)
+
+    assert plan.config["schema_version"] == 1
+    assert not request.config_path.exists()
+    assert not request.manifest_path.exists()
+    assert not request.service_path.exists()
+    assert runner.calls == []
+
+
+def test_workstation_install_is_idempotent_and_manifest_is_mode_0600(tmp_path):
+    runner = RecordingRunner()
+    request = _request(tmp_path)
+
+    first = install(request, runner=runner)
+    first_files = {
+        request.config_path: request.config_path.read_bytes(),
+        request.service_path: request.service_path.read_bytes(),
+        request.manifest_path: request.manifest_path.read_bytes(),
+    }
+    second = install(request, runner=runner)
+
+    assert first.config_text == second.config_text
+    for path, content in first_files.items():
+        assert path.read_bytes() == content
+    assert stat.S_IMODE(request.config_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(request.manifest_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(request.service_path.stat().st_mode) == 0o644
+    assert stat.S_IMODE(request.state_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(request.log_dir.stat().st_mode) == 0o700
+    manifest = json.loads(request.manifest_path.read_text())
+    assert {item["path"] for item in manifest["managed_files"]} == {
+        str(request.config_path),
+        str(request.service_path),
+        str(request.state_dir / "state.json"),
+        str(request.state_dir / "heartbeat.json"),
+    }
+    bootstrap_calls = [call for call, _ in runner.calls if "bootstrap" in call]
+    assert len(bootstrap_calls) == 2
+
+
+def test_install_hardens_repository_dotenv_permissions(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    dotenv = repo / ".env"
+    dotenv.write_text("EXAMPLE=value\n")
+    dotenv.chmod(0o644)
+    runner = RecordingRunner()
+
+    install(_request(tmp_path / "home", repo_root=repo), runner=runner)
+
+    assert stat.S_IMODE(dotenv.stat().st_mode) == 0o600
+
+
+def test_uninstall_removes_only_manifest_owned_files_and_is_idempotent(tmp_path):
+    runner = RecordingRunner()
+    request = _request(tmp_path)
+    install(request, runner=runner)
+    unrelated = request.service_path.parent / "com.example.unrelated.plist"
+    unrelated.write_text("keep me")
+
+    result = uninstall(request.manifest_path, runner=runner)
+    assert result["installed"] is True
+    assert not request.config_path.exists()
+    assert not request.service_path.exists()
+    assert not request.manifest_path.exists()
+    assert unrelated.read_text() == "keep me"
+
+    second = uninstall(request.manifest_path, runner=runner)
+    assert second["installed"] is False
+    assert unrelated.exists()
+
+
+@pytest.mark.parametrize("platform_name", ["macos", "linux"])
+def test_restart_preserves_rendered_policy_and_reactivates_service(
+    tmp_path,
+    platform_name,
+):
+    runner = RecordingRunner()
+    request = _request(tmp_path, platform_name=platform_name)
+    install(request, runner=runner)
+    rendered = {
+        request.config_path: request.config_path.read_bytes(),
+        request.service_path: request.service_path.read_bytes(),
+        request.manifest_path: request.manifest_path.read_bytes(),
+    }
+    runner.calls.clear()
+
+    result = restart(request.manifest_path, runner=runner)
+
+    assert result["installed"] is True
+    assert result["operation"] == "restart"
+    for path, content in rendered.items():
+        assert path.read_bytes() == content
+    commands = [call for call, _ in runner.calls]
+    assert any("bootout" in call or "disable" in call for call in commands)
+    assert any("bootstrap" in call or "enable" in call for call in commands)
+
+
+def test_restart_is_a_noop_when_resilience_is_not_installed(tmp_path):
+    runner = RecordingRunner()
+
+    result = restart(
+        tmp_path / ".devbrain" / "resilience" / "install-manifest.json",
+        runner=runner,
+    )
+
+    assert result["installed"] is False
+    assert runner.calls == []
+
+
+@pytest.mark.parametrize("platform_name", ["macos", "linux"])
+def test_uninstall_refuses_to_delete_files_while_service_is_active(
+    tmp_path,
+    platform_name,
+):
+    request = _request(tmp_path, platform_name=platform_name)
+    install(request, runner=RecordingRunner())
+
+    # A zero exit from launchctl print/systemctl is-active means the service
+    # survived the requested stop.
+    active_runner = RecordingRunner()
+    original_call = active_runner.__call__
+
+    def report_active(args, **kwargs):
+        if "print" in args or "is-active" in args:
+            active_runner.calls.append((tuple(args), dict(kwargs)))
+            return subprocess.CompletedProcess(args, 0, "", "")
+        return original_call(args, **kwargs)
+
+    with pytest.raises(InstallError, match="while .* (loaded|active)"):
+        uninstall(request.manifest_path, runner=report_active)
+
+    assert request.config_path.exists()
+    assert request.service_path.exists()
+    assert request.manifest_path.exists()
+
+
+@pytest.mark.parametrize("platform_name", ["macos", "linux"])
+def test_uninstall_fails_closed_when_inactive_state_cannot_be_verified(
+    tmp_path,
+    platform_name,
+):
+    request = _request(tmp_path, platform_name=platform_name)
+    install(request, runner=RecordingRunner())
+
+    def uncertain_runner(args, **kwargs):
+        return subprocess.CompletedProcess(args, 1, "", "permission denied")
+
+    with pytest.raises(InstallError, match="could not verify"):
+        uninstall(request.manifest_path, runner=uncertain_runner)
+
+    assert request.config_path.exists()
+    assert request.service_path.exists()
+    assert request.manifest_path.exists()
+
+
+def test_uninstall_rejects_tampered_service_artifact_path(tmp_path):
+    runner = RecordingRunner()
+    request = _request(tmp_path)
+    install(request, runner=runner)
+    manifest = json.loads(request.manifest_path.read_text())
+    service_item = next(
+        item for item in manifest["managed_files"] if item["kind"] == "service"
+    )
+    service_item["path"] = "/tmp/not-the-installed-service"
+    request.manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(InstallError, match="does not match"):
+        uninstall(request.manifest_path, runner=runner)
+
+
+def test_uninstall_rejects_paired_manifest_path_tampering(tmp_path):
+    runner = RecordingRunner()
+    request = _request(tmp_path)
+    install(request, runner=runner)
+    manifest = json.loads(request.manifest_path.read_text())
+
+    arbitrary_service = tmp_path / "do-not-delete-service"
+    arbitrary_service.write_text("keep")
+    manifest["service"]["path"] = str(arbitrary_service)
+    service_item = next(
+        item for item in manifest["managed_files"] if item["kind"] == "service"
+    )
+    service_item["path"] = str(arbitrary_service)
+    request.manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(InstallError, match="fixed location"):
+        uninstall(request.manifest_path, runner=runner)
+    assert arbitrary_service.exists()
+
+    manifest = build_plan(request).manifest
+    arbitrary_config = tmp_path / "do-not-delete-config"
+    arbitrary_config.write_text("keep")
+    manifest["config_path"] = str(arbitrary_config)
+    config_item = next(
+        item for item in manifest["managed_files"] if item["kind"] == "config"
+    )
+    config_item["path"] = str(arbitrary_config)
+    request.manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(InstallError, match="fixed location"):
+        uninstall(request.manifest_path, runner=runner)
+    assert arbitrary_config.exists()
+
+
+def test_manifest_rejects_invalid_docker_context(tmp_path):
+    runner = RecordingRunner()
+    request = _request(tmp_path)
+    install(request, runner=runner)
+    manifest = json.loads(request.manifest_path.read_text())
+    manifest["docker_context"] = "../../unsafe"
+    request.manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(InstallError, match="Docker context"):
+        uninstall(request.manifest_path, runner=runner)
+
+
+def test_linux_install_and_uninstall_use_user_systemd(tmp_path):
+    runner = RecordingRunner()
+    request = _request(tmp_path, platform_name="linux")
+
+    install(request, runner=runner)
+    uninstall(request.manifest_path, runner=runner)
+
+    commands = [call for call, _ in runner.calls]
+    assert ("systemctl", "--user", "daemon-reload") in commands
+    assert (
+        "systemctl",
+        "--user",
+        "enable",
+        "--now",
+        SYSTEMD_UNIT,
+    ) in commands
+    assert (
+        "systemctl",
+        "--user",
+        "disable",
+        "--now",
+        SYSTEMD_UNIT,
+    ) in commands
+    assert all("sudo" not in call for call in commands)
+
+
+def test_linux_studio_enables_user_linger_for_boot_persistence(tmp_path):
+    runner = RecordingRunner()
+    request = _request(
+        tmp_path,
+        platform_name="linux",
+        profile="studio",
+    )
+
+    install(request, runner=runner)
+
+    commands = [call for call, _ in runner.calls]
+    assert (
+        "sudo",
+        "loginctl",
+        "enable-linger",
+        "alice",
+    ) in commands
+
+
+def test_parser_rejects_unknown_and_abbreviated_flags():
+    parser = build_parser()
+    with pytest.raises(SystemExit) as unknown:
+        parser.parse_args(["--definitely-unknown"])
+    assert unknown.value.code == 2
+    with pytest.raises(SystemExit) as abbreviated:
+        parser.parse_args(["--prof", "studio"])
+    assert abbreviated.value.code == 2
+
+
+def test_parser_rejects_incompatible_uninstall_options():
+    parser = build_parser()
+    args = parser.parse_args(
+        ["--uninstall", "--profile", "studio", "--container-runtime", "colima"]
+    )
+    with pytest.raises(InstallError, match="incompatible"):
+        _reject_incompatible_args(args)
+    restart_args = parser.parse_args(["--restart", "--profile", "studio"])
+    with pytest.raises(InstallError, match="incompatible"):
+        _reject_incompatible_args(restart_args)
+    restart_yes = parser.parse_args(["--restart", "--yes"])
+    with pytest.raises(InstallError, match="only valid"):
+        _reject_incompatible_args(restart_yes)
+    install_args = parser.parse_args(["--yes"])
+    with pytest.raises(InstallError, match="only valid"):
+        _reject_incompatible_args(install_args)
+
+
+@pytest.mark.parametrize("platform_name", ["macos", "linux"])
+@pytest.mark.parametrize("profile", ["workstation", "studio"])
+def test_every_platform_profile_render_loads_with_production_core(
+    tmp_path, platform_name, profile
+):
+    request = _request(
+        tmp_path / platform_name / profile,
+        platform_name=platform_name,
+        profile=profile,
+    )
+    plan = build_plan(request)
+    request.config_path.parent.mkdir(parents=True, exist_ok=True)
+    request.config_path.write_text(plan.config_text)
+
+    loaded = load_config(request.config_path)
+
+    assert loaded.profile == profile
+    assert loaded.state_path == request.state_dir / "state.json"
+    assert loaded.heartbeat_path == request.state_dir / "heartbeat.json"
+    expected_checks = {
+        "container_runtime",
+        "postgres",
+        "ollama",
+        "ingest",
+        "disk",
+        "tunnel",
+        "agent_bus",
+    }
+    assert {check["id"] for check in loaded.checks} == expected_checks

--- a/factory/tests/test_resilience_medic.py
+++ b/factory/tests/test_resilience_medic.py
@@ -1,0 +1,624 @@
+from __future__ import annotations
+
+import copy
+import fcntl
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from ops.resilience.medic import MedicQueue  # noqa: E402
+from ops.resilience.medic_service import load_medic_config  # noqa: E402
+from ops.resilience.medic_tools import main as medic_tools_main  # noqa: E402
+from ops.resilience.signing import (  # noqa: E402
+    AuthorizedKey,
+    MedicAuthorizationError,
+    ReplayLedger,
+    encode_private_key,
+    encode_public_key,
+    generate_keypair,
+    load_private_key,
+    load_public_key,
+    make_task,
+    sign_task,
+    verify_envelope,
+)
+
+
+def _keys():
+    primary_raw, primary_public_raw = generate_keypair()
+    confirm_raw, confirm_public_raw = generate_keypair()
+    primary = load_private_key(primary_raw)
+    confirm = load_private_key(confirm_raw)
+    keys = {
+        "operator-primary": AuthorizedKey("primary", primary.public_key()),
+        "operator-confirm": AuthorizedKey("confirm", confirm.public_key()),
+    }
+    # Assert the generated public bytes are genuinely tied to the private keys.
+    assert primary.public_key().public_bytes_raw() == primary_public_raw
+    assert confirm.public_key().public_bytes_raw() == confirm_public_raw
+    return primary, confirm, keys
+
+
+def _envelope(task, *signatures):
+    return {"task": task, "signatures": list(signatures)}
+
+
+def test_diagnose_requires_one_valid_primary_signature():
+    primary, _confirm, keys = _keys()
+    task = make_task(instance_id="studio-a", action={"type": "diagnose"})
+    envelope = _envelope(
+        task,
+        sign_task(task, key_id="operator-primary", private_key=primary),
+    )
+
+    verified = verify_envelope(
+        envelope,
+        authorized_keys=keys,
+        instance_id="studio-a",
+    )
+
+    assert verified.task == task
+    assert verified.signer_roles == {"primary"}
+
+
+def test_heal_requires_distinct_primary_and_confirm_signatures():
+    primary, confirm, keys = _keys()
+    task = make_task(
+        instance_id="studio-a",
+        action={"type": "heal", "check": "database"},
+    )
+    primary_only = _envelope(
+        task,
+        sign_task(task, key_id="operator-primary", private_key=primary),
+    )
+    with pytest.raises(MedicAuthorizationError, match="confirm"):
+        verify_envelope(
+            primary_only,
+            authorized_keys=keys,
+            instance_id="studio-a",
+        )
+
+    both = _envelope(
+        task,
+        sign_task(task, key_id="operator-primary", private_key=primary),
+        sign_task(task, key_id="operator-confirm", private_key=confirm),
+    )
+    assert verify_envelope(
+        both,
+        authorized_keys=keys,
+        instance_id="studio-a",
+    ).signer_roles == {"primary", "confirm"}
+
+
+def test_private_key_encoding_is_rejected_at_public_key_boundary():
+    primary, _confirm, _keys_by_role = _keys()
+
+    with pytest.raises(MedicAuthorizationError, match="public-key encoding"):
+        load_public_key(encode_private_key(primary))
+
+
+def test_unsigned_role_change_cannot_reuse_primary_signature():
+    primary, _confirm, keys = _keys()
+    task = make_task(
+        instance_id="studio-a",
+        action={"type": "heal", "check": "database"},
+    )
+    primary_signature = sign_task(
+        task,
+        key_id="operator-primary",
+        private_key=primary,
+    )
+    forged = copy.deepcopy(primary_signature)
+    forged["key_id"] = "operator-confirm"
+
+    with pytest.raises(MedicAuthorizationError, match="invalid signature"):
+        verify_envelope(
+            _envelope(task, primary_signature, forged),
+            authorized_keys=keys,
+            instance_id="studio-a",
+        )
+
+
+def test_confirmation_over_different_payload_is_rejected():
+    primary, confirm, keys = _keys()
+    database_task = make_task(
+        instance_id="studio-a",
+        action={"type": "heal", "check": "database"},
+    )
+    tunnel_task = dict(database_task)
+    tunnel_task["action"] = {"type": "heal", "check": "tunnel"}
+
+    envelope = _envelope(
+        database_task,
+        sign_task(
+            database_task,
+            key_id="operator-primary",
+            private_key=primary,
+        ),
+        sign_task(
+            tunnel_task,
+            key_id="operator-confirm",
+            private_key=confirm,
+        ),
+    )
+    with pytest.raises(MedicAuthorizationError, match="invalid signature"):
+        verify_envelope(
+            envelope,
+            authorized_keys=keys,
+            instance_id="studio-a",
+        )
+
+
+def test_wrong_instance_and_expired_tasks_are_rejected():
+    primary, _confirm, keys = _keys()
+    issued = datetime(2026, 7, 23, tzinfo=timezone.utc)
+    task = make_task(
+        instance_id="studio-a",
+        action={"type": "status"},
+        ttl=timedelta(minutes=1),
+        now=issued,
+    )
+    envelope = _envelope(
+        task,
+        sign_task(task, key_id="operator-primary", private_key=primary),
+    )
+
+    with pytest.raises(MedicAuthorizationError, match="different instance"):
+        verify_envelope(
+            envelope,
+            authorized_keys=keys,
+            instance_id="studio-b",
+            now=issued,
+        )
+    with pytest.raises(MedicAuthorizationError, match="expired"):
+        verify_envelope(
+            envelope,
+            authorized_keys=keys,
+            instance_id="studio-a",
+            now=issued + timedelta(minutes=2),
+        )
+
+
+def test_replay_ledger_fails_closed_on_malformed_expiry(tmp_path):
+    ledger_path = tmp_path / "ledger.json"
+    ledger_path.write_text(json.dumps({"prior-nonce": "not-a-time"}))
+    ledger = ReplayLedger(ledger_path)
+
+    with pytest.raises(MedicAuthorizationError, match="invalid expiry"):
+        ledger.claim(
+            "new-nonce",
+            expires_at="2026-07-23T12:00:00Z",
+            now=datetime(2026, 7, 23, 11, 0, tzinfo=timezone.utc),
+        )
+
+    assert json.loads(ledger_path.read_text()) == {"prior-nonce": "not-a-time"}
+
+
+def test_queue_consumes_nonce_once_and_uses_only_allowlisted_heal(tmp_path):
+    primary, confirm, keys = _keys()
+    calls: list[str] = []
+    queue = MedicQueue(
+        root=tmp_path,
+        instance_id="studio-a",
+        authorized_keys=keys,
+        allowed_heal_checks={"database"},
+        status_callback=lambda: {"healthy": True},
+        diagnose_callback=lambda: {"checks": []},
+        heal_callback=lambda check: calls.append(check) or {"healed": check},
+    )
+    task = make_task(
+        instance_id="studio-a",
+        action={"type": "heal", "check": "database"},
+    )
+    envelope = _envelope(
+        task,
+        sign_task(task, key_id="operator-primary", private_key=primary),
+        sign_task(task, key_id="operator-confirm", private_key=confirm),
+    )
+    source = queue.inbox / "task.json"
+    source.write_text(json.dumps(envelope), encoding="utf-8")
+
+    results = queue.process_once()
+
+    assert calls == ["database"]
+    assert results[0].status == "ok"
+    assert (queue.outbox / f"{task['task_id']}.json").exists()
+
+    (queue.inbox / "replay.json").write_text(
+        json.dumps(envelope),
+        encoding="utf-8",
+    )
+    assert queue.process_once() == []
+    reason_files = list(queue.rejected.glob("*.reason.json"))
+    assert any("already been used" in path.read_text() for path in reason_files)
+
+
+def test_queue_rejects_heal_not_in_local_allowlist(tmp_path):
+    primary, confirm, keys = _keys()
+    queue = MedicQueue(
+        root=tmp_path,
+        instance_id="studio-a",
+        authorized_keys=keys,
+        allowed_heal_checks={"database"},
+        status_callback=lambda: {},
+        diagnose_callback=lambda: {},
+        heal_callback=lambda check: pytest.fail(f"unexpected heal: {check}"),
+    )
+    task = make_task(
+        instance_id="studio-a",
+        action={"type": "heal", "check": "tunnel"},
+    )
+    envelope = _envelope(
+        task,
+        sign_task(task, key_id="operator-primary", private_key=primary),
+        sign_task(task, key_id="operator-confirm", private_key=confirm),
+    )
+    (queue.inbox / "task.json").write_text(json.dumps(envelope), encoding="utf-8")
+
+    assert queue.process_once() == []
+    reason = next(queue.rejected.glob("*.reason.json")).read_text()
+    assert "not locally allowlisted" in reason
+
+
+def test_queue_rejects_nonregular_files_without_following_or_blocking(tmp_path):
+    _primary, _confirm, keys = _keys()
+    queue = MedicQueue(
+        root=tmp_path,
+        instance_id="studio-a",
+        authorized_keys=keys,
+        allowed_heal_checks=set(),
+        status_callback=lambda: {},
+        diagnose_callback=lambda: {},
+        heal_callback=lambda check: {},
+    )
+    (queue.inbox / "zero.json").symlink_to("/dev/zero")
+
+    assert queue.process_once() == []
+    reason = next(queue.rejected.glob("*.reason.json")).read_text()
+    assert "regular file" in reason or "Too many levels" in reason
+
+    os.mkfifo(queue.inbox / "pipe.json")
+    assert queue.process_once() == []
+    reasons = [path.read_text() for path in queue.rejected.glob("*.reason.json")]
+    assert any("regular file" in value for value in reasons)
+
+
+def test_queue_recovers_processing_files_without_replaying_claimed_nonce(tmp_path):
+    primary, _confirm, keys = _keys()
+    calls: list[str] = []
+    queue = MedicQueue(
+        root=tmp_path,
+        instance_id="studio-a",
+        authorized_keys=keys,
+        allowed_heal_checks=set(),
+        status_callback=lambda: calls.append("status") or {"healthy": True},
+        diagnose_callback=lambda: {},
+        heal_callback=lambda check: {},
+    )
+    recoverable = make_task(
+        instance_id="studio-a",
+        action={"type": "status"},
+    )
+    envelope = _envelope(
+        recoverable,
+        sign_task(
+            recoverable,
+            key_id="operator-primary",
+            private_key=primary,
+        ),
+    )
+    (queue.processing / "before-claim.json").write_text(json.dumps(envelope))
+
+    assert queue.process_once()[0].status == "ok"
+    assert calls == ["status"]
+
+    indeterminate = make_task(
+        instance_id="studio-a",
+        action={"type": "status"},
+    )
+    envelope = _envelope(
+        indeterminate,
+        sign_task(
+            indeterminate,
+            key_id="operator-primary",
+            private_key=primary,
+        ),
+    )
+    (queue.processing / "after-claim.json").write_text(json.dumps(envelope))
+    queue.ledger.claim(
+        indeterminate["nonce"],
+        expires_at=indeterminate["expires_at"],
+    )
+
+    assert queue.process_once() == []
+    assert calls == ["status"]
+    reasons = [path.read_text() for path in queue.rejected.glob("*.reason.json")]
+    assert any("already been used" in value for value in reasons)
+
+
+def test_failed_typed_heal_has_failed_top_level_status(tmp_path):
+    primary, confirm, keys = _keys()
+    queue = MedicQueue(
+        root=tmp_path,
+        instance_id="studio-a",
+        authorized_keys=keys,
+        allowed_heal_checks={"database"},
+        status_callback=lambda: {},
+        diagnose_callback=lambda: {},
+        heal_callback=lambda check: {"ok": False, "detail": "restart failed"},
+    )
+    task = make_task(
+        instance_id="studio-a",
+        action={"type": "heal", "check": "database"},
+    )
+    envelope = _envelope(
+        task,
+        sign_task(task, key_id="operator-primary", private_key=primary),
+        sign_task(task, key_id="operator-confirm", private_key=confirm),
+    )
+    (queue.inbox / "failed-heal.json").write_text(json.dumps(envelope))
+
+    result = queue.process_once()[0]
+    payload = json.loads((queue.outbox / f"{task['task_id']}.json").read_text())
+
+    assert result.status == "failed"
+    assert payload["status"] == "failed"
+
+
+def test_queue_processes_at_most_one_task_per_cycle(tmp_path):
+    primary, _confirm, keys = _keys()
+    queue = MedicQueue(
+        root=tmp_path,
+        instance_id="studio-a",
+        authorized_keys=keys,
+        allowed_heal_checks=set(),
+        status_callback=lambda: {"healthy": True},
+        diagnose_callback=lambda: {},
+        heal_callback=lambda check: {},
+    )
+    for index in range(2):
+        task = make_task(
+            instance_id="studio-a",
+            action={"type": "status"},
+        )
+        envelope = _envelope(
+            task,
+            sign_task(
+                task,
+                key_id="operator-primary",
+                private_key=primary,
+            ),
+        )
+        (queue.inbox / f"{index}.json").write_text(json.dumps(envelope))
+
+    assert len(queue.process_once()) == 1
+    assert len(list(queue.inbox.glob("*.json"))) == 1
+    assert len(queue.process_once()) == 1
+    assert not list(queue.inbox.glob("*.json"))
+
+
+def test_queue_consumer_lock_prevents_concurrent_processing(tmp_path):
+    primary, _confirm, keys = _keys()
+    queue = MedicQueue(
+        root=tmp_path,
+        instance_id="studio-a",
+        authorized_keys=keys,
+        allowed_heal_checks=set(),
+        status_callback=lambda: {"healthy": True},
+        diagnose_callback=lambda: {},
+        heal_callback=lambda check: {},
+    )
+    task = make_task(
+        instance_id="studio-a",
+        action={"type": "status"},
+    )
+    envelope = _envelope(
+        task,
+        sign_task(
+            task,
+            key_id="operator-primary",
+            private_key=primary,
+        ),
+    )
+    pending = queue.inbox / "pending.json"
+    pending.write_text(json.dumps(envelope))
+
+    lock_fd = os.open(queue.consumer_lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        assert queue.process_once() == []
+        assert pending.exists()
+        assert not list(queue.processing.glob("*.json"))
+        assert not list(queue.outbox.glob("*.json"))
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+    assert queue.process_once()[0].status == "ok"
+
+
+def test_operator_tool_generates_keys_and_two_signature_task(tmp_path):
+    primary_private = tmp_path / "primary.key"
+    primary_public = tmp_path / "primary.pub"
+    confirm_private = tmp_path / "confirm.key"
+    confirm_public = tmp_path / "confirm.pub"
+    assert (
+        medic_tools_main(
+            [
+                "keygen",
+                "--private",
+                str(primary_private),
+                "--public",
+                str(primary_public),
+            ]
+        )
+        == 0
+    )
+    assert (
+        medic_tools_main(
+            [
+                "keygen",
+                "--private",
+                str(confirm_private),
+                "--public",
+                str(confirm_public),
+            ]
+        )
+        == 0
+    )
+    assert os.stat(primary_private).st_mode & 0o777 == 0o600
+    assert primary_private.read_text().startswith(
+        "devbrain-ed25519-private-v1:"
+    )
+    assert primary_public.read_text().startswith(
+        "devbrain-ed25519-public-v1:"
+    )
+
+    envelope_path = tmp_path / "heal-task.json"
+    assert (
+        medic_tools_main(
+            [
+                "task",
+                "--instance-id",
+                "studio-a",
+                "--action",
+                "heal",
+                "--check",
+                "database",
+                "--sign",
+                f"operator-primary={primary_private}",
+                "--sign",
+                f"operator-confirm={confirm_private}",
+                "--output",
+                str(envelope_path),
+            ]
+        )
+        == 0
+    )
+    envelope = json.loads(envelope_path.read_text())
+    keys = {
+        "operator-primary": AuthorizedKey(
+            "primary",
+            load_private_key(primary_private.read_text().strip()).public_key(),
+        ),
+        "operator-confirm": AuthorizedKey(
+            "confirm",
+            load_private_key(confirm_private.read_text().strip()).public_key(),
+        ),
+    }
+    verified = verify_envelope(
+        envelope,
+        authorized_keys=keys,
+        instance_id="studio-a",
+    )
+    assert verified.task["action"] == {"type": "heal", "check": "database"}
+
+
+def _runtime_config(tmp_path, *, medic_path=None):
+    from ops.resilience.core import load_config
+
+    config_path = tmp_path / "runtime.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "profile": "studio",
+                "state_path": str(tmp_path / "state.json"),
+                "heartbeat_path": str(tmp_path / "heartbeat.json"),
+                "medic_config_path": str(medic_path) if medic_path else None,
+                "checks": [
+                    {
+                        "id": "database",
+                        "type": "docker_container",
+                        "enabled": True,
+                        "required": True,
+                        "timeout_seconds": 5,
+                        "settings": {
+                            "container": "devbrain-db",
+                            "recovery": {
+                                "type": "docker_compose_up",
+                                "project_dir": str(tmp_path),
+                                "services": ["devbrain-db"],
+                            },
+                        },
+                    }
+                ],
+                "heartbeat": None,
+            }
+        )
+    )
+    return load_config(config_path)
+
+
+def test_medic_config_requires_two_distinct_keys_for_heal_mode(tmp_path):
+    primary, _confirm, _keys_map = _keys()
+    path = tmp_path / "medic.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "instance_id": "studio-a",
+                "mode": "heal",
+                "queue_dir": str(tmp_path / "queue"),
+                "keys": [
+                    {
+                        "key_id": "operator-primary",
+                        "role": "primary",
+                        "public_key": encode_public_key(primary.public_key()),
+                    }
+                ],
+                "allowed_heal_checks": ["database"],
+            }
+        )
+    )
+    with pytest.raises(MedicAuthorizationError, match="confirm"):
+        load_medic_config(
+            path,
+            runtime_config=_runtime_config(tmp_path, medic_path=path),
+        )
+
+
+def test_medic_config_binds_heals_to_runtime_recovery_allowlist(tmp_path):
+    primary, confirm, _keys_map = _keys()
+    path = tmp_path / "medic.json"
+    payload = {
+        "schema_version": 1,
+        "instance_id": "studio-a",
+        "mode": "heal",
+        "queue_dir": str(tmp_path / "queue"),
+        "keys": [
+            {
+                "key_id": "operator-primary",
+                "role": "primary",
+                "public_key": encode_public_key(primary.public_key()),
+            },
+            {
+                "key_id": "operator-confirm",
+                "role": "confirm",
+                "public_key": encode_public_key(confirm.public_key()),
+            },
+        ],
+        "allowed_heal_checks": ["tunnel"],
+    }
+    path.write_text(json.dumps(payload))
+    with pytest.raises(MedicAuthorizationError, match="not recoverable"):
+        load_medic_config(
+            path,
+            runtime_config=_runtime_config(tmp_path, medic_path=path),
+        )
+
+    payload["allowed_heal_checks"] = ["database"]
+    path.write_text(json.dumps(payload))
+    loaded = load_medic_config(
+        path,
+        runtime_config=_runtime_config(tmp_path, medic_path=path),
+    )
+    assert loaded.mode == "heal"
+    assert loaded.allowed_heal_checks == {"database"}

--- a/factory/tests/test_resilience_medic_install.py
+++ b/factory/tests/test_resilience_medic_install.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from ops.resilience.core import load_config  # noqa: E402
+from ops.resilience.install import (  # noqa: E402
+    InstallError,
+    build_plan,
+    create_request,
+    install,
+    uninstall,
+)
+from ops.resilience.medic_service import load_medic_config  # noqa: E402
+from ops.resilience.signing import (  # noqa: E402
+    encode_private_key,
+    encode_public_key,
+    generate_keypair,
+    load_private_key,
+)
+
+
+class RecordingRunner:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, args, **kwargs):
+        self.calls.append((tuple(args), kwargs))
+        returncode = 0
+        if "print" in args:
+            returncode = 113
+        elif "is-active" in args:
+            returncode = 3
+        return subprocess.CompletedProcess(
+            args,
+            returncode,
+            "",
+            "",
+        )
+
+
+def _public_key_file(path: Path) -> Path:
+    private_raw, _public_raw = generate_keypair()
+    private = load_private_key(private_raw)
+    path.write_text(encode_public_key(private.public_key()))
+    return path
+
+
+def _request(tmp_path: Path, **overrides):
+    values = {
+        "profile": "workstation",
+        "platform_name": "macos",
+        "repo_root": REPO_ROOT,
+        "home": tmp_path,
+        "username": "alice",
+        "uid": 501,
+        "python_executable": Path("/usr/bin/python3"),
+    }
+    values.update(overrides)
+    return create_request(**values)
+
+
+def test_diagnose_medic_renders_public_key_only_and_loads(tmp_path):
+    primary = _public_key_file(tmp_path / "primary.pub")
+    request = _request(
+        tmp_path,
+        medic_mode="diagnose",
+        medic_instance_id="studio-a",
+        medic_primary_public_key_path=primary,
+    )
+    plan = build_plan(request)
+
+    assert plan.config["medic_config_path"] == str(request.medic_config_path)
+    assert plan.medic_config["mode"] == "diagnose"
+    assert plan.medic_config["allowed_heal_checks"] == []
+    assert {key["role"] for key in plan.medic_config["keys"]} == {"primary"}
+    assert "PRIVATE" not in plan.medic_config_text
+    assert {item["kind"] for item in plan.manifest["managed_files"]} >= {"medic_config"}
+
+    request.config_path.parent.mkdir(parents=True, exist_ok=True)
+    request.config_path.write_text(plan.config_text)
+    request.medic_config_path.write_text(plan.medic_config_text)
+    runtime = load_config(request.config_path)
+    medic = load_medic_config(request.medic_config_path, runtime_config=runtime)
+    assert medic.mode == "diagnose"
+    assert medic.instance_id == "studio-a"
+
+
+def test_heal_medic_requires_two_keys_and_explicit_recoverable_checks(tmp_path):
+    primary = _public_key_file(tmp_path / "primary.pub")
+    confirm = _public_key_file(tmp_path / "confirm.pub")
+    request = _request(
+        tmp_path,
+        profile="studio",
+        medic_mode="heal",
+        medic_instance_id="studio-a",
+        medic_primary_public_key_path=primary,
+        medic_confirm_public_key_path=confirm,
+        medic_allowed_heal_checks=["postgres", "ollama"],
+    )
+    plan = build_plan(request)
+
+    assert {key["role"] for key in plan.medic_config["keys"]} == {
+        "primary",
+        "confirm",
+    }
+    assert plan.medic_config["allowed_heal_checks"] == ["postgres", "ollama"]
+
+    with pytest.raises(InstallError, match="confirm"):
+        _request(
+            tmp_path / "missing-confirm",
+            medic_mode="heal",
+            medic_instance_id="studio-a",
+            medic_primary_public_key_path=primary,
+            medic_allowed_heal_checks=["postgres"],
+        )
+    with pytest.raises(InstallError, match="not enabled/recoverable"):
+        build_plan(
+            _request(
+                tmp_path / "bad-check",
+                medic_mode="heal",
+                medic_instance_id="studio-a",
+                medic_primary_public_key_path=primary,
+                medic_confirm_public_key_path=confirm,
+                medic_allowed_heal_checks=["tunnel"],
+            )
+        )
+
+
+def test_installer_rejects_private_key_file_in_public_key_option(tmp_path):
+    private_raw, _public_raw = generate_keypair()
+    private = load_private_key(private_raw)
+    private_path = tmp_path / "must-stay-off-host.key"
+    private_path.write_text(encode_private_key(private))
+
+    with pytest.raises(InstallError, match="primary public key is invalid"):
+        _request(
+            tmp_path / "host",
+            medic_mode="diagnose",
+            medic_instance_id="studio-a",
+            medic_primary_public_key_path=private_path,
+        )
+
+
+def test_medic_artifact_is_mode_0600_and_removed_when_option_is_disabled(tmp_path):
+    primary = _public_key_file(tmp_path / "primary.pub")
+    runner = RecordingRunner()
+    enabled = _request(
+        tmp_path,
+        medic_mode="diagnose",
+        medic_instance_id="studio-a",
+        medic_primary_public_key_path=primary,
+    )
+    install(enabled, runner=runner)
+    assert enabled.medic_config_path.exists()
+    assert enabled.medic_config_path.stat().st_mode & 0o777 == 0o600
+    installed_manifest = json.loads(enabled.manifest_path.read_text())
+    assert any(
+        item["kind"] == "medic_config" for item in installed_manifest["managed_files"]
+    )
+    inbox = enabled.state_dir / "medic-queue" / "inbox"
+    inbox.mkdir(parents=True)
+    (inbox / "pending.json").write_text("{}")
+
+    disabled = _request(tmp_path)
+    install(disabled, runner=runner)
+    assert not enabled.medic_config_path.exists()
+    assert load_config(disabled.config_path).medic_config_path is None
+    assert not inbox.exists()
+    quarantined = list(
+        (enabled.state_dir / "medic-queue" / "quarantine").glob(
+            "policy-change-*/inbox/pending.json"
+        )
+    )
+    assert len(quarantined) == 1
+
+
+def test_medic_reconfiguration_stops_old_consumer_before_replacing_policy(
+    tmp_path,
+):
+    primary = _public_key_file(tmp_path / "primary.pub")
+    runner = RecordingRunner()
+    request = _request(
+        tmp_path,
+        medic_mode="diagnose",
+        medic_instance_id="studio-a",
+        medic_primary_public_key_path=primary,
+    )
+    install(request, runner=runner)
+
+    runner.calls.clear()
+    install(request, runner=runner)
+
+    commands = [call for call, _ in runner.calls]
+    assert commands[0][:2] == ("launchctl", "bootout")
+    assert commands[1][:2] == ("launchctl", "print")
+
+
+def test_runtime_recovery_binding_change_quarantines_pending_medic_task(
+    tmp_path,
+):
+    primary = _public_key_file(tmp_path / "primary.pub")
+    runner = RecordingRunner()
+    original = _request(
+        tmp_path,
+        medic_mode="diagnose",
+        medic_instance_id="studio-a",
+        medic_primary_public_key_path=primary,
+    )
+    install(original, runner=runner)
+    inbox = original.state_dir / "medic-queue" / "inbox"
+    inbox.mkdir(parents=True)
+    (inbox / "pending.json").write_text("{}")
+
+    changed = _request(
+        tmp_path,
+        docker_context="alternate-context",
+        medic_mode="diagnose",
+        medic_instance_id="studio-a",
+        medic_primary_public_key_path=primary,
+    )
+    install(changed, runner=runner)
+
+    assert not inbox.exists()
+    quarantined = list(
+        (
+            original.state_dir
+            / "medic-queue"
+            / "quarantine"
+        ).glob("policy-change-*/inbox/pending.json")
+    )
+    assert len(quarantined) == 1
+
+
+def test_policy_change_and_uninstall_refuse_to_race_active_medic_consumer(
+    tmp_path,
+):
+    primary = _public_key_file(tmp_path / "primary.pub")
+    runner = RecordingRunner()
+    request = _request(
+        tmp_path,
+        medic_mode="diagnose",
+        medic_instance_id="studio-a",
+        medic_primary_public_key_path=primary,
+    )
+    install(request, runner=runner)
+    inbox = request.state_dir / "medic-queue" / "inbox"
+    inbox.mkdir(parents=True)
+    pending = inbox / "pending.json"
+    pending.write_text("{}")
+
+    lock_path = request.state_dir / "medic-queue" / "consumer.lock"
+    lock_fd = os.open(lock_path, os.O_RDWR)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        runner.calls.clear()
+        with pytest.raises(InstallError, match="medic queue is active"):
+            install(request, runner=runner)
+        assert runner.calls == []
+        assert pending.exists()
+        assert request.manifest_path.exists()
+
+        with pytest.raises(InstallError, match="medic queue is active"):
+            uninstall(request.manifest_path, runner=runner)
+        assert runner.calls == []
+        assert pending.exists()
+        assert request.config_path.exists()
+        assert request.service_path.exists()
+        assert request.manifest_path.exists()
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+
+def test_uninstall_quarantines_pending_tasks_and_retains_audit_root(tmp_path):
+    primary = _public_key_file(tmp_path / "primary.pub")
+    runner = RecordingRunner()
+    request = _request(
+        tmp_path,
+        medic_mode="diagnose",
+        medic_instance_id="studio-a",
+        medic_primary_public_key_path=primary,
+    )
+    install(request, runner=runner)
+    inbox = request.state_dir / "medic-queue" / "inbox"
+    inbox.mkdir(parents=True)
+    (inbox / "pending.json").write_text("{}")
+
+    result = uninstall(request.manifest_path, runner=runner)
+
+    assert result["quarantined_pending"]
+    assert not inbox.exists()
+    assert (request.state_dir / "medic-queue" / "quarantine").is_dir()
+    assert not request.medic_config_path.exists()

--- a/factory/tests/test_resilience_surfaces.py
+++ b/factory/tests/test_resilience_surfaces.py
@@ -1,0 +1,688 @@
+"""Focused tests for resilience entry points outside ops.resilience."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import click
+import config
+from click.testing import CliRunner
+
+import cli as cli_module
+import setup
+from cli import cli
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "scripts" / "install.sh"
+REINSTALLER = REPO_ROOT / "scripts" / "reinstall.sh"
+DEVBRAIN_WRAPPER = REPO_ROOT / "bin" / "devbrain"
+
+
+def _prepare_setup_script(monkeypatch, tmp_path: Path) -> Path:
+    script = tmp_path / "scripts" / "install-resilience.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("#!/bin/bash\n")
+    monkeypatch.setattr(setup, "DEVBRAIN_HOME", tmp_path)
+    monkeypatch.setattr(setup.Path, "home", staticmethod(lambda: tmp_path))
+    return script
+
+
+def test_main_installer_help_exposes_profiles_and_optional_remote_checks():
+    result = subprocess.run(
+        ["bash", str(INSTALLER), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "--profile=workstation|studio" in result.stdout
+    assert "--container-runtime=RUNTIME" in result.stdout
+    assert "--with-resilience" in result.stdout
+    assert "--no-resilience" in result.stdout
+    assert "--with-heartbeat" in result.stdout
+    assert "--with-tunnel-check" in result.stdout
+    assert "--with-agent-bus-check" in result.stdout
+    assert "--with-backup-check" in result.stdout
+    assert "--backup-path=PATH" in result.stdout
+    assert "--with-medic=diagnose|heal" in result.stdout
+    assert "--medic-allow-check=CHECK" in result.stdout
+    assert "works locally without a VPS" in result.stdout
+
+
+def test_main_installer_keeps_workstation_yes_opt_in_and_studio_default():
+    source = INSTALLER.read_text()
+
+    assert 'DEPLOYMENT_PROFILE="workstation"' in source
+    assert 'elif [[ "$DEPLOYMENT_PROFILE" == "studio" ]]' in source
+    assert "elif $AUTO_YES; then" in source
+    assert "enable=false" in source
+    assert 'CONTAINER_RUNTIME="colima"' in source
+    assert 'CONTAINER_RUNTIME="docker-desktop"' in source
+    assert 'bash "$DEVBRAIN_HOME/scripts/install-resilience.sh"' in source
+    assert '--container-runtime "$CONTAINER_RUNTIME"' in source
+    assert "A Docker CLI installed for Colima is not evidence" in source
+    assert "[[ -d /Applications/Docker.app ]]" in source
+    assert 'INSTALL_TARGET_PATH="$HOME/.devbrain/install-target.json"' in source
+    assert "record_install_target" in source
+    assert "load_existing_install_target" in source
+    assert "Refusing to switch" in source
+    assert "'  \"schema_version\": 2,'" in source
+
+
+def test_main_installer_rejects_unknown_options_before_installing():
+    result = subprocess.run(
+        ["bash", str(INSTALLER), "--no-resilence"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "unknown installer option" in result.stderr
+
+
+def test_main_installer_rejects_backup_path_without_explicit_opt_in(tmp_path):
+    result = subprocess.run(
+        ["bash", str(INSTALLER), "--backup-path", str(tmp_path / "backups")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "--backup-path requires --with-backup-check" in result.stderr
+
+
+def test_main_installer_rerun_preserves_recorded_profile_and_runtime(tmp_path):
+    source = INSTALLER.read_text()
+    prefix = source.split(
+        "# ─── Formatting ─────────────────────────────────────────────────",
+        1,
+    )[0]
+    resolver = tmp_path / "resolve-installer-target.sh"
+    resolver.write_text(
+        prefix
+        + '\nprintf "%s|%s|%s\\n" "$DEPLOYMENT_PROFILE" '
+        + '"$CONTAINER_RUNTIME" "$DOCKER_CONTEXT_NAME"\n'
+    )
+    target = tmp_path / ".devbrain" / "install-target.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "generated_by": "devbrain-installer",
+                "profile": "studio",
+                "container_runtime": "colima",
+                "docker_context": "colima-nooma",
+            }
+        )
+    )
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "DEVBRAIN_HOME": str(tmp_path / "devbrain"),
+    }
+
+    rerun = subprocess.run(
+        ["bash", str(resolver)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    switch = subprocess.run(
+        [
+            "bash",
+            str(resolver),
+            "--container-runtime",
+            "docker-desktop",
+        ],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert rerun.returncode == 0, rerun.stderr
+    assert rerun.stdout.strip() == "studio|colima|colima-nooma"
+    assert switch.returncode == 2
+    assert "Refusing to switch" in switch.stderr
+
+
+def test_setup_resilience_local_only_uses_argument_vector(monkeypatch, tmp_path):
+    script = _prepare_setup_script(monkeypatch, tmp_path)
+    confirms = iter([True, False, False, False, False, False])
+    prompts = iter(["workstation", "docker-desktop"])
+    captured = {}
+
+    monkeypatch.setattr(setup, "_confirm", lambda *args, **kwargs: next(confirms))
+    monkeypatch.setattr(setup, "_prompt", lambda *args, **kwargs: next(prompts))
+
+    def fake_run(args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(setup.subprocess, "run", fake_run)
+
+    setup.setup_resilience()
+
+    assert captured["args"] == [
+        "bash",
+        str(script),
+        "--profile",
+        "workstation",
+        "--container-runtime",
+        "docker-desktop",
+    ]
+    assert captured["kwargs"] == {"check": False}
+
+
+def test_setup_resilience_passes_only_selected_remote_values(monkeypatch, tmp_path):
+    script = _prepare_setup_script(monkeypatch, tmp_path)
+    confirms = iter([True, True, True, True, False, False])
+    prompts = iter(
+        [
+            "studio",
+            "colima",
+            "https://heartbeat.example.invalid/ping",
+            "MY_HEARTBEAT_TOKEN",
+            "com.example.reverse-tunnel",
+            "http://127.0.0.1:18900/healthz",
+        ]
+    )
+    captured = {}
+
+    monkeypatch.setattr(setup, "_confirm", lambda *args, **kwargs: next(confirms))
+    monkeypatch.setattr(setup, "_prompt", lambda *args, **kwargs: next(prompts))
+
+    def fake_run(args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(setup.subprocess, "run", fake_run)
+
+    setup.setup_resilience()
+
+    args = captured["args"]
+    assert args[:6] == [
+        "bash",
+        str(script),
+        "--profile",
+        "studio",
+        "--container-runtime",
+        "colima",
+    ]
+    assert args[args.index("--heartbeat-url") + 1] == (
+        "https://heartbeat.example.invalid/ping"
+    )
+    assert args[args.index("--heartbeat-secret-env") + 1] == ("MY_HEARTBEAT_TOKEN")
+    assert args[args.index("--tunnel-label") + 1] == ("com.example.reverse-tunnel")
+    assert args[args.index("--agent-bus-url") + 1] == ("http://127.0.0.1:18900/healthz")
+    assert captured["kwargs"] == {"check": False}
+
+
+def test_setup_resilience_surfaces_installer_failure(monkeypatch, tmp_path):
+    _prepare_setup_script(monkeypatch, tmp_path)
+    confirms = iter([True, False, False, False, False, False])
+    prompts = iter(["workstation", "docker-desktop"])
+    monkeypatch.setattr(setup, "_confirm", lambda *args, **kwargs: next(confirms))
+    monkeypatch.setattr(setup, "_prompt", lambda *args, **kwargs: next(prompts))
+    monkeypatch.setattr(
+        setup.subprocess,
+        "run",
+        lambda args, **kwargs: subprocess.CompletedProcess(args, 17),
+    )
+
+    try:
+        setup.setup_resilience()
+    except click.ClickException as exc:
+        assert "status 17" in str(exc)
+    else:
+        raise AssertionError("installer failure should be surfaced")
+
+
+def test_setup_cli_help_and_dispatch_include_resilience(monkeypatch):
+    runner = CliRunner()
+    help_result = runner.invoke(cli, ["setup", "--help"])
+    assert help_result.exit_code == 0
+    assert "setup resilience" in help_result.output
+
+    calls = []
+    monkeypatch.setattr(setup, "run_setup", lambda section=None: calls.append(section))
+    result = runner.invoke(cli, ["setup", "resilience"])
+    assert result.exit_code == 0
+    assert calls == ["resilience"]
+    assert any(key == "resilience" for _, key, _ in setup.MENU_SECTIONS)
+
+    ops_help = runner.invoke(cli, ["ops", "--help"])
+    assert ops_help.exit_code == 0
+    assert "run-once" in ops_help.output
+    assert "medic" in ops_help.output
+    medic_help = runner.invoke(cli, ["ops", "medic", "--help"])
+    assert medic_help.exit_code == 0
+    assert "keygen" in medic_help.output
+    assert "task" in medic_help.output
+
+
+def test_full_setup_invokes_resilience_before_verification(monkeypatch):
+    calls = []
+    monkeypatch.setattr(setup, "setup_github", lambda: calls.append("github"))
+    monkeypatch.setattr(setup, "setup_ai_cli_logins", lambda: calls.append("ai-clis"))
+    monkeypatch.setattr(
+        setup,
+        "setup_identity",
+        lambda: calls.append("identity") or "alice",
+    )
+    monkeypatch.setattr(setup, "setup_projects", lambda: calls.append("projects"))
+    monkeypatch.setattr(
+        setup,
+        "setup_notifications",
+        lambda dev_id: calls.append(f"notifications:{dev_id}"),
+    )
+    monkeypatch.setattr(setup, "setup_mcp_client", lambda: calls.append("mcp"))
+    monkeypatch.setattr(setup, "setup_resilience", lambda: calls.append("resilience"))
+    monkeypatch.setattr(setup, "setup_pkrelay", lambda: calls.append("pkrelay"))
+    monkeypatch.setattr(setup, "run_verification", lambda: calls.append("verify"))
+    monkeypatch.setattr(setup, "print_post_actions", lambda: calls.append("actions"))
+
+    setup._run_full_setup()
+
+    assert "resilience" in calls
+    assert calls.index("resilience") < calls.index("verify")
+
+
+def test_setup_resilience_adds_explicit_backup_path(monkeypatch, tmp_path):
+    script = _prepare_setup_script(monkeypatch, tmp_path)
+    backup_path = tmp_path / "backup-output"
+    confirms = iter([True, False, False, False, True, False])
+    prompts = iter(["studio", "colima", str(backup_path)])
+    captured = {}
+    monkeypatch.setattr(
+        setup, "_confirm", lambda *args, **kwargs: next(confirms)
+    )
+    monkeypatch.setattr(
+        setup, "_prompt", lambda *args, **kwargs: next(prompts)
+    )
+    monkeypatch.setattr(
+        setup.subprocess,
+        "run",
+        lambda args, **kwargs: (
+            captured.update({"args": args, "kwargs": kwargs})
+            or subprocess.CompletedProcess(args, 0)
+        ),
+    )
+
+    setup.setup_resilience()
+
+    args = captured["args"]
+    assert args[:6] == [
+        "bash",
+        str(script),
+        "--profile",
+        "studio",
+        "--container-runtime",
+        "colima",
+    ]
+    assert args[args.index("--backup-path") + 1] == str(backup_path)
+    assert "--with-backup-check" in args
+
+
+def test_ops_status_and_run_once_forward_exact_config_and_exit_code(
+    monkeypatch, tmp_path
+):
+    calls = []
+
+    def fake_main(argv):
+        calls.append(argv)
+        return 0 if argv[-1] == "status" else 1
+
+    monkeypatch.setattr(cli_module, "_load_resilience_cli", lambda: fake_main)
+    config = tmp_path / "config.json"
+    runner = CliRunner()
+
+    status = runner.invoke(
+        cli,
+        ["ops", "status", "--config", str(config)],
+    )
+    run_once = runner.invoke(
+        cli,
+        ["ops", "run-once", "--config", str(config)],
+    )
+
+    assert status.exit_code == 0
+    assert run_once.exit_code == 1
+    assert calls == [
+        ["--config", str(config.resolve()), "status"],
+        ["--config", str(config.resolve()), "run-once"],
+    ]
+
+
+def test_setup_resilience_adds_diagnose_only_medic_without_private_key(
+    monkeypatch, tmp_path
+):
+    _prepare_setup_script(monkeypatch, tmp_path)
+    confirms = iter([True, False, False, False, False, True])
+    prompts = iter(
+        [
+            "studio",
+            "colima",
+            "diagnose",
+            "/operator-share/primary.pub",
+            "nooma-studio",
+        ]
+    )
+    captured = {}
+    monkeypatch.setattr(setup, "_confirm", lambda *args, **kwargs: next(confirms))
+    monkeypatch.setattr(setup, "_prompt", lambda *args, **kwargs: next(prompts))
+    monkeypatch.setattr(
+        setup.subprocess,
+        "run",
+        lambda args, **kwargs: (
+            captured.update({"args": args, "kwargs": kwargs})
+            or subprocess.CompletedProcess(args, 0)
+        ),
+    )
+
+    setup.setup_resilience()
+
+    args = captured["args"]
+    assert args[args.index("--with-medic") + 1] == "diagnose"
+    assert args[args.index("--medic-primary-public-key") + 1] == (
+        "/operator-share/primary.pub"
+    )
+    assert args[args.index("--medic-instance-id") + 1] == "nooma-studio"
+    assert "--medic-confirm-public-key" not in args
+    assert "--sign" not in args
+    assert not any(value.endswith(".key") for value in args)
+
+
+def test_reinstall_uninstalls_from_manifest_before_repo_removal():
+    source = REINSTALLER.read_text()
+    uninstall = 'bash "$DEVBRAIN_HOME/scripts/install-resilience.sh" --uninstall --yes'
+    remove_repo = 'rm -rf "$DEVBRAIN_HOME"'
+
+    assert (
+        'RESILIENCE_MANIFEST="$HOME/.devbrain/resilience/install-manifest.json"'
+        in source
+    )
+    assert uninstall in source
+    assert source.index(uninstall) < source.index(remove_repo)
+    assert "from ops.resilience.install import _load_manifest" in source
+    assert "devbrain_devbrain-wal-archive" in source
+    assert 'INSTALL_TARGET_PATH="$HOME/.devbrain/install-target.json"' in source
+    assert 'docker --context "$TARGET_DOCKER_CONTEXT"' in source
+    assert "--container-runtime=RUNTIME --docker-context=CONTEXT" in source
+    assert "resilience and install target metadata disagree" in source
+    assert "Explicit container target disagrees with recorded metadata" in source
+    assert "Could not verify the post-cleanup container inventory" in source
+    assert "Could not remove the confirmed devbrain-db container" in source
+    assert "label=com.docker.compose.volume=" in source
+    assert ".Mounts" in source
+    assert "compose down" not in source
+    assert source.index("_capture_container_target") < source.index(
+        uninstall
+    )
+
+
+def test_reinstall_help_exposes_safe_target_override_and_rejects_unknown_flags():
+    help_result = subprocess.run(
+        ["bash", str(REINSTALLER), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    unknown_result = subprocess.run(
+        ["bash", str(REINSTALLER), "--unknown"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert help_result.returncode == 0
+    assert "--container-runtime=RUNTIME" in help_result.stdout
+    assert "--docker-context=CONTEXT" in help_result.stdout
+    assert unknown_result.returncode == 2
+    assert "unknown reinstall option" in unknown_result.stderr
+
+
+def test_upgrade_refreshes_requirements_and_restarts_installed_resilience(
+    monkeypatch, tmp_path
+):
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("cryptography>=42\n")
+    venv_python = tmp_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("")
+    installer = tmp_path / "scripts" / "install-resilience.sh"
+    installer.parent.mkdir(parents=True)
+    installer.write_text("#!/bin/bash\n")
+    manifest = (
+        tmp_path / ".devbrain" / "resilience" / "install-manifest.json"
+    )
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text("{}")
+
+    calls = []
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(config, "DEVBRAIN_HOME", tmp_path)
+    monkeypatch.setattr(
+        subprocess,
+        "call",
+        lambda args, **kwargs: calls.append((args, kwargs)) or 0,
+    )
+    monkeypatch.setattr(
+        cli_module.devdoctor,
+        "callback",
+        lambda as_json, fix: None,
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "upgrade",
+            "--yes",
+            "--no-pull",
+            "--no-rebuild",
+            "--no-rotate",
+            "--no-tier",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        (
+            [
+                str(venv_python),
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "-q",
+                "-r",
+                str(requirements),
+            ],
+            {"cwd": str(tmp_path)},
+        ),
+        (
+            ["bash", str(installer), "--restart"],
+            {"cwd": str(tmp_path)},
+        ),
+    ]
+
+
+def test_recorded_db_context_resolution_is_exact(
+    monkeypatch,
+    tmp_path,
+):
+    target = tmp_path / ".devbrain" / "install-target.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "generated_by": "devbrain-installer",
+                "profile": "studio",
+                "container_runtime": "colima",
+                "docker_context": "colima",
+            }
+        )
+    )
+    calls = []
+    container_id = "a" * 64
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, f"{container_id}\n", "")
+
+    monkeypatch.setattr(cli_module.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(cli_module.subprocess, "run", fake_run)
+
+    assert cli_module._resolve_devbrain_docker_context() == "colima"
+    assert calls == [
+        [
+            "docker",
+            "--context",
+            "colima",
+            "container",
+            "ls",
+            "--all",
+            "--no-trunc",
+            "--filter",
+            "name=^/devbrain-db$",
+            "--format",
+            "{{.ID}}",
+        ]
+    ]
+
+
+def test_legacy_db_context_resolution_fails_if_any_context_is_unprobeable(
+    monkeypatch,
+    tmp_path,
+):
+    def fake_run(args, **kwargs):
+        if args[:4] == ["docker", "context", "ls", "--format"]:
+            return subprocess.CompletedProcess(args, 0, "default\nold-remote\n", "")
+        if args[2] == "default":
+            return subprocess.CompletedProcess(args, 0, f"{'a' * 64}\n", "")
+        return subprocess.CompletedProcess(args, 1, "", "connection failed")
+
+    monkeypatch.setattr(cli_module.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(cli_module.subprocess, "run", fake_run)
+
+    try:
+        cli_module._resolve_devbrain_docker_context()
+    except click.ClickException as exc:
+        assert "old-remote" in str(exc)
+        assert "unavailable" in str(exc)
+    else:
+        raise AssertionError("an unprobeable legacy context must fail closed")
+
+
+def test_db_context_resolution_rejects_nonregular_metadata(
+    monkeypatch,
+    tmp_path,
+):
+    target = tmp_path / ".devbrain" / "install-target.json"
+    target.mkdir(parents=True)
+    monkeypatch.setattr(cli_module.Path, "home", staticmethod(lambda: tmp_path))
+
+    try:
+        cli_module._resolve_devbrain_docker_context()
+    except click.ClickException as exc:
+        assert "not a regular file" in str(exc)
+    else:
+        raise AssertionError("non-regular target metadata must fail closed")
+
+
+def test_legacy_db_context_resolution_rejects_ambiguous_matches(
+    monkeypatch,
+    tmp_path,
+):
+    def fake_run(args, **kwargs):
+        if args[:4] == ["docker", "context", "ls", "--format"]:
+            return subprocess.CompletedProcess(args, 0, "default\ncolima\n", "")
+        container_id = "a" * 64 if args[2] == "default" else "b" * 64
+        return subprocess.CompletedProcess(args, 0, f"{container_id}\n", "")
+
+    monkeypatch.setattr(cli_module.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(cli_module.subprocess, "run", fake_run)
+
+    try:
+        cli_module._resolve_devbrain_docker_context()
+    except click.ClickException as exc:
+        assert "found in 2 distinct Docker backends" in str(exc)
+    else:
+        raise AssertionError("ambiguous legacy targets must fail closed")
+
+
+def test_legacy_db_context_resolution_accepts_aliases_to_same_backend(
+    monkeypatch,
+    tmp_path,
+):
+    container_id = "c" * 64
+
+    def fake_run(args, **kwargs):
+        if args[:4] == ["docker", "context", "ls", "--format"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                "default\ndesktop-linux\n",
+                "",
+            )
+        return subprocess.CompletedProcess(args, 0, f"{container_id}\n", "")
+
+    monkeypatch.setattr(cli_module.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(cli_module.subprocess, "run", fake_run)
+
+    assert cli_module._resolve_devbrain_docker_context() == "desktop-linux"
+
+
+def test_legacy_db_context_resolution_probes_plus_named_context(
+    monkeypatch,
+    tmp_path,
+):
+    container_id = "d" * 64
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        if args[:4] == ["docker", "context", "ls", "--format"]:
+            return subprocess.CompletedProcess(args, 0, "nooma+studio\n", "")
+        return subprocess.CompletedProcess(args, 0, f"{container_id}\n", "")
+
+    monkeypatch.setattr(cli_module.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(cli_module.subprocess, "run", fake_run)
+
+    assert cli_module._resolve_devbrain_docker_context() == "nooma+studio"
+    assert any(call[2] == "nooma+studio" for call in calls if len(call) > 2)
+
+
+def test_password_recreation_source_pins_context_before_password_mutation():
+    source = Path(cli_module.__file__).read_text()
+    function = source.split("def rotate_db_password(", 1)[1]
+
+    resolve = "_resolve_devbrain_docker_context() if recreate else None"
+    mutate = "result = rotate_with_dependents("
+    docker = 'docker = ["docker", "--context", docker_context]'
+    assert function.index(resolve) < function.index(mutate)
+    assert docker in function
+    assert '[*docker, "compose", "down"]' in function
+    assert '[*docker, "compose", "up", "-d", "devbrain-db"]' in function
+
+
+def test_wrapper_updates_before_loading_upgrade_python():
+    source = DEVBRAIN_WRAPPER.read_text()
+
+    assert '"${1:-}" =~ ^(setup|upgrade)$' in source
+    assert '"$_arg" == "--no-pull"' in source
+    assert source.index("_auto_update") < source.index(
+        'exec "$DEVBRAIN_DIR/.venv/bin/python"'
+    )

--- a/ops/resilience/__init__.py
+++ b/ops/resilience/__init__.py
@@ -1,0 +1,37 @@
+"""Provider-neutral local resilience monitor for DevBrain hosts."""
+
+from .core import (
+    CHECK_TYPES,
+    RECOVERY_TYPES,
+    ActionResult,
+    CheckResult,
+    ConfigError,
+    CycleResult,
+    Monitor,
+    MonitorConfig,
+    WebhookResult,
+    atomic_write_json,
+    execute_recovery,
+    load_config,
+    read_heartbeat,
+    run_check,
+    send_webhook,
+)
+
+__all__ = [
+    "CHECK_TYPES",
+    "RECOVERY_TYPES",
+    "ActionResult",
+    "CheckResult",
+    "ConfigError",
+    "CycleResult",
+    "Monitor",
+    "MonitorConfig",
+    "WebhookResult",
+    "atomic_write_json",
+    "execute_recovery",
+    "load_config",
+    "read_heartbeat",
+    "run_check",
+    "send_webhook",
+]

--- a/ops/resilience/__main__.py
+++ b/ops/resilience/__main__.py
@@ -1,0 +1,172 @@
+"""Command-line entrypoint for ``python -m ops.resilience``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+from .core import ConfigError, Monitor, load_config, read_heartbeat
+
+logger = logging.getLogger("devbrain.resilience")
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="DevBrain local resilience monitor")
+    parser.add_argument("--config", required=True, help="absolute path to JSON config")
+    parser.add_argument("--verbose", action="store_true")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    subcommands.add_parser("run-once", help="run one check/recovery cycle")
+    subcommands.add_parser("watch", help="run check/recovery cycles continuously")
+    subcommands.add_parser("status", help="print the last local heartbeat")
+    return parser
+
+
+def _print(payload: object) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def load_dotenv_no_override(path: Path) -> None:
+    """Load simple KEY=VALUE entries without shell evaluation or overrides."""
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.warning("cannot read environment file %s: %s", path, exc)
+        return
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].lstrip()
+        key, separator, value = line.partition("=")
+        key = key.strip()
+        if (
+            not separator
+            or not key
+            or not key.replace("_", "a").isalnum()
+            or key[0].isdigit()
+            or key in os.environ
+        ):
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        os.environ[key] = value
+
+
+def watch_forever(
+    monitor,
+    medic,
+    *,
+    monotonic=time.monotonic,
+    sleep=time.sleep,
+    max_wakeups: int | None = None,
+) -> None:
+    """Run health and medic schedules independently in one bounded process."""
+
+    now = monotonic()
+    next_monitor = now
+    next_medic = now if medic is not None else None
+    wakeups = 0
+    while True:
+        now = monotonic()
+        if now >= next_monitor:
+            try:
+                cycle = monitor.run_cycle()
+                logger.info(
+                    "cycle healthy=%s recoveries=%d webhook=%s",
+                    cycle.heartbeat["healthy"],
+                    len(cycle.heartbeat["recoveries"]),
+                    cycle.webhook.detail,
+                )
+            except Exception:
+                logger.exception("resilience health cycle failed")
+            next_monitor = monotonic() + monitor.config.interval_seconds
+
+        if medic is not None and next_medic is not None and monotonic() >= next_medic:
+            try:
+                medic_results = medic.process_once()
+                if medic_results:
+                    logger.info("medic tasks processed=%d", len(medic_results))
+            except Exception:
+                logger.exception("resilience medic cycle failed")
+            next_medic = monotonic() + medic.medic_config.poll_interval_seconds
+
+        wakeups += 1
+        if max_wakeups is not None and wakeups >= max_wakeups:
+            return
+        deadlines = [next_monitor]
+        if next_medic is not None:
+            deadlines.append(next_medic)
+        try:
+            sleep(max(0.0, min(deadlines) - monotonic()))
+        except KeyboardInterrupt:
+            return
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    # launchd/systemd intentionally receive no secret values in their service
+    # definitions. Load the repository's mode-0600 .env at runtime, matching
+    # bin/devbrain semantics while preserving caller-provided overrides.
+    load_dotenv_no_override(_REPO_ROOT / ".env")
+    try:
+        config = load_config(args.config)
+    except ConfigError as exc:
+        logger.error("%s", exc)
+        return 2
+
+    if args.command == "status":
+        try:
+            heartbeat = read_heartbeat(config)
+        except RuntimeError as exc:
+            logger.error("%s", exc)
+            return 2
+        _print(heartbeat)
+        return 0 if heartbeat.get("healthy") is True else 1
+
+    monitor = Monitor(config)
+    medic = None
+    if config.medic_config_path is not None:
+        try:
+            from .medic_service import MedicService, load_medic_config
+
+            medic = MedicService(
+                config,
+                load_medic_config(
+                    config.medic_config_path,
+                    runtime_config=config,
+                ),
+                monitor=monitor,
+            )
+        except (ConfigError, ValueError) as exc:
+            logger.error("medic configuration is invalid: %s", exc)
+            return 2
+    if args.command == "run-once":
+        cycle = monitor.run_cycle()
+        medic_results = medic.process_once() if medic is not None else []
+        output = dict(cycle.heartbeat)
+        output["webhook"] = cycle.webhook.as_dict()
+        output["medic_tasks_processed"] = len(medic_results)
+        _print(output)
+        return 0 if cycle.heartbeat["healthy"] else 1
+
+    watch_forever(monitor, medic)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/resilience/core.py
+++ b/ops/resilience/core.py
@@ -1,0 +1,1366 @@
+"""Local health checks and deterministic recovery for a DevBrain host.
+
+The module deliberately exposes no generic command or shell action. Every
+subprocess invocation is selected by a typed check or typed recovery action,
+uses an argv list, and runs without a shell.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+logger = logging.getLogger("devbrain.resilience")
+
+CHECK_TYPES = frozenset(
+    {
+        "docker_runtime",
+        "docker_container",
+        "http",
+        "tcp",
+        "launchd_label",
+        "systemd_user_unit",
+        "disk",
+        "file_freshness",
+    }
+)
+RECOVERY_TYPES = frozenset(
+    {
+        "runtime_start",
+        "docker_compose_up",
+        "launchd_kickstart",
+        "systemd_restart",
+        "homebrew_service_start",
+    }
+)
+
+_EXECUTABLE_NAMES = frozenset(
+    {"brew", "colima", "docker", "launchctl", "open", "systemctl"}
+)
+_EXECUTABLE_CANDIDATES: dict[str, tuple[str, ...]] = {
+    "brew": ("/opt/homebrew/bin/brew", "/usr/local/bin/brew"),
+    "colima": ("/opt/homebrew/bin/colima", "/usr/local/bin/colima"),
+    "docker": ("/usr/local/bin/docker", "/opt/homebrew/bin/docker", "/usr/bin/docker"),
+    "launchctl": ("/bin/launchctl",),
+    "open": ("/usr/bin/open",),
+    "systemctl": ("/usr/bin/systemctl", "/bin/systemctl"),
+}
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.@+-]{0,127}$")
+_SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+_LAUNCHD_DOMAIN = re.compile(r"^(?:system|(?:gui|user)/[0-9]+)$")
+_FORBIDDEN_CONFIG_KEYS = frozenset({"argv", "cmd", "command", "shell"})
+_STATE_VERSION = 1
+_HEARTBEAT_VERSION = 1
+
+
+class ConfigError(ValueError):
+    """Raised when a resilience JSON config is invalid or unsafe."""
+
+
+@dataclass(frozen=True)
+class ProcessResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    check_id: str
+    check_type: str
+    ok: bool
+    detail: str
+    duration_ms: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.check_type,
+            "ok": self.ok,
+            "detail": self.detail,
+            "duration_ms": self.duration_ms,
+        }
+
+
+@dataclass(frozen=True)
+class ActionResult:
+    check_id: str
+    action_type: str
+    ok: bool
+    detail: str
+    duration_ms: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "check_id": self.check_id,
+            "type": self.action_type,
+            "ok": self.ok,
+            "detail": self.detail,
+            "duration_ms": self.duration_ms,
+        }
+
+
+@dataclass(frozen=True)
+class WebhookResult:
+    configured: bool
+    delivered: bool
+    detail: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "configured": self.configured,
+            "delivered": self.delivered,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class CycleResult:
+    heartbeat: dict[str, Any]
+    webhook: WebhookResult
+
+
+@dataclass(frozen=True)
+class MonitorConfig:
+    schema_version: int
+    profile: str
+    source_path: Path
+    state_path: Path
+    heartbeat_path: Path
+    medic_config_path: Path | None
+    interval_seconds: float
+    failure_threshold: int
+    cooldown_seconds: float
+    max_attempts: int
+    host: str
+    checks: tuple[dict[str, Any], ...]
+    executables: Mapping[str, Path]
+    heartbeat: Mapping[str, Any] | None
+
+    def executable(self, name: str) -> str:
+        if name not in _EXECUTABLE_NAMES:
+            raise RuntimeError(f"unsupported executable: {name}")
+        configured = self.executables.get(name)
+        if configured is not None:
+            return str(configured)
+        found = shutil.which(name)
+        if found:
+            return str(Path(found).resolve())
+        for candidate in _EXECUTABLE_CANDIDATES[name]:
+            if Path(candidate).is_file():
+                return candidate
+        raise RuntimeError(
+            f"{name} executable not found; set executables.{name} to an absolute path"
+        )
+
+
+ProcessRunner = Callable[[Sequence[str], float, Path | None], ProcessResult]
+CheckExecutor = Callable[[MonitorConfig, Mapping[str, Any]], CheckResult]
+ActionExecutor = Callable[
+    [MonitorConfig, Mapping[str, Any], Mapping[str, Any]], ActionResult
+]
+WebhookSender = Callable[[MonitorConfig, Mapping[str, Any]], WebhookResult]
+
+
+def _timestamp(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, UTC).isoformat().replace("+00:00", "Z")
+
+
+def _trim(value: str, limit: int = 500) -> str:
+    compact = " ".join(value.strip().split())
+    return compact[:limit]
+
+
+def _run_process(
+    argv: Sequence[str], timeout_seconds: float, cwd: Path | None = None
+) -> ProcessResult:
+    completed = subprocess.run(
+        list(argv),
+        cwd=str(cwd) if cwd is not None else None,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+        shell=False,
+    )
+    return ProcessResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def _require_mapping(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ConfigError(f"{field} must be a JSON object")
+    return dict(value)
+
+
+def _require_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _number(
+    value: Any,
+    field: str,
+    *,
+    minimum: float,
+    allow_integer_only: bool = False,
+) -> float | int:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ConfigError(f"{field} must be a number")
+    if allow_integer_only and not isinstance(value, int):
+        raise ConfigError(f"{field} must be an integer")
+    if value < minimum:
+        raise ConfigError(f"{field} must be >= {minimum}")
+    return value
+
+
+def _absolute_path(value: Any, field: str) -> Path:
+    raw = _require_string(value, field)
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        raise ConfigError(f"{field} must be an absolute path")
+    return path.resolve(strict=False)
+
+
+def _reject_forbidden_keys(value: Any, field: str = "config") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in _FORBIDDEN_CONFIG_KEYS:
+                raise ConfigError(
+                    f"{field}.{key} is forbidden; only typed recovery actions are supported"
+                )
+            _reject_forbidden_keys(child, f"{field}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_forbidden_keys(child, f"{field}[{index}]")
+
+
+def _check_unknown_keys(
+    value: Mapping[str, Any], allowed: set[str], field: str
+) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ConfigError(f"{field} has unknown keys: {', '.join(unknown)}")
+
+
+def _safe_name(value: Any, field: str) -> str:
+    name = _require_string(value, field)
+    if not _SAFE_NAME.fullmatch(name):
+        raise ConfigError(f"{field} contains unsupported characters")
+    return name
+
+
+def _launchd_domain(value: Any, field: str) -> str:
+    domain = _require_string(value, field)
+    if not _LAUNCHD_DOMAIN.fullmatch(domain):
+        raise ConfigError(f"{field} must be system, gui/<uid>, or user/<uid>")
+    return domain
+
+
+def _timeout(value: Any, field: str, default: float = 10.0) -> float:
+    return float(_number(default if value is None else value, field, minimum=0.1))
+
+
+def _normalize_action(raw: Any, field: str, check: Mapping[str, Any]) -> dict[str, Any]:
+    action = _require_mapping(raw, field)
+    action_type = _require_string(action.get("type"), f"{field}.type")
+    if action_type not in RECOVERY_TYPES:
+        raise ConfigError(
+            f"{field}.type must be one of: {', '.join(sorted(RECOVERY_TYPES))}"
+        )
+    allowed = {"type", "timeout_seconds"}
+    normalized: dict[str, Any] = {
+        "type": action_type,
+        "timeout_seconds": _timeout(
+            action.get("timeout_seconds"), f"{field}.timeout_seconds", 60.0
+        ),
+    }
+    if action_type == "runtime_start":
+        allowed.add("runtime")
+        runtime = _require_string(action.get("runtime"), f"{field}.runtime")
+        if runtime not in {"colima", "docker_desktop", "orbstack"}:
+            raise ConfigError(
+                f"{field}.runtime must be colima, docker_desktop, or orbstack"
+            )
+        normalized["runtime"] = runtime
+    elif action_type == "docker_compose_up":
+        allowed.update({"context", "project_dir", "services"})
+        if action.get("context") is not None or check.get("context") is not None:
+            normalized["context"] = _safe_name(
+                action.get("context", check.get("context")),
+                f"{field}.context",
+            )
+        normalized["project_dir"] = str(
+            _absolute_path(action.get("project_dir"), f"{field}.project_dir")
+        )
+        services = action.get("services", [])
+        if not isinstance(services, list):
+            raise ConfigError(f"{field}.services must be a JSON array")
+        normalized["services"] = [
+            _safe_name(service, f"{field}.services[{index}]")
+            for index, service in enumerate(services)
+        ]
+    elif action_type == "launchd_kickstart":
+        allowed.update({"label", "domain"})
+        normalized["label"] = _safe_name(
+            action.get("label", check.get("label")), f"{field}.label"
+        )
+        normalized["domain"] = _launchd_domain(
+            action.get("domain", check.get("domain", f"gui/{os.getuid()}")),
+            f"{field}.domain",
+        )
+    elif action_type == "systemd_restart":
+        allowed.add("unit")
+        normalized["unit"] = _safe_name(
+            action.get("unit", check.get("unit")), f"{field}.unit"
+        )
+    elif action_type == "homebrew_service_start":
+        allowed.add("service")
+        normalized["service"] = _safe_name(action.get("service"), f"{field}.service")
+    _check_unknown_keys(action, allowed, field)
+    return normalized
+
+
+def _normalize_check(raw: Any, index: int) -> dict[str, Any]:
+    field = f"checks[{index}]"
+    check = _require_mapping(raw, field)
+    check_id = _require_string(check.get("id"), f"{field}.id")
+    if not _SAFE_ID.fullmatch(check_id):
+        raise ConfigError(f"{field}.id contains unsupported characters")
+    check_type = _require_string(check.get("type"), f"{field}.type")
+    if check_type not in CHECK_TYPES:
+        raise ConfigError(
+            f"{field}.type must be one of: {', '.join(sorted(CHECK_TYPES))}"
+        )
+    allowed = {"id", "type", "enabled", "required", "timeout_seconds", "settings"}
+    enabled = check.get("enabled", True)
+    required = check.get("required", True)
+    if not isinstance(enabled, bool):
+        raise ConfigError(f"{field}.enabled must be boolean")
+    if not isinstance(required, bool):
+        raise ConfigError(f"{field}.required must be boolean")
+    settings = _require_mapping(check.get("settings", {}), f"{field}.settings")
+    settings_field = f"{field}.settings"
+    settings_allowed = {
+        "cooldown_seconds",
+        "failure_threshold",
+        "max_attempts",
+        "recovery",
+    }
+    normalized: dict[str, Any] = {
+        "id": check_id,
+        "type": check_type,
+        "enabled": enabled,
+        "required": required,
+        "timeout_seconds": _timeout(
+            check.get("timeout_seconds"), f"{field}.timeout_seconds"
+        ),
+        "settings": {},
+    }
+    normalized_settings = normalized["settings"]
+    if "failure_threshold" in settings:
+        normalized_settings["failure_threshold"] = int(
+            _number(
+                settings["failure_threshold"],
+                f"{settings_field}.failure_threshold",
+                minimum=1,
+                allow_integer_only=True,
+            )
+        )
+    if "cooldown_seconds" in settings:
+        normalized_settings["cooldown_seconds"] = float(
+            _number(
+                settings["cooldown_seconds"],
+                f"{settings_field}.cooldown_seconds",
+                minimum=0,
+            )
+        )
+    if "max_attempts" in settings:
+        normalized_settings["max_attempts"] = int(
+            _number(
+                settings["max_attempts"],
+                f"{settings_field}.max_attempts",
+                minimum=0,
+                allow_integer_only=True,
+            )
+        )
+
+    if check_type == "docker_runtime":
+        settings_allowed.add("context")
+        normalized_settings["context"] = _safe_name(
+            settings.get("context", "default"),
+            f"{settings_field}.context",
+        )
+    elif check_type == "docker_container":
+        settings_allowed.update({"container", "context", "require_healthcheck"})
+        normalized_settings["context"] = _safe_name(
+            settings.get("context", "default"),
+            f"{settings_field}.context",
+        )
+        normalized_settings["container"] = _safe_name(
+            settings.get("container"), f"{settings_field}.container"
+        )
+        require_healthcheck = settings.get("require_healthcheck", False)
+        if not isinstance(require_healthcheck, bool):
+            raise ConfigError(f"{settings_field}.require_healthcheck must be boolean")
+        normalized_settings["require_healthcheck"] = require_healthcheck
+    elif check_type == "http":
+        settings_allowed.update({"url", "method", "status_min", "status_max"})
+        url = _require_string(settings.get("url"), f"{settings_field}.url")
+        parsed = urllib.parse.urlsplit(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            raise ConfigError(f"{settings_field}.url must be an http or https URL")
+        method = _require_string(
+            settings.get("method", "GET"), f"{settings_field}.method"
+        ).upper()
+        if method not in {"GET", "HEAD"}:
+            raise ConfigError(f"{settings_field}.method must be GET or HEAD")
+        status_min = int(
+            _number(
+                settings.get("status_min", 200),
+                f"{settings_field}.status_min",
+                minimum=100,
+                allow_integer_only=True,
+            )
+        )
+        status_max = int(
+            _number(
+                settings.get("status_max", 399),
+                f"{settings_field}.status_max",
+                minimum=status_min,
+                allow_integer_only=True,
+            )
+        )
+        if status_max > 599:
+            raise ConfigError(f"{settings_field}.status_max must be <= 599")
+        normalized_settings.update(
+            {
+                "url": url,
+                "method": method,
+                "status_min": status_min,
+                "status_max": status_max,
+            }
+        )
+    elif check_type == "tcp":
+        settings_allowed.update({"host", "port"})
+        normalized_settings["host"] = _require_string(
+            settings.get("host"), f"{settings_field}.host"
+        )
+        port = int(
+            _number(
+                settings.get("port"),
+                f"{settings_field}.port",
+                minimum=1,
+                allow_integer_only=True,
+            )
+        )
+        if port > 65535:
+            raise ConfigError(f"{settings_field}.port must be <= 65535")
+        normalized_settings["port"] = port
+    elif check_type == "launchd_label":
+        settings_allowed.update({"label", "domain", "require_running"})
+        normalized_settings["label"] = _safe_name(
+            settings.get("label"), f"{settings_field}.label"
+        )
+        normalized_settings["domain"] = _launchd_domain(
+            settings.get("domain", f"gui/{os.getuid()}"),
+            f"{settings_field}.domain",
+        )
+        require_running = settings.get("require_running", True)
+        if not isinstance(require_running, bool):
+            raise ConfigError(f"{settings_field}.require_running must be boolean")
+        normalized_settings["require_running"] = require_running
+    elif check_type == "systemd_user_unit":
+        settings_allowed.add("unit")
+        normalized_settings["unit"] = _safe_name(
+            settings.get("unit"), f"{settings_field}.unit"
+        )
+    elif check_type == "disk":
+        settings_allowed.update({"path", "min_free_percent", "min_free_bytes"})
+        normalized_settings["path"] = str(
+            _absolute_path(settings.get("path"), f"{settings_field}.path")
+        )
+        min_percent = float(
+            _number(
+                settings.get("min_free_percent", 10),
+                f"{settings_field}.min_free_percent",
+                minimum=0,
+            )
+        )
+        if min_percent > 100:
+            raise ConfigError(f"{settings_field}.min_free_percent must be <= 100")
+        normalized_settings["min_free_percent"] = min_percent
+        normalized_settings["min_free_bytes"] = int(
+            _number(
+                settings.get("min_free_bytes", 0),
+                f"{settings_field}.min_free_bytes",
+                minimum=0,
+                allow_integer_only=True,
+            )
+        )
+    elif check_type == "file_freshness":
+        settings_allowed.update(
+            {"path", "pattern", "max_age_seconds", "minimum_matches"}
+        )
+        normalized_settings["path"] = str(
+            _absolute_path(settings.get("path"), f"{settings_field}.path")
+        )
+        pattern = _require_string(
+            settings.get("pattern", "*"), f"{settings_field}.pattern"
+        )
+        if (
+            Path(pattern).is_absolute()
+            or ".." in Path(pattern).parts
+            or "\x00" in pattern
+            or len(pattern) > 256
+        ):
+            raise ConfigError(
+                f"{settings_field}.pattern must be a bounded relative glob"
+            )
+        normalized_settings["pattern"] = pattern
+        normalized_settings["max_age_seconds"] = float(
+            _number(
+                settings.get("max_age_seconds", 172800),
+                f"{settings_field}.max_age_seconds",
+                minimum=1,
+            )
+        )
+        normalized_settings["minimum_matches"] = int(
+            _number(
+                settings.get("minimum_matches", 1),
+                f"{settings_field}.minimum_matches",
+                minimum=1,
+                allow_integer_only=True,
+            )
+        )
+    if "recovery" in settings:
+        action_context = dict(normalized_settings)
+        normalized_settings["recovery"] = _normalize_action(
+            settings["recovery"], f"{settings_field}.recovery", action_context
+        )
+    _check_unknown_keys(settings, settings_allowed, settings_field)
+    _check_unknown_keys(check, allowed, field)
+    return normalized
+
+
+def load_config(path: str | os.PathLike[str]) -> MonitorConfig:
+    """Load, validate, and normalize a JSON configuration.
+
+    All filesystem paths in the returned configuration are resolved absolute
+    paths. Persistent/output paths are required explicitly so a service never
+    depends on launchd/systemd's working directory.
+    """
+
+    source_path = Path(path).expanduser().resolve(strict=False)
+    try:
+        with source_path.open(encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except FileNotFoundError as exc:
+        raise ConfigError(f"config not found: {source_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"invalid JSON in {source_path}: {exc}") from exc
+    config = _require_mapping(raw, "config")
+    _reject_forbidden_keys(config)
+    allowed = {
+        "checks",
+        "cooldown_seconds",
+        "executables",
+        "failure_threshold",
+        "heartbeat",
+        "heartbeat_path",
+        "host",
+        "interval_seconds",
+        "max_attempts",
+        "medic_config_path",
+        "profile",
+        "schema_version",
+        "state_path",
+    }
+    _check_unknown_keys(config, allowed, "config")
+
+    checks_raw = config.get("checks")
+    if not isinstance(checks_raw, list) or not checks_raw:
+        raise ConfigError("config.checks must be a non-empty JSON array")
+    checks = tuple(
+        _normalize_check(check, index) for index, check in enumerate(checks_raw)
+    )
+    ids = [check["id"] for check in checks]
+    if len(ids) != len(set(ids)):
+        raise ConfigError("config.checks contains duplicate ids")
+
+    executables_raw = config.get("executables", {})
+    executables_obj = _require_mapping(executables_raw, "config.executables")
+    unknown_executables = sorted(set(executables_obj) - _EXECUTABLE_NAMES)
+    if unknown_executables:
+        raise ConfigError(
+            "config.executables has unsupported names: "
+            + ", ".join(unknown_executables)
+        )
+    executables = {
+        name: _absolute_path(value, f"config.executables.{name}")
+        for name, value in executables_obj.items()
+    }
+
+    schema_version = config.get("schema_version")
+    if schema_version != 1:
+        raise ConfigError("config.schema_version must be 1")
+    profile = _require_string(config.get("profile"), "config.profile")
+
+    heartbeat: dict[str, Any] | None = None
+    if config.get("heartbeat") is not None:
+        heartbeat_raw = _require_mapping(config["heartbeat"], "config.heartbeat")
+        _check_unknown_keys(
+            heartbeat_raw,
+            {"url", "secret_env"},
+            "config.heartbeat",
+        )
+        url_value = heartbeat_raw.get("url")
+        if isinstance(url_value, str) and url_value.strip():
+            url = url_value.strip()
+            parsed = urllib.parse.urlsplit(url)
+            if (
+                parsed.scheme != "https"
+                or not parsed.hostname
+                or parsed.username is not None
+                or parsed.password is not None
+            ):
+                raise ConfigError(
+                    "config.heartbeat.url must be an HTTPS URL without "
+                    "embedded credentials"
+                )
+            heartbeat = {"url": url}
+        elif url_value not in (None, ""):
+            raise ConfigError("config.heartbeat.url must be a string")
+        if "secret_env" in heartbeat_raw and heartbeat_raw["secret_env"]:
+            env_name = _require_string(
+                heartbeat_raw["secret_env"],
+                "config.heartbeat.secret_env",
+            )
+            if not re.fullmatch(r"^[A-Za-z_][A-Za-z0-9_]*$", env_name):
+                raise ConfigError(
+                    "config.heartbeat.secret_env must be an environment variable name"
+                )
+            if heartbeat is None:
+                raise ConfigError(
+                    "config.heartbeat.secret_env requires config.heartbeat.url"
+                )
+            heartbeat["secret_env"] = env_name
+
+    return MonitorConfig(
+        schema_version=schema_version,
+        profile=profile,
+        source_path=source_path,
+        state_path=_absolute_path(config.get("state_path"), "config.state_path"),
+        heartbeat_path=_absolute_path(
+            config.get("heartbeat_path"), "config.heartbeat_path"
+        ),
+        medic_config_path=(
+            _absolute_path(
+                config.get("medic_config_path"),
+                "config.medic_config_path",
+            )
+            if config.get("medic_config_path")
+            else None
+        ),
+        interval_seconds=float(
+            _number(
+                config.get("interval_seconds", 120),
+                "config.interval_seconds",
+                minimum=1,
+            )
+        ),
+        failure_threshold=int(
+            _number(
+                config.get("failure_threshold", 2),
+                "config.failure_threshold",
+                minimum=1,
+                allow_integer_only=True,
+            )
+        ),
+        cooldown_seconds=float(
+            _number(
+                config.get("cooldown_seconds", 300),
+                "config.cooldown_seconds",
+                minimum=0,
+            )
+        ),
+        max_attempts=int(
+            _number(
+                config.get("max_attempts", 3),
+                "config.max_attempts",
+                minimum=0,
+                allow_integer_only=True,
+            )
+        ),
+        host=_require_string(config.get("host", socket.gethostname()), "config.host"),
+        checks=checks,
+        executables=executables,
+        heartbeat=heartbeat,
+    )
+
+
+def _process_detail(result: ProcessResult) -> str:
+    output = _trim(result.stderr or result.stdout)
+    return output or f"exit {result.returncode}"
+
+
+def run_check(
+    config: MonitorConfig,
+    check: Mapping[str, Any],
+    *,
+    process_runner: ProcessRunner | None = None,
+    urlopen: Callable[..., Any] | None = None,
+    socket_connector: Callable[..., Any] | None = None,
+    disk_usage: Callable[[str], Any] | None = None,
+    time_fn: Callable[[], float] | None = None,
+) -> CheckResult:
+    """Run one validated typed check."""
+
+    process_runner = process_runner or _run_process
+    urlopen = urlopen or urllib.request.urlopen
+    socket_connector = socket_connector or socket.create_connection
+    disk_usage = disk_usage or shutil.disk_usage
+    time_fn = time_fn or time.time
+    check_id = str(check["id"])
+    check_type = str(check["type"])
+    settings = check.get("settings", {})
+    timeout_seconds = float(check.get("timeout_seconds", 10.0))
+    started = time.monotonic()
+    ok = False
+    detail = ""
+    try:
+        if check_type == "docker_runtime":
+            docker_argv = [config.executable("docker")]
+            context = settings.get("context")
+            if context:
+                docker_argv.extend(["--context", str(context)])
+            docker_argv.extend(["info", "--format", "{{.ServerVersion}}"])
+            result = process_runner(
+                docker_argv,
+                timeout_seconds,
+                None,
+            )
+            ok = result.returncode == 0
+            detail = (
+                f"docker server {_trim(result.stdout)}"
+                if ok
+                else f"docker unavailable: {_process_detail(result)}"
+            )
+        elif check_type == "docker_container":
+            docker_argv = [config.executable("docker")]
+            context = settings.get("context")
+            if context:
+                docker_argv.extend(["--context", str(context)])
+            docker_argv.extend(
+                [
+                    "inspect",
+                    "--format",
+                    "{{json .State}}",
+                    "--",
+                    str(settings["container"]),
+                ]
+            )
+            result = process_runner(
+                docker_argv,
+                timeout_seconds,
+                None,
+            )
+            if result.returncode != 0:
+                detail = f"container unavailable: {_process_detail(result)}"
+            else:
+                try:
+                    state = json.loads(result.stdout)
+                except json.JSONDecodeError as exc:
+                    detail = f"invalid docker state JSON: {exc}"
+                else:
+                    running = bool(state.get("Running"))
+                    health_obj = state.get("Health")
+                    health = (
+                        str(health_obj.get("Status", "")).lower()
+                        if isinstance(health_obj, dict)
+                        else ""
+                    )
+                    if not running:
+                        detail = f"container {state.get('Status', 'not running')}"
+                    elif health and health != "healthy":
+                        detail = f"container running, health={health}"
+                    elif settings.get("require_healthcheck") and not health:
+                        detail = "container running, no healthcheck"
+                    else:
+                        ok = True
+                        detail = (
+                            f"container running, health={health}"
+                            if health
+                            else "container running"
+                        )
+        elif check_type == "http":
+            request = urllib.request.Request(
+                str(settings["url"]),
+                method=str(settings.get("method", "GET")),
+                headers={"User-Agent": "devbrain-resilience/1"},
+            )
+            try:
+                response = urlopen(request, timeout=timeout_seconds)
+                try:
+                    status = int(response.status)
+                finally:
+                    response.close()
+            except urllib.error.HTTPError as exc:
+                status = int(exc.code)
+            ok = int(settings["status_min"]) <= status <= int(settings["status_max"])
+            detail = f"HTTP {status}"
+        elif check_type == "tcp":
+            connection = socket_connector(
+                (str(settings["host"]), int(settings["port"])),
+                timeout=timeout_seconds,
+            )
+            try:
+                ok = True
+                detail = f"connected to {settings['host']}:{settings['port']}"
+            finally:
+                connection.close()
+        elif check_type == "launchd_label":
+            target = f"{settings['domain']}/{settings['label']}"
+            result = process_runner(
+                [config.executable("launchctl"), "print", target],
+                timeout_seconds,
+                None,
+            )
+            loaded = result.returncode == 0
+            running = bool(re.search(r"(?m)^\s*state\s*=\s*running\s*$", result.stdout))
+            ok = loaded and (running or not bool(settings.get("require_running", True)))
+            detail = (
+                "loaded and running"
+                if ok and running
+                else "loaded"
+                if ok
+                else f"not healthy: {_process_detail(result)}"
+                if not loaded
+                else "loaded but not running"
+            )
+        elif check_type == "systemd_user_unit":
+            result = process_runner(
+                [
+                    config.executable("systemctl"),
+                    "--user",
+                    "is-active",
+                    "--quiet",
+                    "--",
+                    str(settings["unit"]),
+                ],
+                timeout_seconds,
+                None,
+            )
+            ok = result.returncode == 0
+            detail = "active" if ok else f"inactive: {_process_detail(result)}"
+        elif check_type == "disk":
+            usage = disk_usage(str(settings["path"]))
+            free_percent = (100.0 * usage.free / usage.total) if usage.total else 0.0
+            min_percent = float(settings["min_free_percent"])
+            min_bytes = int(settings["min_free_bytes"])
+            ok = free_percent >= min_percent and usage.free >= min_bytes
+            detail = (
+                f"{free_percent:.1f}% free ({usage.free} bytes); "
+                f"minimum {min_percent:.1f}%/{min_bytes} bytes"
+            )
+        elif check_type == "file_freshness":
+            target = Path(str(settings["path"]))
+            if target.is_file():
+                matches = [target]
+            elif target.is_dir():
+                matches = [
+                    path
+                    for path in target.glob(str(settings["pattern"]))
+                    if path.is_file()
+                ]
+            else:
+                matches = []
+            minimum_matches = int(settings["minimum_matches"])
+            if len(matches) < minimum_matches:
+                detail = f"{len(matches)} matching file(s); minimum {minimum_matches}"
+            else:
+                latest = max(path.stat().st_mtime for path in matches)
+                age = max(0.0, float(time_fn()) - latest)
+                maximum = float(settings["max_age_seconds"])
+                ok = age <= maximum
+                detail = (
+                    f"newest of {len(matches)} file(s) is {age:.0f}s old; "
+                    f"maximum {maximum:.0f}s"
+                )
+        else:  # load_config rejects this; preserve fail-closed behavior for callers.
+            detail = f"unsupported check type: {check_type}"
+    except subprocess.TimeoutExpired:
+        detail = f"timed out after {timeout_seconds:g}s"
+    except (OSError, RuntimeError, ValueError, urllib.error.URLError) as exc:
+        detail = f"{type(exc).__name__}: {_trim(str(exc))}"
+    duration_ms = int((time.monotonic() - started) * 1000)
+    return CheckResult(check_id, check_type, ok, detail, duration_ms)
+
+
+def execute_recovery(
+    config: MonitorConfig,
+    check: Mapping[str, Any],
+    action: Mapping[str, Any],
+    *,
+    process_runner: ProcessRunner | None = None,
+) -> ActionResult:
+    """Execute one validated typed recovery action without a shell."""
+
+    process_runner = process_runner or _run_process
+    check_id = str(check["id"])
+    action_type = str(action["type"])
+    timeout_seconds = float(action.get("timeout_seconds", 60.0))
+    started = time.monotonic()
+    argv: list[str]
+    cwd: Path | None = None
+    try:
+        if action_type == "runtime_start":
+            runtime = str(action["runtime"])
+            if runtime == "colima":
+                argv = [config.executable("colima"), "start"]
+            elif runtime == "docker_desktop":
+                argv = [config.executable("open"), "-a", "Docker"]
+            elif runtime == "orbstack":
+                argv = [config.executable("open"), "-a", "OrbStack"]
+            else:
+                raise RuntimeError(f"unsupported runtime: {runtime}")
+        elif action_type == "docker_compose_up":
+            argv = [config.executable("docker")]
+            if action.get("context"):
+                argv.extend(["--context", str(action["context"])])
+            argv.extend(["compose", "up", "-d"])
+            argv.extend(str(service) for service in action.get("services", []))
+            cwd = Path(str(action["project_dir"]))
+        elif action_type == "launchd_kickstart":
+            target = f"{action['domain']}/{action['label']}"
+            argv = [config.executable("launchctl"), "kickstart", "-k", target]
+        elif action_type == "systemd_restart":
+            argv = [
+                config.executable("systemctl"),
+                "--user",
+                "restart",
+                "--",
+                str(action["unit"]),
+            ]
+        elif action_type == "homebrew_service_start":
+            argv = [
+                config.executable("brew"),
+                "services",
+                "start",
+                str(action["service"]),
+            ]
+        else:
+            raise RuntimeError(f"unsupported recovery type: {action_type}")
+        result = process_runner(argv, timeout_seconds, cwd)
+        ok = result.returncode == 0
+        detail = "started" if ok else _process_detail(result)
+    except subprocess.TimeoutExpired:
+        ok = False
+        detail = f"timed out after {timeout_seconds:g}s"
+    except (OSError, RuntimeError, ValueError) as exc:
+        ok = False
+        detail = f"{type(exc).__name__}: {_trim(str(exc))}"
+    return ActionResult(
+        check_id,
+        action_type,
+        ok,
+        detail,
+        int((time.monotonic() - started) * 1000),
+    )
+
+
+def atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    """Atomically replace a JSON file and fsync both file and parent directory."""
+
+    path = path.resolve(strict=False)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+        try:
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            state = json.load(handle)
+        if (
+            not isinstance(state, dict)
+            or state.get("version") != _STATE_VERSION
+            or not isinstance(state.get("checks"), dict)
+        ):
+            raise ValueError("unsupported state schema")
+        return state
+    except FileNotFoundError:
+        return {"version": _STATE_VERSION, "checks": {}}
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        logger.warning("ignoring unreadable resilience state %s: %s", path, exc)
+        return {"version": _STATE_VERSION, "checks": {}}
+
+
+def read_heartbeat(config: MonitorConfig) -> dict[str, Any]:
+    try:
+        with config.heartbeat_path.open(encoding="utf-8") as handle:
+            heartbeat = json.load(handle)
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"heartbeat not found: {config.heartbeat_path}") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"heartbeat unreadable: {config.heartbeat_path}: {exc}"
+        ) from exc
+    if (
+        not isinstance(heartbeat, dict)
+        or heartbeat.get("version") != _HEARTBEAT_VERSION
+    ):
+        raise RuntimeError("heartbeat has an unsupported schema")
+    return heartbeat
+
+
+def _canonical_json(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def send_webhook(
+    config: MonitorConfig,
+    heartbeat: Mapping[str, Any],
+    *,
+    urlopen: Callable[..., Any] | None = None,
+) -> WebhookResult:
+    """POST a heartbeat to an optional HTTPS endpoint.
+
+    If ``hmac_secret_env`` is configured but absent, delivery fails closed and
+    no unsigned request is sent.
+    """
+
+    if config.heartbeat is None:
+        return WebhookResult(False, False, "not configured")
+    urlopen = urlopen or urllib.request.urlopen
+    body = _canonical_json(heartbeat)
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "devbrain-resilience/1",
+    }
+    secret_env = config.heartbeat.get("secret_env")
+    if secret_env:
+        secret = os.getenv(str(secret_env))
+        if not secret:
+            return WebhookResult(
+                True, False, f"required HMAC environment variable {secret_env} is unset"
+            )
+        digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        headers["X-DevBrain-Signature"] = f"sha256={digest}"
+    request = urllib.request.Request(
+        str(config.heartbeat["url"]), data=body, method="POST", headers=headers
+    )
+    try:
+        response = urlopen(request, timeout=10.0)
+        try:
+            status = int(response.status)
+        finally:
+            response.close()
+        if 200 <= status < 300:
+            return WebhookResult(True, True, f"HTTP {status}")
+        return WebhookResult(True, False, f"HTTP {status}")
+    except urllib.error.HTTPError as exc:
+        return WebhookResult(True, False, f"HTTP {exc.code}")
+    except (OSError, ValueError, urllib.error.URLError) as exc:
+        return WebhookResult(True, False, f"{type(exc).__name__}: {_trim(str(exc))}")
+
+
+class Monitor:
+    """Run checks, apply bounded recovery policy, and persist local status."""
+
+    def __init__(
+        self,
+        config: MonitorConfig,
+        *,
+        check_executor: CheckExecutor | None = None,
+        action_executor: ActionExecutor | None = None,
+        webhook_sender: WebhookSender | None = None,
+        time_fn: Callable[[], float] | None = None,
+    ):
+        self.config = config
+        self._check_executor = check_executor or run_check
+        self._action_executor = action_executor or execute_recovery
+        self._webhook_sender = webhook_sender or send_webhook
+        self._time_fn = time_fn or time.time
+        self._state = _load_state(config.state_path)
+
+    def _persist_state(self, now: float, *, prune: bool = False) -> None:
+        state_checks = self._state.setdefault("checks", {})
+        if prune:
+            configured_ids = {
+                str(check["id"])
+                for check in self.config.checks
+                if bool(check.get("enabled", True))
+            }
+            self._state["checks"] = {
+                check_id: value
+                for check_id, value in state_checks.items()
+                if check_id in configured_ids
+            }
+        self._state["version"] = _STATE_VERSION
+        self._state["updated_at"] = now
+        self._state["updated_at_iso"] = _timestamp(now)
+        atomic_write_json(self.config.state_path, self._state)
+
+    def run_targeted_recovery(self, check_id: str) -> ActionResult:
+        """Apply the normal local policy to one fresh, signed heal request."""
+
+        self._state = _load_state(self.config.state_path)
+        now = float(self._time_fn())
+        check = next(
+            (
+                candidate
+                for candidate in self.config.checks
+                if candidate["id"] == check_id and bool(candidate.get("enabled", True))
+            ),
+            None,
+        )
+        if check is None:
+            return ActionResult(
+                check_id,
+                "policy",
+                False,
+                "unknown or disabled check; recovery not run",
+            )
+        settings = check.get("settings", {})
+        action = settings.get("recovery")
+        action_type = (
+            str(action.get("type", "policy")) if isinstance(action, dict) else "policy"
+        )
+        if not isinstance(action, dict):
+            return ActionResult(
+                check_id,
+                action_type,
+                False,
+                "check has no typed recovery",
+            )
+
+        try:
+            result = self._check_executor(self.config, check)
+        except Exception as exc:
+            logger.exception("targeted check %s crashed", check_id)
+            result = CheckResult(
+                check_id,
+                str(check["type"]),
+                False,
+                f"check crashed: {type(exc).__name__}: {_trim(str(exc))}",
+            )
+
+        state_checks = self._state.setdefault("checks", {})
+        entry = state_checks.get(check_id)
+        if not isinstance(entry, dict):
+            entry = {}
+            state_checks[check_id] = entry
+        entry["last_checked_at"] = now
+        entry["last_ok"] = result.ok
+        entry["last_detail"] = result.detail
+        if result.ok:
+            entry["consecutive_failures"] = 0
+            entry["recovery_attempts"] = 0
+            self._persist_state(now)
+            return ActionResult(
+                check_id,
+                action_type,
+                False,
+                "fresh check is healthy; recovery not run",
+            )
+
+        failures = int(entry.get("consecutive_failures", 0)) + 1
+        attempts = int(entry.get("recovery_attempts", 0))
+        threshold = int(
+            settings.get("failure_threshold", self.config.failure_threshold)
+        )
+        cooldown = float(settings.get("cooldown_seconds", self.config.cooldown_seconds))
+        max_attempts = int(settings.get("max_attempts", self.config.max_attempts))
+        last_recovery_at = entry.get("last_recovery_at")
+        entry["consecutive_failures"] = failures
+
+        blocked_reason = ""
+        if failures < threshold:
+            blocked_reason = f"failure threshold not reached ({failures}/{threshold})"
+        elif attempts >= max_attempts:
+            blocked_reason = (
+                f"maximum recovery attempts reached ({attempts}/{max_attempts})"
+            )
+        elif last_recovery_at is not None and now - float(last_recovery_at) < cooldown:
+            remaining = cooldown - (now - float(last_recovery_at))
+            blocked_reason = f"recovery cooldown active ({remaining:.0f}s remaining)"
+        if blocked_reason:
+            self._persist_state(now)
+            return ActionResult(check_id, action_type, False, blocked_reason)
+
+        try:
+            recovery = self._action_executor(self.config, check, action)
+        except Exception as exc:
+            logger.exception("targeted recovery for %s crashed", check_id)
+            recovery = ActionResult(
+                check_id,
+                action_type,
+                False,
+                f"recovery crashed: {type(exc).__name__}: {_trim(str(exc))}",
+            )
+        entry["recovery_attempts"] = attempts + 1
+        entry["last_recovery_at"] = now
+        entry["last_recovery_ok"] = recovery.ok
+        entry["last_recovery_detail"] = recovery.detail
+        self._persist_state(now)
+        return recovery
+
+    def run_cycle(self) -> CycleResult:
+        # A signed medic request can update the same policy state between
+        # regular cycles. Reload so cooldown and attempt limits stay coherent.
+        self._state = _load_state(self.config.state_path)
+        now = float(self._time_fn())
+        state_checks = self._state.setdefault("checks", {})
+        heartbeat_checks: dict[str, Any] = {}
+        recoveries: list[dict[str, Any]] = []
+
+        for check in self.config.checks:
+            check_id = str(check["id"])
+            required = bool(check.get("required", True))
+            enabled = bool(check.get("enabled", True))
+            if not enabled:
+                heartbeat_checks[check_id] = {
+                    "type": str(check["type"]),
+                    "enabled": False,
+                    "required": required,
+                    "ok": None,
+                    "detail": "disabled",
+                    "duration_ms": 0,
+                }
+                state_checks.pop(check_id, None)
+                continue
+            try:
+                result = self._check_executor(self.config, check)
+            except Exception as exc:  # one broken probe must not suppress all others
+                logger.exception("check %s crashed", check_id)
+                result = CheckResult(
+                    check_id,
+                    str(check["type"]),
+                    False,
+                    f"check crashed: {type(exc).__name__}: {_trim(str(exc))}",
+                )
+            heartbeat_checks[check_id] = {
+                **result.as_dict(),
+                "enabled": True,
+                "required": required,
+            }
+            entry = state_checks.get(check_id)
+            if not isinstance(entry, dict):
+                entry = {}
+                state_checks[check_id] = entry
+            entry["last_checked_at"] = now
+            entry["last_ok"] = result.ok
+            entry["last_detail"] = result.detail
+
+            if result.ok:
+                entry["consecutive_failures"] = 0
+                entry["recovery_attempts"] = 0
+                continue
+
+            failures = int(entry.get("consecutive_failures", 0)) + 1
+            entry["consecutive_failures"] = failures
+            settings = check.get("settings", {})
+            action = settings.get("recovery")
+            threshold = int(
+                settings.get("failure_threshold", self.config.failure_threshold)
+            )
+            cooldown = float(
+                settings.get("cooldown_seconds", self.config.cooldown_seconds)
+            )
+            max_attempts = int(settings.get("max_attempts", self.config.max_attempts))
+            attempts = int(entry.get("recovery_attempts", 0))
+            last_recovery_at = entry.get("last_recovery_at")
+            cooldown_elapsed = (
+                last_recovery_at is None or now - float(last_recovery_at) >= cooldown
+            )
+            if (
+                isinstance(action, dict)
+                and failures >= threshold
+                and attempts < max_attempts
+                and cooldown_elapsed
+            ):
+                try:
+                    recovery = self._action_executor(self.config, check, action)
+                except Exception as exc:
+                    logger.exception("recovery for %s crashed", check_id)
+                    recovery = ActionResult(
+                        check_id,
+                        str(action.get("type", "unknown")),
+                        False,
+                        f"recovery crashed: {type(exc).__name__}: {_trim(str(exc))}",
+                    )
+                entry["recovery_attempts"] = attempts + 1
+                entry["last_recovery_at"] = now
+                entry["last_recovery_ok"] = recovery.ok
+                entry["last_recovery_detail"] = recovery.detail
+                recoveries.append(recovery.as_dict())
+
+        self._persist_state(now, prune=True)
+
+        healthy = all(
+            bool(result["ok"])
+            for result in heartbeat_checks.values()
+            if bool(result["enabled"]) and bool(result["required"])
+        )
+        heartbeat: dict[str, Any] = {
+            "version": _HEARTBEAT_VERSION,
+            "schema_version": self.config.schema_version,
+            "profile": self.config.profile,
+            "host": self.config.host,
+            "generated_at": _timestamp(now),
+            "generated_at_epoch": now,
+            "healthy": healthy,
+            "checks": heartbeat_checks,
+            "recoveries": recoveries,
+            "config_path": str(self.config.source_path),
+        }
+        atomic_write_json(self.config.heartbeat_path, heartbeat)
+        try:
+            webhook = self._webhook_sender(self.config, heartbeat)
+        except Exception as exc:
+            logger.exception("webhook sender crashed")
+            webhook = WebhookResult(
+                self.config.heartbeat is not None,
+                False,
+                f"webhook crashed: {type(exc).__name__}: {_trim(str(exc))}",
+            )
+        return CycleResult(heartbeat, webhook)

--- a/ops/resilience/install.py
+++ b/ops/resilience/install.py
@@ -1,0 +1,1887 @@
+"""Render and install the DevBrain resilience service.
+
+This module owns only service-manager integration and the generated runtime
+configuration.  The watchdog itself is provided by ``python -m
+ops.resilience`` and has the stable interface::
+
+    python -m ops.resilience --config PATH run-once|watch|status
+
+The installer intentionally keeps credentials out of service definitions and
+the install manifest.  Heartbeat authentication is represented only by the
+name of an environment variable that the runtime resolves.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import getpass
+import json
+import os
+import platform as platform_module
+import pwd
+import re
+import socket
+import stat
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator, Mapping, Sequence
+from urllib.parse import urlparse
+from xml.sax.saxutils import escape as xml_escape
+
+SCHEMA_VERSION = 1
+SERVICE_LABEL = "com.devbrain.resilience"
+SYSTEMD_UNIT = "devbrain-resilience.service"
+HEARTBEAT_SECRET_ENV_DEFAULT = "DEVBRAIN_HEARTBEAT_TOKEN"
+DEFAULT_AGENT_BUS_URL = "http://localhost:18900/healthz"
+SERVICE_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_DOCKER_CONTEXT_RE = re.compile(r"^[A-Za-z0-9][-A-Za-z0-9._+]*$")
+_USER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
+_CONTAINER_RUNTIMES = {
+    "colima": "colima",
+    "docker-desktop": "docker_desktop",
+    "docker_desktop": "docker_desktop",
+    "docker-engine": "docker_engine",
+    "docker_engine": "docker_engine",
+    "orbstack": "orbstack",
+}
+_TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class InstallError(ValueError):
+    """Raised for an unsafe or internally inconsistent install request."""
+
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+@dataclass(frozen=True)
+class InstallRequest:
+    """Fully resolved inputs for rendering one service installation."""
+
+    profile: str
+    platform: str
+    repo_root: Path
+    home: Path
+    username: str
+    uid: int
+    python_executable: Path
+    config_path: Path
+    manifest_path: Path
+    container_runtime: str
+    docker_context: str
+    with_heartbeat: bool = False
+    heartbeat_url: str | None = None
+    heartbeat_secret_env: str | None = None
+    with_tunnel_check: bool = False
+    tunnel_label: str | None = None
+    with_agent_bus_check: bool = False
+    agent_bus_url: str | None = None
+    with_backup_check: bool = False
+    backup_path: Path | None = None
+    medic_mode: str | None = None
+    medic_instance_id: str | None = None
+    medic_primary_public_key: str | None = None
+    medic_confirm_public_key: str | None = None
+    medic_allowed_heal_checks: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.profile not in ("workstation", "studio"):
+            raise InstallError(
+                f"unsupported profile {self.profile!r}; expected workstation or studio"
+            )
+        if self.platform not in ("macos", "linux"):
+            raise InstallError(
+                f"unsupported platform {self.platform!r}; expected macos or linux"
+            )
+        if (
+            not self.username
+            or self.username == "root"
+            or not _USER_RE.fullmatch(self.username)
+        ):
+            raise InstallError(
+                "the resilience service must run as the invoking non-root user"
+            )
+        if self.uid < 0:
+            raise InstallError("uid must be a non-negative integer")
+        if self.container_runtime not in tuple(_CONTAINER_RUNTIMES.values()):
+            raise InstallError(
+                "container_runtime must be colima, docker-desktop, "
+                "docker-engine, or orbstack"
+            )
+        if not _DOCKER_CONTEXT_RE.fullmatch(self.docker_context):
+            raise InstallError("docker_context contains unsupported characters")
+
+        for name, path in {
+            "repo_root": self.repo_root,
+            "home": self.home,
+            "python_executable": self.python_executable,
+            "config_path": self.config_path,
+            "manifest_path": self.manifest_path,
+            **({"backup_path": self.backup_path} if self.backup_path else {}),
+        }.items():
+            if not path.is_absolute():
+                raise InstallError(f"{name} must be an absolute path: {path}")
+            if "\n" in str(path) or "\x00" in str(path):
+                raise InstallError(f"{name} contains an unsafe character")
+        expected_state_dir = self.home / ".devbrain" / "resilience"
+        if self.manifest_path != expected_state_dir / "install-manifest.json":
+            raise InstallError(
+                "manifest_path must use the fixed per-user resilience location"
+            )
+        if self.config_path != expected_state_dir / "config.json":
+            raise InstallError(
+                "config_path must use the fixed per-user resilience location"
+            )
+        owned_paths = {
+            self.config_path,
+            self.manifest_path,
+            self.service_path,
+            self.state_dir / "state.json",
+            self.state_dir / "heartbeat.json",
+        }
+        expected_paths = 5
+        if self.medic_mode is not None:
+            owned_paths.add(self.medic_config_path)
+            expected_paths += 1
+        if len(owned_paths) != expected_paths:
+            raise InstallError("resilience managed paths must be distinct")
+
+        if self.with_heartbeat:
+            _validate_http_url(
+                self.heartbeat_url,
+                "heartbeat URL",
+                require_https=True,
+            )
+            _validate_env_name(
+                self.heartbeat_secret_env, "heartbeat secret environment variable"
+            )
+        elif self.heartbeat_url or self.heartbeat_secret_env:
+            raise InstallError("heartbeat URL/secret-env require --with-heartbeat")
+
+        if self.with_tunnel_check:
+            if not self.tunnel_label or not _LABEL_RE.fullmatch(self.tunnel_label):
+                raise InstallError(
+                    "--with-tunnel-check requires a valid --tunnel-label"
+                )
+        elif self.tunnel_label:
+            raise InstallError("--tunnel-label requires --with-tunnel-check")
+
+        if self.with_agent_bus_check:
+            _validate_http_url(self.agent_bus_url, "agent-bus URL")
+        elif self.agent_bus_url:
+            raise InstallError("agent-bus URL requires --with-agent-bus-check")
+
+        if self.with_backup_check:
+            if self.backup_path is None:
+                raise InstallError(
+                    "--with-backup-check requires an explicit --backup-path"
+                )
+        elif self.backup_path is not None:
+            raise InstallError("--backup-path requires --with-backup-check")
+
+        if self.medic_mode is None:
+            if (
+                self.medic_instance_id
+                or self.medic_primary_public_key
+                or self.medic_confirm_public_key
+                or self.medic_allowed_heal_checks
+            ):
+                raise InstallError("medic settings require --with-medic")
+        else:
+            try:
+                from .signing import encode_public_key, load_public_key
+            except ImportError as exc:
+                raise InstallError(
+                    "signed medic requires the cryptography package; "
+                    "install DevBrain requirements first"
+                ) from exc
+            if self.medic_mode not in {"diagnose", "heal"}:
+                raise InstallError("medic mode must be diagnose or heal")
+            if not self.medic_instance_id or not _LABEL_RE.fullmatch(
+                self.medic_instance_id
+            ):
+                raise InstallError("medic instance ID contains unsupported characters")
+            if not self.medic_primary_public_key:
+                raise InstallError("--with-medic requires --medic-primary-public-key")
+            try:
+                primary = load_public_key(self.medic_primary_public_key)
+            except ValueError as exc:
+                raise InstallError("medic primary public key is invalid") from exc
+            if self.medic_mode == "diagnose":
+                if self.medic_confirm_public_key:
+                    raise InstallError(
+                        "a confirm key is valid only with --with-medic heal"
+                    )
+                if self.medic_allowed_heal_checks:
+                    raise InstallError(
+                        "diagnose-only medic cannot allow healing checks"
+                    )
+            else:
+                if not self.medic_confirm_public_key:
+                    raise InstallError(
+                        "medic heal mode requires --medic-confirm-public-key"
+                    )
+                try:
+                    confirm = load_public_key(self.medic_confirm_public_key)
+                except ValueError as exc:
+                    raise InstallError("medic confirm public key is invalid") from exc
+                if encode_public_key(primary) == encode_public_key(confirm):
+                    raise InstallError(
+                        "medic primary and confirm keys must be distinct"
+                    )
+                if not self.medic_allowed_heal_checks:
+                    raise InstallError(
+                        "medic heal mode requires at least one --medic-allow-check"
+                    )
+            for check_id in self.medic_allowed_heal_checks:
+                if not _LABEL_RE.fullmatch(check_id):
+                    raise InstallError(
+                        f"medic heal check contains unsupported characters: {check_id}"
+                    )
+
+    @property
+    def state_dir(self) -> Path:
+        return self.manifest_path.parent
+
+    @property
+    def log_dir(self) -> Path:
+        return self.home / ".devbrain" / "logs"
+
+    @property
+    def medic_config_path(self) -> Path:
+        return self.state_dir / "medic.json"
+
+    @property
+    def service_manager(self) -> str:
+        return "launchd" if self.platform == "macos" else "systemd-user"
+
+    @property
+    def service_scope(self) -> str:
+        if self.platform == "macos" and self.profile == "studio":
+            return "system"
+        return "user"
+
+    @property
+    def service_path(self) -> Path:
+        if self.platform == "linux":
+            return self.home / ".config" / "systemd" / "user" / SYSTEMD_UNIT
+        if self.profile == "studio":
+            return Path("/Library/LaunchDaemons") / f"{SERVICE_LABEL}.plist"
+        return self.home / "Library" / "LaunchAgents" / f"{SERVICE_LABEL}.plist"
+
+    @property
+    def interval_seconds(self) -> int:
+        return 60 if self.profile == "studio" else 300
+
+
+@dataclass(frozen=True)
+class InstallPlan:
+    """Rendered, side-effect-free installation artifacts."""
+
+    request: InstallRequest
+    config: dict[str, Any]
+    config_text: str
+    medic_config: dict[str, Any] | None
+    medic_config_text: str | None
+    service_text: str
+    manifest: dict[str, Any]
+    manifest_text: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "operation": "install",
+            "profile": self.request.profile,
+            "platform": self.request.platform,
+            "scope": self.request.service_scope,
+            "config_path": str(self.request.config_path),
+            "service_path": str(self.request.service_path),
+            "manifest_path": str(self.request.manifest_path),
+            "config": self.config,
+            "medic": self.medic_config,
+            "service": self.service_text,
+            "manifest": self.manifest,
+        }
+
+
+def _validate_http_url(
+    value: str | None,
+    label: str,
+    *,
+    require_https: bool = False,
+) -> None:
+    if not value:
+        raise InstallError(f"{label} is required")
+    parsed = urlparse(value)
+    allowed_schemes = {"https"} if require_https else {"http", "https"}
+    if parsed.scheme not in allowed_schemes or not parsed.hostname:
+        protocol = "HTTPS" if require_https else "http(s)"
+        raise InstallError(f"{label} must be an absolute {protocol} URL")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise InstallError(f"{label} contains an invalid port") from exc
+    if parsed.username or parsed.password:
+        raise InstallError(f"{label} must not contain embedded credentials")
+
+
+def _validate_env_name(value: str | None, label: str) -> None:
+    if not value or not _ENV_NAME_RE.fullmatch(value):
+        raise InstallError(f"{label} must be a valid environment-variable name")
+
+
+def _read_dotenv_values(path: Path) -> dict[str, str]:
+    """Read simple KEY=VALUE entries without evaluating shell syntax."""
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return {}
+    except OSError as exc:
+        raise InstallError(f"cannot read environment file {path}: {exc}") from exc
+    values: dict[str, str] = {}
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].lstrip()
+        key, separator, value = line.partition("=")
+        key = key.strip()
+        if not separator or not _ENV_NAME_RE.fullmatch(key):
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def normalize_platform(value: str | None = None) -> str:
+    raw = (value or platform_module.system()).strip().lower()
+    if raw in {"darwin", "mac", "macos"}:
+        return "macos"
+    if raw == "linux":
+        return "linux"
+    raise InstallError(
+        f"unsupported platform {raw!r}; resilience services support macOS and Linux"
+    )
+
+
+def resolve_invoking_user(
+    env: Mapping[str, str] | None = None,
+) -> tuple[str, int, Path]:
+    """Resolve the non-root identity that will own and run the service."""
+
+    source = os.environ if env is None else env
+    if os.geteuid() == 0:
+        raise InstallError(
+            "run the installer as the non-root service user, without sudo; "
+            "studio installs request sudo only for LaunchDaemon operations"
+        )
+
+    uid = os.getuid()
+    try:
+        entry = pwd.getpwuid(uid)
+        username = entry.pw_name
+        home = Path(entry.pw_dir).resolve()
+    except KeyError:
+        username = getpass.getuser()
+        home_value = source.get("HOME")
+        if not home_value:
+            raise InstallError("could not determine the invoking user's home directory")
+        home = Path(home_value).expanduser().resolve()
+
+    if username == "root" or uid == 0:
+        raise InstallError(
+            "do not run the installer from a root login; invoke it as the "
+            "non-root service user (sudo is requested only for LaunchDaemon steps)"
+        )
+    return username, uid, home
+
+
+def create_request(
+    *,
+    profile: str = "workstation",
+    platform_name: str | None = None,
+    repo_root: Path | str | None = None,
+    home: Path | str | None = None,
+    username: str | None = None,
+    uid: int | None = None,
+    python_executable: Path | str | None = None,
+    config_path: Path | str | None = None,
+    manifest_path: Path | str | None = None,
+    container_runtime: str | None = None,
+    docker_context: str | None = None,
+    with_heartbeat: bool = False,
+    heartbeat_url: str | None = None,
+    heartbeat_secret_env: str | None = None,
+    with_tunnel_check: bool = False,
+    tunnel_label: str | None = None,
+    with_agent_bus_check: bool = False,
+    agent_bus_url: str | None = None,
+    with_backup_check: bool = False,
+    backup_path: Path | str | None = None,
+    medic_mode: str | None = None,
+    medic_instance_id: str | None = None,
+    medic_primary_public_key_path: Path | str | None = None,
+    medic_confirm_public_key_path: Path | str | None = None,
+    medic_allowed_heal_checks: Sequence[str] = (),
+    env: Mapping[str, str] | None = None,
+) -> InstallRequest:
+    """Resolve defaults and validate an install request.
+
+    Explicit identity and path arguments are primarily useful for tests and
+    automated provisioning.  Normal callers let the function derive them from
+    the invoking user.
+    """
+
+    source = os.environ if env is None else env
+    if username is None or uid is None or home is None:
+        detected_user, detected_uid, detected_home = resolve_invoking_user(source)
+        username = username or detected_user
+        uid = detected_uid if uid is None else uid
+        home = home or detected_home
+
+    resolved_platform = normalize_platform(platform_name)
+    resolved_home = Path(home).expanduser().resolve()
+    resolved_repo = Path(repo_root or _REPO_ROOT).expanduser().resolve()
+    dotenv = _read_dotenv_values(resolved_repo / ".env")
+
+    def configured_value(name: str) -> str | None:
+        return source.get(name) or dotenv.get(name)
+
+    # Keep a virtual-environment executable path intact. Resolving this symlink
+    # to the Homebrew/system interpreter would silently discard the venv when
+    # launchd or systemd starts the monitor.
+    resolved_python = Path(python_executable or sys.executable).expanduser().absolute()
+    state_dir = resolved_home / ".devbrain" / "resilience"
+    resolved_config = (
+        Path(config_path or state_dir / "config.json").expanduser().resolve()
+    )
+    resolved_manifest = (
+        Path(manifest_path or state_dir / "install-manifest.json")
+        .expanduser()
+        .resolve()
+    )
+    runtime_input = container_runtime or (
+        "colima"
+        if profile == "studio" and resolved_platform == "macos"
+        else "docker-desktop"
+        if resolved_platform == "macos"
+        else "docker-engine"
+    )
+    resolved_runtime = _CONTAINER_RUNTIMES.get(runtime_input, runtime_input)
+    # The existing full installer historically calls the Linux Docker Engine
+    # path "docker-desktop". Normalize that alias for a safe detection-only
+    # watchdog policy rather than rendering a macOS `open -a Docker` recovery.
+    if resolved_platform == "linux" and resolved_runtime == "docker_desktop":
+        resolved_runtime = "docker_engine"
+    if resolved_platform == "macos" and resolved_runtime == "docker_engine":
+        raise InstallError("docker-engine is supported only on Linux")
+    default_contexts = {
+        "colima": "colima",
+        "docker_desktop": "desktop-linux",
+        "docker_engine": "default",
+        "orbstack": "orbstack",
+    }
+    resolved_context = docker_context or default_contexts.get(resolved_runtime)
+    if resolved_context is None:
+        raise InstallError("could not determine the Docker context")
+
+    if with_heartbeat:
+        heartbeat_url = heartbeat_url or configured_value("DEVBRAIN_HEARTBEAT_URL")
+        heartbeat_secret_env = heartbeat_secret_env or HEARTBEAT_SECRET_ENV_DEFAULT
+        if not dotenv.get(heartbeat_secret_env):
+            raise InstallError(
+                f"{heartbeat_secret_env} must be set in {resolved_repo / '.env'} "
+                "so the background service can sign heartbeats"
+            )
+    if with_tunnel_check:
+        tunnel_label = tunnel_label or configured_value("DEVBRAIN_TUNNEL_LABEL")
+    if with_agent_bus_check:
+        agent_bus_url = (
+            agent_bus_url
+            or configured_value("DEVBRAIN_AGENT_BUS_HEALTH_URL")
+            or DEFAULT_AGENT_BUS_URL
+        )
+    resolved_backup_path: Path | None = None
+    if with_backup_check:
+        backup_path_value = backup_path or configured_value("DEVBRAIN_BACKUP_PATH")
+        if not backup_path_value:
+            raise InstallError(
+                "--with-backup-check requires --backup-path or "
+                "DEVBRAIN_BACKUP_PATH"
+            )
+        resolved_backup_path = Path(backup_path_value).expanduser().resolve()
+    elif backup_path is not None:
+        resolved_backup_path = Path(backup_path).expanduser().resolve()
+
+    primary_public_key: str | None = None
+    confirm_public_key: str | None = None
+    if medic_mode is not None:
+        medic_instance_id = (
+            medic_instance_id
+            or configured_value("DEVBRAIN_INSTANCE_ID")
+            or socket.gethostname().split(".", 1)[0]
+        )
+        primary_path_value = medic_primary_public_key_path or configured_value(
+            "DEVBRAIN_MEDIC_PRIMARY_PUBLIC_KEY_FILE"
+        )
+        if primary_path_value:
+            try:
+                primary_public_key = (
+                    Path(primary_path_value)
+                    .expanduser()
+                    .resolve()
+                    .read_text(encoding="utf-8")
+                    .strip()
+                )
+            except OSError as exc:
+                raise InstallError(
+                    f"cannot read medic primary public key: {exc}"
+                ) from exc
+        confirm_path_value = medic_confirm_public_key_path or configured_value(
+            "DEVBRAIN_MEDIC_CONFIRM_PUBLIC_KEY_FILE"
+        )
+        if confirm_path_value:
+            try:
+                confirm_public_key = (
+                    Path(confirm_path_value)
+                    .expanduser()
+                    .resolve()
+                    .read_text(encoding="utf-8")
+                    .strip()
+                )
+            except OSError as exc:
+                raise InstallError(
+                    f"cannot read medic confirm public key: {exc}"
+                ) from exc
+
+    return InstallRequest(
+        profile=profile,
+        platform=resolved_platform,
+        repo_root=resolved_repo,
+        home=resolved_home,
+        username=str(username),
+        uid=int(uid),
+        python_executable=resolved_python,
+        config_path=resolved_config,
+        manifest_path=resolved_manifest,
+        container_runtime=resolved_runtime,
+        docker_context=resolved_context,
+        with_heartbeat=with_heartbeat,
+        heartbeat_url=heartbeat_url,
+        heartbeat_secret_env=heartbeat_secret_env,
+        with_tunnel_check=with_tunnel_check,
+        tunnel_label=tunnel_label,
+        with_agent_bus_check=with_agent_bus_check,
+        agent_bus_url=agent_bus_url,
+        with_backup_check=with_backup_check,
+        backup_path=resolved_backup_path,
+        medic_mode=medic_mode,
+        medic_instance_id=medic_instance_id,
+        medic_primary_public_key=primary_public_key,
+        medic_confirm_public_key=confirm_public_key,
+        medic_allowed_heal_checks=tuple(medic_allowed_heal_checks),
+    )
+
+
+def _default_checks(request: InstallRequest) -> list[dict[str, Any]]:
+    """Return the typed, secret-free checks for a deployment profile."""
+
+    is_studio = request.profile == "studio"
+    launch_domain = f"gui/{request.uid}"
+    ingest_type = (
+        "launchd_label" if request.platform == "macos" else "systemd_user_unit"
+    )
+    ingest_settings: dict[str, Any]
+    tunnel_settings: dict[str, Any]
+    if request.platform == "macos":
+        ingest_settings = {
+            "label": "com.devbrain.ingest",
+            "domain": launch_domain,
+            "require_running": True,
+            "recovery": {
+                "type": "launchd_kickstart",
+                "label": "com.devbrain.ingest",
+                "domain": launch_domain,
+            },
+        }
+        tunnel_label = request.tunnel_label or "com.devbrain.tunnel"
+        tunnel_settings = {
+            "label": tunnel_label,
+            "domain": launch_domain,
+            "require_running": True,
+        }
+        if request.with_tunnel_check:
+            tunnel_settings["recovery"] = {
+                "type": "launchd_kickstart",
+                "label": tunnel_label,
+                "domain": launch_domain,
+            }
+    else:
+        ingest_settings = {
+            "unit": "devbrain-ingest.service",
+        }
+        tunnel_unit = request.tunnel_label or "devbrain-tunnel.service"
+        tunnel_settings = {
+            "unit": tunnel_unit,
+        }
+        if request.with_tunnel_check:
+            tunnel_settings["recovery"] = {
+                "type": "systemd_restart",
+                "unit": tunnel_unit,
+            }
+
+    for settings in (ingest_settings, tunnel_settings):
+        settings.update(
+            {
+                "failure_threshold": 2,
+                "cooldown_seconds": 300,
+                "max_attempts": 3,
+            }
+        )
+
+    agent_bus = urlparse(request.agent_bus_url or DEFAULT_AGENT_BUS_URL)
+    agent_bus_port = agent_bus.port or (443 if agent_bus.scheme == "https" else 80)
+
+    runtime_settings: dict[str, Any] = {
+        "context": request.docker_context,
+        "failure_threshold": 2,
+        "cooldown_seconds": 300,
+        "max_attempts": 3,
+    }
+    if request.container_runtime != "docker_engine":
+        runtime_settings["recovery"] = {
+            "type": "runtime_start",
+            "runtime": request.container_runtime,
+        }
+
+    checks = [
+        {
+            "id": "container_runtime",
+            "type": "docker_runtime",
+            "enabled": True,
+            "required": True,
+            "timeout_seconds": 10,
+            "settings": runtime_settings,
+        },
+        {
+            "id": "postgres",
+            "type": "docker_container",
+            "enabled": True,
+            "required": True,
+            "timeout_seconds": 5,
+            "settings": {
+                "container": "devbrain-db",
+                "context": request.docker_context,
+                "require_healthcheck": True,
+                "recovery": {
+                    "type": "docker_compose_up",
+                    "context": request.docker_context,
+                    "project_dir": str(request.repo_root),
+                    "services": ["devbrain-db"],
+                },
+                "failure_threshold": 2,
+                "cooldown_seconds": 300,
+                "max_attempts": 3,
+            },
+        },
+        {
+            "id": "ollama",
+            "type": "http",
+            "enabled": True,
+            "required": True,
+            "timeout_seconds": 5,
+            "settings": {
+                "url": "http://localhost:11434/api/tags",
+                **(
+                    {
+                        "recovery": {
+                            "type": "homebrew_service_start",
+                            "service": "ollama",
+                        }
+                    }
+                    if request.platform == "macos"
+                    else {}
+                ),
+                "failure_threshold": 2,
+                "cooldown_seconds": 300,
+                "max_attempts": 3,
+            },
+        },
+        {
+            "id": "ingest",
+            "type": ingest_type,
+            "enabled": request.platform == "macos",
+            "required": False,
+            "timeout_seconds": 5,
+            "settings": ingest_settings,
+        },
+        {
+            "id": "disk",
+            "type": "disk",
+            "enabled": True,
+            "required": True,
+            "timeout_seconds": 5,
+            "settings": {
+                "path": "/",
+                "min_free_percent": 10,
+                "min_free_bytes": (10 if is_studio else 5) * 1024**3,
+                "failure_threshold": 1,
+                "cooldown_seconds": 3600,
+                "max_attempts": 0,
+            },
+        },
+        {
+            "id": "tunnel",
+            "type": ingest_type,
+            "enabled": request.with_tunnel_check,
+            "required": False,
+            "timeout_seconds": 5,
+            "settings": tunnel_settings,
+        },
+        {
+            "id": "agent_bus",
+            "type": "tcp",
+            "enabled": request.with_agent_bus_check,
+            "required": False,
+            "timeout_seconds": 5,
+            "settings": {
+                "host": agent_bus.hostname or "localhost",
+                "port": agent_bus_port,
+                "failure_threshold": 2,
+                "cooldown_seconds": 300,
+                "max_attempts": 0,
+            },
+        },
+    ]
+    if request.with_backup_check:
+        checks.insert(
+            5,
+            {
+                "id": "backup",
+                "type": "file_freshness",
+                "enabled": True,
+                "required": False,
+                "timeout_seconds": 5,
+                "settings": {
+                    "path": str(request.backup_path),
+                    "pattern": "*",
+                    "max_age_seconds": 172800,
+                    "minimum_matches": 1,
+                },
+            },
+        )
+    return checks
+
+
+def render_config(request: InstallRequest) -> dict[str, Any]:
+    """Build the JSON object consumed by the resilience runtime."""
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "profile": request.profile,
+        "state_path": str(request.state_dir / "state.json"),
+        "heartbeat_path": str(request.state_dir / "heartbeat.json"),
+        "medic_config_path": (
+            str(request.medic_config_path) if request.medic_mode is not None else None
+        ),
+        "interval_seconds": request.interval_seconds,
+        "failure_threshold": 2,
+        "cooldown_seconds": 300,
+        "max_attempts": 3,
+        "checks": _default_checks(request),
+        "heartbeat": (
+            {
+                "url": request.heartbeat_url,
+                "secret_env": request.heartbeat_secret_env,
+            }
+            if request.with_heartbeat
+            else None
+        ),
+    }
+
+
+def render_medic_config(request: InstallRequest) -> dict[str, Any] | None:
+    """Render the public-key-only medic policy for an explicit opt-in."""
+
+    if request.medic_mode is None:
+        return None
+    try:
+        from .signing import encode_public_key, load_public_key
+    except ImportError as exc:
+        raise InstallError(
+            "signed medic requires the cryptography package; "
+            "install DevBrain requirements first"
+        ) from exc
+    recoverable = {
+        str(check["id"])
+        for check in _default_checks(request)
+        if check.get("enabled", True)
+        and isinstance(check.get("settings", {}).get("recovery"), dict)
+    }
+    unknown = sorted(set(request.medic_allowed_heal_checks) - recoverable)
+    if unknown:
+        raise InstallError(
+            "medic heal checks are not enabled/recoverable: " + ", ".join(unknown)
+        )
+    primary = load_public_key(str(request.medic_primary_public_key))
+    keys = [
+        {
+            "key_id": "operator-primary",
+            "role": "primary",
+            "public_key": encode_public_key(primary),
+        }
+    ]
+    if request.medic_mode == "heal":
+        confirm = load_public_key(str(request.medic_confirm_public_key))
+        keys.append(
+            {
+                "key_id": "operator-confirm",
+                "role": "confirm",
+                "public_key": encode_public_key(confirm),
+            }
+        )
+    return {
+        "schema_version": 1,
+        "instance_id": request.medic_instance_id,
+        "mode": request.medic_mode,
+        "queue_dir": str(request.state_dir / "medic-queue"),
+        "poll_interval_seconds": 10,
+        "keys": keys,
+        "allowed_heal_checks": list(request.medic_allowed_heal_checks),
+    }
+
+
+def _render_template(name: str, values: Mapping[str, str], *, xml: bool) -> str:
+    template_path = _TEMPLATE_DIR / name
+    if not template_path.exists():
+        raise InstallError(f"missing service template: {template_path}")
+    output = template_path.read_text()
+    for key, raw_value in values.items():
+        value = xml_escape(raw_value) if xml else _systemd_escape(raw_value)
+        output = output.replace(f"@{key}@", value)
+
+    unresolved = sorted(set(re.findall(r"@[A-Z][A-Z0-9_]*@", output)))
+    if unresolved:
+        raise InstallError(
+            f"unresolved template placeholder(s) in {name}: {', '.join(unresolved)}"
+        )
+    return output
+
+
+def _systemd_escape(value: str) -> str:
+    if "\n" in value or "\r" in value or "\x00" in value:
+        raise InstallError("systemd template value contains an unsafe character")
+    # Every substituted value occupies one systemd argument or assignment.
+    # Double quotes handle whitespace; percent must be doubled to avoid unit
+    # specifier expansion.
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("%", "%%")
+    return f'"{escaped}"'
+
+
+def render_service(request: InstallRequest) -> str:
+    values = {
+        "LABEL": SERVICE_LABEL,
+        "RUN_AS_USER": request.username,
+        "PYTHON": str(request.python_executable),
+        "CONFIG_PATH": str(request.config_path),
+        "DEVBRAIN_HOME": str(request.repo_root),
+        "HOME": str(request.home),
+        "PATH": SERVICE_PATH,
+        "STDOUT_PATH": str(request.log_dir / "resilience.log"),
+        "STDERR_PATH": str(request.log_dir / "resilience.err.log"),
+        "DEVBRAIN_ENV": f"DEVBRAIN_HOME={request.repo_root}",
+        "HOME_ENV": f"HOME={request.home}",
+        "PATH_ENV": f"PATH={SERVICE_PATH}",
+        "STDOUT_TARGET": f"append:{request.log_dir / 'resilience.log'}",
+        "STDERR_TARGET": f"append:{request.log_dir / 'resilience.err.log'}",
+    }
+    if request.platform == "linux":
+        return _render_template(
+            "linux-systemd-user.service.template", values, xml=False
+        )
+    template = (
+        "macos-launchdaemon.plist.template"
+        if request.profile == "studio"
+        else "macos-launchagent.plist.template"
+    )
+    return _render_template(template, values, xml=True)
+
+
+def render_manifest(request: InstallRequest) -> dict[str, Any]:
+    service: dict[str, Any] = {
+        "manager": request.service_manager,
+        "scope": request.service_scope,
+        "path": str(request.service_path),
+    }
+    if request.platform == "macos":
+        service["label"] = SERVICE_LABEL
+        service["uid"] = request.uid
+    else:
+        service["unit"] = SYSTEMD_UNIT
+
+    managed_files = [
+        {"kind": "config", "path": str(request.config_path)},
+        {"kind": "service", "path": str(request.service_path)},
+        {
+            "kind": "runtime_state",
+            "path": str(request.state_dir / "state.json"),
+        },
+        {
+            "kind": "heartbeat",
+            "path": str(request.state_dir / "heartbeat.json"),
+        },
+    ]
+    if request.medic_mode is not None:
+        managed_files.append(
+            {"kind": "medic_config", "path": str(request.medic_config_path)}
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_by": "devbrain-resilience-installer",
+        "profile": request.profile,
+        "platform": request.platform,
+        "container_runtime": request.container_runtime.replace("_", "-"),
+        "docker_context": request.docker_context,
+        "backup_path": (
+            str(request.backup_path) if request.with_backup_check else None
+        ),
+        "run_as_user": request.username,
+        "config_path": str(request.config_path),
+        "medic_config_path": (
+            str(request.medic_config_path) if request.medic_mode is not None else None
+        ),
+        "medic_queue_dir": (
+            str(request.state_dir / "medic-queue")
+            if request.medic_mode is not None
+            else None
+        ),
+        "service": service,
+        "managed_files": managed_files,
+    }
+
+
+def build_plan(request: InstallRequest) -> InstallPlan:
+    config = render_config(request)
+    medic_config = render_medic_config(request)
+    manifest = render_manifest(request)
+    return InstallPlan(
+        request=request,
+        config=config,
+        config_text=json.dumps(config, indent=2, sort_keys=True) + "\n",
+        medic_config=medic_config,
+        medic_config_text=(
+            json.dumps(medic_config, indent=2, sort_keys=True) + "\n"
+            if medic_config is not None
+            else None
+        ),
+        service_text=render_service(request),
+        manifest=manifest,
+        manifest_text=json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def _atomic_write(path: Path, content: str, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _default_runner(args: Sequence[str], **kwargs: Any) -> subprocess.CompletedProcess:
+    return subprocess.run(list(args), **kwargs)
+
+
+def _run(
+    runner: Runner,
+    args: Sequence[str],
+    *,
+    check: bool,
+) -> subprocess.CompletedProcess:
+    return runner(
+        list(args),
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_service(
+    request: InstallRequest,
+    content: str,
+    runner: Runner,
+) -> None:
+    if request.platform == "macos" and request.profile == "studio":
+        request.state_dir.mkdir(parents=True, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(
+            prefix=f".{SERVICE_LABEL}.", suffix=".plist", dir=str(request.state_dir)
+        )
+        try:
+            with os.fdopen(fd, "w") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temporary, 0o644)
+            if os.geteuid() == 0:
+                _atomic_write(request.service_path, content, 0o644)
+            else:
+                _run(
+                    runner,
+                    [
+                        "sudo",
+                        "install",
+                        "-o",
+                        "root",
+                        "-g",
+                        "wheel",
+                        "-m",
+                        "0644",
+                        temporary,
+                        str(request.service_path),
+                    ],
+                    check=True,
+                )
+        finally:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+        return
+    _atomic_write(request.service_path, content, 0o644)
+
+
+def _deactivate_service(service: Mapping[str, Any], runner: Runner) -> None:
+    manager = service.get("manager")
+    if manager == "launchd":
+        scope = service.get("scope")
+        label = service.get("label")
+        path = service.get("path")
+        uid = service.get("uid")
+        if not isinstance(label, str) or not isinstance(path, str):
+            raise InstallError("manifest launchd service is missing label/path")
+        if scope == "system":
+            _run(
+                runner,
+                ["sudo", "launchctl", "bootout", f"system/{label}"],
+                check=False,
+            )
+            probe = _run(
+                runner,
+                ["sudo", "launchctl", "print", f"system/{label}"],
+                check=False,
+            )
+        elif scope == "user" and isinstance(uid, int):
+            _run(
+                runner,
+                ["launchctl", "bootout", f"gui/{uid}", path],
+                check=False,
+            )
+            probe = _run(
+                runner,
+                ["launchctl", "print", f"gui/{uid}/{label}"],
+                check=False,
+            )
+        else:
+            raise InstallError("manifest launchd service has an invalid scope/uid")
+        if probe.returncode == 0:
+            raise InstallError(
+                f"refusing to remove resilience files while {label} is still loaded"
+            )
+        if probe.returncode != 113:
+            raise InstallError(
+                "could not verify that the resilience launchd service stopped "
+                f"(launchctl print exited {probe.returncode})"
+            )
+        return
+
+    if manager == "systemd-user":
+        unit = service.get("unit")
+        if not isinstance(unit, str):
+            raise InstallError("manifest systemd service is missing its unit")
+        _run(
+            runner,
+            ["systemctl", "--user", "disable", "--now", unit],
+            check=False,
+        )
+        probe = _run(
+            runner,
+            ["systemctl", "--user", "is-active", "--quiet", unit],
+            check=False,
+        )
+        if probe.returncode == 0:
+            raise InstallError(
+                f"refusing to remove resilience files while {unit} is still active"
+            )
+        if probe.returncode not in {3, 4}:
+            raise InstallError(
+                "could not verify that the resilience systemd service stopped "
+                f"(systemctl is-active exited {probe.returncode})"
+            )
+        return
+
+    raise InstallError(f"manifest has unsupported service manager: {manager!r}")
+
+
+def _activate_service(request: InstallRequest, runner: Runner) -> None:
+    if request.platform == "linux":
+        if request.profile == "studio":
+            # A headless Studio must keep its user manager alive across logout
+            # and boot. Do not disable linger on uninstall: other user units
+            # may depend on it.
+            _run(
+                runner,
+                ["sudo", "loginctl", "enable-linger", request.username],
+                check=True,
+            )
+        _run(runner, ["systemctl", "--user", "daemon-reload"], check=True)
+        _run(
+            runner,
+            ["systemctl", "--user", "enable", "--now", SYSTEMD_UNIT],
+            check=True,
+        )
+        _run(
+            runner,
+            ["systemctl", "--user", "restart", SYSTEMD_UNIT],
+            check=True,
+        )
+        return
+
+    if request.profile == "studio":
+        _run(
+            runner,
+            ["sudo", "launchctl", "bootout", f"system/{SERVICE_LABEL}"],
+            check=False,
+        )
+        _run(
+            runner,
+            ["sudo", "launchctl", "bootstrap", "system", str(request.service_path)],
+            check=True,
+        )
+        return
+
+    domain = f"gui/{request.uid}"
+    _run(
+        runner,
+        ["launchctl", "bootout", domain, str(request.service_path)],
+        check=False,
+    )
+    _run(
+        runner,
+        ["launchctl", "bootstrap", domain, str(request.service_path)],
+        check=True,
+    )
+
+
+def _load_manifest(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise InstallError(f"cannot read install manifest {path}: {exc}") from exc
+    _validate_manifest(value, path)
+    return value
+
+
+def _validate_manifest(value: Any, manifest_path: Path) -> None:
+    if not isinstance(value, dict):
+        raise InstallError("install manifest must contain a JSON object")
+    if value.get("generated_by") != "devbrain-resilience-installer":
+        raise InstallError("refusing an install manifest not generated by DevBrain")
+    if value.get("schema_version") != SCHEMA_VERSION:
+        raise InstallError(
+            f"unsupported install manifest schema: {value.get('schema_version')!r}"
+        )
+    profile = value.get("profile")
+    platform_name = value.get("platform")
+    container_runtime = value.get("container_runtime")
+    docker_context = value.get("docker_context")
+    run_as_user = value.get("run_as_user")
+    if profile not in {"workstation", "studio"}:
+        raise InstallError("install manifest profile is invalid")
+    if platform_name not in {"macos", "linux"}:
+        raise InstallError("install manifest platform is invalid")
+    if container_runtime not in {
+        runtime.replace("_", "-") for runtime in _CONTAINER_RUNTIMES.values()
+    }:
+        raise InstallError("install manifest container runtime is invalid")
+    if not isinstance(docker_context, str) or not _DOCKER_CONTEXT_RE.fullmatch(
+        docker_context
+    ):
+        raise InstallError("install manifest Docker context is invalid")
+    if (
+        not isinstance(run_as_user, str)
+        or run_as_user == "root"
+        or not _USER_RE.fullmatch(run_as_user)
+    ):
+        raise InstallError("install manifest run-as user is invalid")
+    if (
+        manifest_path.name != "install-manifest.json"
+        or manifest_path.parent.name != "resilience"
+        or manifest_path.parent.parent.name != ".devbrain"
+    ):
+        raise InstallError(
+            "install manifest must be the DevBrain per-user resilience manifest"
+        )
+    inferred_home = manifest_path.parents[2]
+    service = value.get("service")
+    managed = value.get("managed_files")
+    if not isinstance(service, dict) or not isinstance(managed, list):
+        raise InstallError("install manifest is missing service/managed_files")
+    manager = service.get("manager")
+    scope = service.get("scope")
+    service_path = service.get("path")
+    if manager == "launchd":
+        if set(service) != {"manager", "scope", "path", "label", "uid"}:
+            raise InstallError("install manifest launchd service fields are invalid")
+        if service.get("label") != SERVICE_LABEL:
+            raise InstallError("install manifest launchd label is invalid")
+        uid = service.get("uid")
+        if isinstance(uid, bool) or not isinstance(uid, int) or uid < 0:
+            raise InstallError("install manifest launchd uid is invalid")
+        if scope == "system":
+            expected_service_path = str(
+                Path("/Library/LaunchDaemons") / f"{SERVICE_LABEL}.plist"
+            )
+        elif scope == "user":
+            expected_service_path = str(
+                inferred_home / "Library" / "LaunchAgents" / f"{SERVICE_LABEL}.plist"
+            )
+        else:
+            raise InstallError("install manifest launchd scope is invalid")
+    elif manager == "systemd-user":
+        if set(service) != {"manager", "scope", "path", "unit"}:
+            raise InstallError("install manifest systemd service fields are invalid")
+        if scope != "user" or service.get("unit") != SYSTEMD_UNIT:
+            raise InstallError("install manifest systemd service is invalid")
+        expected_service_path = str(
+            inferred_home / ".config" / "systemd" / "user" / SYSTEMD_UNIT
+        )
+    else:
+        raise InstallError("install manifest service manager is invalid")
+    if platform_name == "macos" and manager != "launchd":
+        raise InstallError("install manifest platform/service manager mismatch")
+    if platform_name == "linux" and manager != "systemd-user":
+        raise InstallError("install manifest platform/service manager mismatch")
+    expected_scope = (
+        "system"
+        if platform_name == "macos" and profile == "studio"
+        else "user"
+    )
+    if scope != expected_scope:
+        raise InstallError("install manifest profile/service scope mismatch")
+    if service_path != expected_service_path:
+        raise InstallError(
+            "install manifest service artifact is outside its fixed location"
+        )
+    config_path = value.get("config_path")
+    expected_config_path = str(manifest_path.parent / "config.json")
+    if config_path != expected_config_path:
+        raise InstallError(
+            "install manifest config artifact is outside its fixed location"
+        )
+    expected_paths = {
+        "config": config_path,
+        "service": service_path,
+        "runtime_state": str(manifest_path.parent / "state.json"),
+        "heartbeat": str(manifest_path.parent / "heartbeat.json"),
+    }
+    medic_path = value.get("medic_config_path")
+    medic_queue_dir = value.get("medic_queue_dir")
+    if medic_path is not None:
+        expected_medic_path = str(manifest_path.parent / "medic.json")
+        if medic_path != expected_medic_path:
+            raise InstallError(
+                "install manifest medic artifact does not match its declared path"
+            )
+        expected_paths["medic_config"] = medic_path
+        expected_queue_dir = str(manifest_path.parent / "medic-queue")
+        if medic_queue_dir != expected_queue_dir:
+            raise InstallError(
+                "install manifest medic queue is outside its fixed location"
+            )
+    elif medic_queue_dir is not None:
+        raise InstallError(
+            "install manifest medic queue requires a medic configuration"
+        )
+    seen_kinds: set[str] = set()
+    seen_paths: set[str] = set()
+    for item in managed:
+        if (
+            not isinstance(item, dict)
+            or item.get("kind") not in set(expected_paths)
+            or not isinstance(item.get("path"), str)
+            or not Path(item["path"]).is_absolute()
+        ):
+            raise InstallError("install manifest contains an invalid managed file")
+        kind = str(item["kind"])
+        item_path = str(item["path"])
+        if kind in seen_kinds or item_path in seen_paths:
+            raise InstallError("install manifest contains duplicate managed files")
+        seen_kinds.add(kind)
+        seen_paths.add(item_path)
+        if item_path != expected_paths[kind]:
+            raise InstallError(
+                f"install manifest {kind} artifact does not match its declared path"
+            )
+    if seen_kinds != set(expected_paths):
+        raise InstallError("install manifest does not list the exact managed artifacts")
+
+
+def _remove_managed_path(
+    item: Mapping[str, Any],
+    service: Mapping[str, Any],
+    runner: Runner,
+) -> None:
+    path = Path(str(item["path"]))
+    is_privileged_service = (
+        item.get("kind") == "service"
+        and service.get("manager") == "launchd"
+        and service.get("scope") == "system"
+    )
+    if is_privileged_service and os.geteuid() != 0:
+        _run(runner, ["sudo", "rm", "-f", str(path)], check=True)
+    else:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _medic_has_pending(queue_dir: Path) -> bool:
+    for name in ("inbox", "processing"):
+        source = queue_dir / name
+        if source.is_symlink():
+            return True
+        if source.is_dir():
+            try:
+                next(source.iterdir())
+            except StopIteration:
+                continue
+            return True
+        if source.exists():
+            return True
+    return False
+
+
+@contextmanager
+def _medic_consumer_lock(queue_dir: Path) -> Iterator[None]:
+    """Exclude task consumers while changing or removing medic policy."""
+
+    if queue_dir.is_symlink():
+        raise InstallError("medic queue directory must not be a symlink")
+    queue_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(queue_dir, 0o700)
+    lock_path = queue_dir / "consumer.lock"
+    flags = os.O_RDWR | os.O_CREAT
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise InstallError(f"cannot open medic consumer lock: {exc}") from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise InstallError("medic consumer lock must be a regular file")
+        os.fchmod(fd, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise InstallError(
+                "medic queue is active; retry after the current task finishes"
+            ) from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def _quarantine_pending_medic(queue_dir: Path) -> list[str]:
+    """Atomically retire pending inputs while retaining audit history."""
+
+    if not _medic_has_pending(queue_dir):
+        return []
+    quarantine_root = queue_dir / "quarantine"
+    quarantine_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(quarantine_root, 0o700)
+    session_dir = Path(
+        tempfile.mkdtemp(prefix="policy-change-", dir=str(quarantine_root))
+    )
+    quarantined: list[str] = []
+    for name in ("inbox", "processing"):
+        source = queue_dir / name
+        if not (source.exists() or source.is_symlink()):
+            continue
+        if source.is_dir() and not source.is_symlink():
+            try:
+                next(source.iterdir())
+            except StopIteration:
+                continue
+        destination = session_dir / name
+        os.replace(source, destination)
+        quarantined.append(str(destination))
+    return quarantined
+
+
+def _load_previous_medic_policy(
+    manifest: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not manifest or manifest.get("medic_config_path") is None:
+        return None
+    path = Path(str(manifest["medic_config_path"]))
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _load_previous_runtime_config(
+    manifest: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not manifest:
+        return None
+    path = Path(str(manifest["config_path"]))
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _apply_install(
+    request: InstallRequest,
+    plan: InstallPlan,
+    previous: Mapping[str, Any] | None,
+    runner: Runner,
+) -> InstallPlan:
+    previous_medic_policy = _load_previous_medic_policy(previous)
+    previous_runtime_config = _load_previous_runtime_config(previous)
+    queue_dir = request.state_dir / "medic-queue"
+    policy_unchanged = (
+        previous_medic_policy is not None
+        and plan.medic_config is not None
+        and previous_medic_policy == plan.medic_config
+        and previous_runtime_config == plan.config
+    )
+    previous_service_deactivated = False
+    if previous and previous.get("medic_config_path") is not None:
+        # Stop the old signed-task consumer before changing any key, allowlist,
+        # or typed recovery binding. This closes the reconfiguration window in
+        # which a newly arrived task could otherwise execute under old policy.
+        _deactivate_service(previous["service"], runner)
+        previous_service_deactivated = True
+    if _medic_has_pending(queue_dir) and not policy_unchanged:
+        _quarantine_pending_medic(queue_dir)
+    request.state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    request.log_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(request.state_dir, 0o700)
+    os.chmod(request.log_dir, 0o700)
+    dotenv_path = request.repo_root / ".env"
+    if dotenv_path.exists():
+        os.chmod(dotenv_path, 0o600)
+    _atomic_write(request.config_path, plan.config_text, 0o600)
+    if plan.medic_config_text is not None:
+        _atomic_write(request.medic_config_path, plan.medic_config_text, 0o600)
+    _write_service(request, plan.service_text, runner)
+
+    # Persist the exact artifact list before activation.  If activation fails,
+    # a subsequent --uninstall still has complete cleanup information.
+    _atomic_write(request.manifest_path, plan.manifest_text, 0o600)
+
+    if previous:
+        old_service = previous["service"]
+        same_service = (
+            old_service.get("manager") == plan.manifest["service"].get("manager")
+            and old_service.get("scope") == plan.manifest["service"].get("scope")
+            and old_service.get("path") == plan.manifest["service"].get("path")
+        )
+        if not same_service and not previous_service_deactivated:
+            _deactivate_service(old_service, runner)
+        new_paths = {item["path"] for item in plan.manifest["managed_files"]}
+        for item in previous["managed_files"]:
+            if item["path"] not in new_paths:
+                _remove_managed_path(item, old_service, runner)
+
+    _activate_service(request, runner)
+    return plan
+
+
+def install(
+    request: InstallRequest,
+    *,
+    dry_run: bool = False,
+    runner: Runner = _default_runner,
+) -> InstallPlan:
+    """Install or idempotently upgrade the configured resilience service."""
+
+    plan = build_plan(request)
+    if dry_run:
+        return plan
+
+    previous = _load_manifest(request.manifest_path)
+    queue_dir = request.state_dir / "medic-queue"
+    medic_lifecycle = (
+        previous is not None
+        and previous.get("medic_config_path") is not None
+    ) or plan.medic_config is not None or _medic_has_pending(queue_dir)
+    lock = (
+        _medic_consumer_lock(queue_dir)
+        if medic_lifecycle
+        else nullcontext()
+    )
+    with lock:
+        return _apply_install(request, plan, previous, runner)
+
+
+def _activate_manifest_service(
+    manifest: Mapping[str, Any],
+    runner: Runner,
+) -> None:
+    """Activate an already rendered service without rewriting its policy."""
+
+    service = manifest["service"]
+    manager = service["manager"]
+    if manager == "launchd":
+        path = str(service["path"])
+        if service["scope"] == "system":
+            _run(
+                runner,
+                ["sudo", "launchctl", "bootstrap", "system", path],
+                check=True,
+            )
+        else:
+            _run(
+                runner,
+                [
+                    "launchctl",
+                    "bootstrap",
+                    f"gui/{service['uid']}",
+                    path,
+                ],
+                check=True,
+            )
+        return
+
+    if manager == "systemd-user":
+        if manifest["profile"] == "studio":
+            _run(
+                runner,
+                [
+                    "sudo",
+                    "loginctl",
+                    "enable-linger",
+                    str(manifest["run_as_user"]),
+                ],
+                check=True,
+            )
+        unit = str(service["unit"])
+        _run(runner, ["systemctl", "--user", "daemon-reload"], check=True)
+        _run(
+            runner,
+            ["systemctl", "--user", "enable", "--now", unit],
+            check=True,
+        )
+        _run(
+            runner,
+            ["systemctl", "--user", "restart", unit],
+            check=True,
+        )
+        return
+
+    raise InstallError(f"manifest has unsupported service manager: {manager!r}")
+
+
+def restart(
+    manifest_path: Path | str,
+    *,
+    dry_run: bool = False,
+    runner: Runner = _default_runner,
+) -> dict[str, Any]:
+    """Restart an installed service while preserving its rendered policy."""
+
+    path = Path(manifest_path).expanduser().resolve()
+    manifest = _load_manifest(path)
+    if manifest is None:
+        return {
+            "operation": "restart",
+            "manifest_path": str(path),
+            "installed": False,
+        }
+    result = {
+        "operation": "restart",
+        "manifest_path": str(path),
+        "installed": True,
+        "service": manifest["service"],
+    }
+    if dry_run:
+        return result
+
+    queue_dir = path.parent / "medic-queue"
+    lock = (
+        _medic_consumer_lock(queue_dir)
+        if manifest.get("medic_config_path") is not None
+        else nullcontext()
+    )
+    with lock:
+        _deactivate_service(manifest["service"], runner)
+        _activate_manifest_service(manifest, runner)
+    return result
+
+
+def uninstall(
+    manifest_path: Path | str,
+    *,
+    dry_run: bool = False,
+    runner: Runner = _default_runner,
+) -> dict[str, Any]:
+    """Remove only artifacts recorded in the exact install manifest."""
+
+    path = Path(manifest_path).expanduser().resolve()
+    manifest = _load_manifest(path)
+    if manifest is None:
+        return {
+            "operation": "uninstall",
+            "manifest_path": str(path),
+            "installed": False,
+            "managed_files": [],
+        }
+
+    result = {
+        "operation": "uninstall",
+        "manifest_path": str(path),
+        "installed": True,
+        "service": manifest["service"],
+        "managed_files": list(manifest["managed_files"]),
+    }
+    if dry_run:
+        return result
+
+    service = manifest["service"]
+    queue_dir = path.parent / "medic-queue"
+    lock = (
+        _medic_consumer_lock(queue_dir)
+        if manifest.get("medic_config_path") is not None
+        else nullcontext()
+    )
+    with lock:
+        _deactivate_service(service, runner)
+        result["quarantined_pending"] = _quarantine_pending_medic(queue_dir)
+        for item in manifest["managed_files"]:
+            _remove_managed_path(item, service, runner)
+
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+        if service.get("manager") == "systemd-user":
+            _run(runner, ["systemctl", "--user", "daemon-reload"], check=True)
+        try:
+            path.parent.rmdir()
+        except OSError:
+            pass
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="install-resilience",
+        description="Install the DevBrain resilience service",
+        allow_abbrev=False,
+    )
+    parser.add_argument("--profile", choices=("workstation", "studio"))
+    parser.add_argument(
+        "--container-runtime",
+        choices=("colima", "docker-desktop", "docker-engine", "orbstack"),
+    )
+    parser.add_argument("--docker-context")
+    parser.add_argument("--with-heartbeat", action="store_true")
+    parser.add_argument("--heartbeat-url")
+    parser.add_argument("--heartbeat-secret-env")
+    parser.add_argument("--with-tunnel-check", action="store_true")
+    parser.add_argument("--tunnel-label")
+    parser.add_argument("--with-agent-bus-check", action="store_true")
+    parser.add_argument("--agent-bus-url")
+    parser.add_argument("--with-backup-check", action="store_true")
+    parser.add_argument("--backup-path", type=Path)
+    parser.add_argument("--with-medic", choices=("diagnose", "heal"))
+    parser.add_argument("--medic-instance-id")
+    parser.add_argument("--medic-primary-public-key", type=Path)
+    parser.add_argument("--medic-confirm-public-key", type=Path)
+    parser.add_argument("--medic-allow-check", action="append", default=[])
+    parser.add_argument("--dry-run", action="store_true")
+    operation = parser.add_mutually_exclusive_group()
+    operation.add_argument("--uninstall", action="store_true")
+    operation.add_argument("--restart", action="store_true")
+    parser.add_argument("--yes", action="store_true")
+    return parser
+
+
+def _reject_incompatible_args(args: argparse.Namespace) -> None:
+    if args.uninstall or args.restart:
+        operation = "--uninstall" if args.uninstall else "--restart"
+        incompatible = []
+        for name in (
+            "profile",
+            "container_runtime",
+            "docker_context",
+            "with_heartbeat",
+            "heartbeat_url",
+            "heartbeat_secret_env",
+            "with_tunnel_check",
+            "tunnel_label",
+            "with_agent_bus_check",
+            "agent_bus_url",
+            "with_backup_check",
+            "backup_path",
+            "with_medic",
+            "medic_instance_id",
+            "medic_primary_public_key",
+            "medic_confirm_public_key",
+            "medic_allow_check",
+        ):
+            if getattr(args, name):
+                incompatible.append("--" + name.replace("_", "-"))
+        if incompatible:
+            raise InstallError(
+                f"{operation} is incompatible with install options: "
+                + ", ".join(incompatible)
+            )
+        if args.yes and args.restart:
+            raise InstallError("--yes is only valid with --uninstall")
+        return
+
+    if not args.with_heartbeat and (args.heartbeat_url or args.heartbeat_secret_env):
+        raise InstallError(
+            "--heartbeat-url/--heartbeat-secret-env require --with-heartbeat"
+        )
+    if not args.with_tunnel_check and args.tunnel_label:
+        raise InstallError("--tunnel-label requires --with-tunnel-check")
+    if not args.with_agent_bus_check and args.agent_bus_url:
+        raise InstallError("--agent-bus-url requires --with-agent-bus-check")
+    if not args.with_backup_check and args.backup_path:
+        raise InstallError("--backup-path requires --with-backup-check")
+    if not args.with_medic and (
+        args.medic_instance_id
+        or args.medic_primary_public_key
+        or args.medic_confirm_public_key
+        or args.medic_allow_check
+    ):
+        raise InstallError("medic options require --with-medic diagnose|heal")
+    if args.yes:
+        raise InstallError("--yes is only valid with --uninstall")
+
+
+def _confirm_uninstall(manifest_path: Path) -> bool:
+    if not sys.stdin.isatty():
+        raise InstallError(
+            "--uninstall requires --yes when no interactive terminal is available"
+        )
+    answer = input(
+        f"Uninstall the exact resilience artifacts in {manifest_path}? [y/N]: "
+    ).strip()
+    return answer.lower() in {"y", "yes"}
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        _reject_incompatible_args(args)
+        username, uid, home = resolve_invoking_user(env)
+        manifest_path = home / ".devbrain" / "resilience" / "install-manifest.json"
+
+        if args.restart:
+            result = restart(manifest_path, dry_run=args.dry_run)
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 0
+
+        if args.uninstall:
+            if (
+                not args.dry_run
+                and not args.yes
+                and not _confirm_uninstall(manifest_path)
+            ):
+                print("Uninstall cancelled.")
+                return 0
+            result = uninstall(manifest_path, dry_run=args.dry_run)
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 0
+
+        request = create_request(
+            profile=args.profile or "workstation",
+            username=username,
+            uid=uid,
+            home=home,
+            container_runtime=args.container_runtime,
+            docker_context=args.docker_context,
+            with_heartbeat=args.with_heartbeat,
+            heartbeat_url=args.heartbeat_url,
+            heartbeat_secret_env=args.heartbeat_secret_env,
+            with_tunnel_check=args.with_tunnel_check,
+            tunnel_label=args.tunnel_label,
+            with_agent_bus_check=args.with_agent_bus_check,
+            agent_bus_url=args.agent_bus_url,
+            with_backup_check=args.with_backup_check,
+            backup_path=args.backup_path,
+            medic_mode=args.with_medic,
+            medic_instance_id=args.medic_instance_id,
+            medic_primary_public_key_path=args.medic_primary_public_key,
+            medic_confirm_public_key_path=args.medic_confirm_public_key,
+            medic_allowed_heal_checks=args.medic_allow_check,
+            env=env,
+        )
+        plan = install(request, dry_run=args.dry_run)
+        output = (
+            plan.as_dict()
+            if args.dry_run
+            else {
+                "operation": "install",
+                "profile": request.profile,
+                "platform": request.platform,
+                "scope": request.service_scope,
+                "config_path": str(request.config_path),
+                "service_path": str(request.service_path),
+                "manifest_path": str(request.manifest_path),
+            }
+        )
+        print(json.dumps(output, indent=2, sort_keys=True))
+        return 0
+    except InstallError as exc:
+        parser.error(str(exc))
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/resilience/medic.py
+++ b/ops/resilience/medic.py
@@ -1,0 +1,318 @@
+"""A bounded, signed queue for optional DevBrain recovery requests.
+
+This module deliberately has no arbitrary command, shell, reboot, or config
+write action.  A heal request may name only a check already declared by the
+local resilience configuration; the watchdog's typed recovery executor remains
+the sole authority that can perform the action.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import stat
+import tempfile
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from .signing import (
+    AuthorizedKey,
+    MedicAuthorizationError,
+    ReplayLedger,
+    verify_envelope,
+)
+
+MAX_TASK_BYTES = 64 * 1024
+MAX_TASKS_PER_CYCLE = 1
+
+
+@dataclass(frozen=True)
+class MedicResult:
+    task_id: str
+    action: str
+    status: str
+    detail: Any
+
+
+def _atomic_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if os.path.exists(temp_name):
+            os.unlink(temp_name)
+
+
+class MedicQueue:
+    """Process a filesystem inbox containing signed JSON task envelopes."""
+
+    def __init__(
+        self,
+        *,
+        root: str | Path,
+        instance_id: str,
+        authorized_keys: Mapping[str, AuthorizedKey],
+        allowed_heal_checks: set[str] | frozenset[str],
+        status_callback: Callable[[], Any],
+        diagnose_callback: Callable[[], Any],
+        heal_callback: Callable[[str], Any],
+        max_task_bytes: int = MAX_TASK_BYTES,
+        max_tasks_per_cycle: int = MAX_TASKS_PER_CYCLE,
+    ):
+        self.root = Path(root).expanduser().resolve()
+        self.instance_id = instance_id
+        self.authorized_keys = authorized_keys
+        self.allowed_heal_checks = frozenset(allowed_heal_checks)
+        self.status_callback = status_callback
+        self.diagnose_callback = diagnose_callback
+        self.heal_callback = heal_callback
+        self.max_task_bytes = max_task_bytes
+        self.max_tasks_per_cycle = max_tasks_per_cycle
+        self.inbox = self.root / "inbox"
+        self.processing = self.root / "processing"
+        self.outbox = self.root / "outbox"
+        self.archive = self.root / "archive"
+        self.rejected = self.root / "rejected"
+        self.ledger = ReplayLedger(self.root / "replay-ledger.json")
+        for path in (
+            self.root,
+            self.inbox,
+            self.processing,
+            self.outbox,
+            self.archive,
+            self.rejected,
+        ):
+            path.mkdir(parents=True, exist_ok=True, mode=0o700)
+            os.chmod(path, 0o700)
+        self.consumer_lock_path = self.root / "consumer.lock"
+
+    def _result_payload(
+        self,
+        *,
+        task_id: str,
+        action: str,
+        status: str,
+        detail: Any,
+    ) -> dict[str, Any]:
+        return {
+            "version": 1,
+            "instance_id": self.instance_id,
+            "task_id": task_id,
+            "action": action,
+            "status": status,
+            "completed_at": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "detail": detail,
+        }
+
+    def _reject(self, claimed: Path, reason: str) -> None:
+        destination = self.rejected / claimed.name
+        if destination.exists() or destination.is_symlink():
+            destination = self.rejected / (
+                f"{claimed.stem}.{uuid.uuid4()}{claimed.suffix}"
+            )
+        os.replace(claimed, destination)
+        _atomic_json(
+            destination.with_suffix(destination.suffix + ".reason.json"),
+            {
+                "status": "rejected",
+                "reason": reason,
+                "rejected_at": datetime.now(timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z"),
+            },
+        )
+
+    def _execute(self, task: Mapping[str, Any]) -> MedicResult:
+        action = task["action"]
+        action_type = action["type"]
+        if action_type == "status":
+            detail = self.status_callback()
+        elif action_type == "diagnose":
+            # "Diagnose" means a fresh typed health snapshot.  It does not
+            # invoke an AI CLI or grant filesystem/process execution.
+            detail = self.diagnose_callback()
+        elif action_type == "heal":
+            check = action["check"]
+            if check not in self.allowed_heal_checks:
+                raise MedicAuthorizationError(
+                    f"heal check is not locally allowlisted: {check}"
+                )
+            detail = self.heal_callback(check)
+        else:  # verify_envelope rejects this; defensive for future versions.
+            raise MedicAuthorizationError("unsupported medic action")
+        status = (
+            "failed"
+            if action_type == "heal"
+            and isinstance(detail, Mapping)
+            and detail.get("ok") is False
+            else "ok"
+        )
+        return MedicResult(
+            task_id=task["task_id"],
+            action=action_type,
+            status=status,
+            detail=detail,
+        )
+
+    def _load_envelope(self, path: Path) -> Any:
+        """Read one regular file through a single bounded, no-follow fd."""
+
+        flags = os.O_RDONLY
+        flags |= getattr(os, "O_NONBLOCK", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(path, flags)
+        try:
+            metadata = os.fstat(fd)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise MedicAuthorizationError("task must be a regular file")
+            if metadata.st_size > self.max_task_bytes:
+                raise MedicAuthorizationError("task exceeds maximum size")
+            chunks: list[bytes] = []
+            remaining = self.max_task_bytes + 1
+            while remaining:
+                chunk = os.read(fd, min(remaining, 64 * 1024))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            content = b"".join(chunks)
+            if len(content) > self.max_task_bytes:
+                raise MedicAuthorizationError("task exceeds maximum size")
+            try:
+                return json.loads(content.decode("utf-8"))
+            except UnicodeDecodeError as exc:
+                raise MedicAuthorizationError("task is not valid UTF-8") from exc
+        finally:
+            os.close(fd)
+
+    def _try_consumer_lock(self) -> int | None:
+        """Take the queue-wide consumer lock without waiting."""
+
+        flags = os.O_RDWR | os.O_CREAT
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(self.consumer_lock_path, flags, 0o600)
+        try:
+            metadata = os.fstat(fd)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise MedicAuthorizationError(
+                    "medic consumer lock must be a regular file"
+                )
+            os.fchmod(fd, 0o600)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                os.close(fd)
+                return None
+            return fd
+        except BaseException:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+
+    def process_once(self) -> list[MedicResult]:
+        """Recover or claim and process a bounded number of task files.
+
+        Files already in ``processing`` are handled first after a restart. If
+        their nonce was durably claimed but no result exists, they are
+        quarantined as indeterminate and are never executed a second time. A
+        queue-wide nonblocking lock prevents a foreground ``run-once`` from
+        racing the daemon consumer.
+        """
+
+        lock_fd = self._try_consumer_lock()
+        if lock_fd is None:
+            return []
+        try:
+            return self._process_locked()
+        finally:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            finally:
+                os.close(lock_fd)
+
+    def _process_locked(self) -> list[MedicResult]:
+        results: list[MedicResult] = []
+        processing = [(path, True) for path in sorted(self.processing.glob("*.json"))]
+        inbox = [(path, False) for path in sorted(self.inbox.glob("*.json"))]
+        candidates = (processing + inbox)[: self.max_tasks_per_cycle]
+        for source, was_processing in candidates:
+            claimed = source if was_processing else self.processing / source.name
+            if not was_processing:
+                if claimed.exists() or claimed.is_symlink():
+                    self._reject(source, "processing filename collision")
+                    continue
+                try:
+                    os.replace(source, claimed)
+                except FileNotFoundError:
+                    continue
+            try:
+                envelope = self._load_envelope(claimed)
+                verified = verify_envelope(
+                    envelope,
+                    authorized_keys=self.authorized_keys,
+                    instance_id=self.instance_id,
+                )
+                task = verified.task
+                result_path = self.outbox / f"{task['task_id']}.json"
+                archive_path = self.archive / f"{task['task_id']}.json"
+                if result_path.exists() or result_path.is_symlink():
+                    if was_processing:
+                        if archive_path.exists() or archive_path.is_symlink():
+                            raise MedicAuthorizationError(
+                                "task_id already has archive and outbox records"
+                            )
+                        os.replace(claimed, archive_path)
+                        continue
+                self.ledger.claim(
+                    task["nonce"],
+                    expires_at=task["expires_at"],
+                )
+                if (
+                    result_path.exists()
+                    or result_path.is_symlink()
+                    or archive_path.exists()
+                    or archive_path.is_symlink()
+                ):
+                    raise MedicAuthorizationError("task_id already has an audit record")
+                result = self._execute(task)
+                payload = self._result_payload(
+                    task_id=result.task_id,
+                    action=result.action,
+                    status=result.status,
+                    detail=result.detail,
+                )
+                _atomic_json(result_path, payload)
+                os.replace(claimed, archive_path)
+                results.append(result)
+            except (
+                MedicAuthorizationError,
+                json.JSONDecodeError,
+                OSError,
+                RuntimeError,
+                TypeError,
+                ValueError,
+            ) as exc:
+                if claimed.exists() or claimed.is_symlink():
+                    self._reject(claimed, str(exc))
+        return results

--- a/ops/resilience/medic_service.py
+++ b/ops/resilience/medic_service.py
@@ -1,0 +1,233 @@
+"""Connect the signed medic queue to the typed resilience runtime."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from cryptography.hazmat.primitives import serialization
+
+from .core import (
+    Monitor,
+    MonitorConfig,
+    load_config,
+    read_heartbeat,
+    run_check,
+)
+from .medic import MedicQueue, MedicResult
+from .signing import AuthorizedKey, MedicAuthorizationError, load_public_key
+
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+@dataclass(frozen=True)
+class MedicServiceConfig:
+    source_path: Path
+    instance_id: str
+    mode: str
+    queue_dir: Path
+    poll_interval_seconds: float
+    authorized_keys: Mapping[str, AuthorizedKey]
+    allowed_heal_checks: frozenset[str]
+
+
+def _object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MedicAuthorizationError(f"{field} must be an object")
+    return dict(value)
+
+
+def _safe_name(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not _SAFE_NAME.fullmatch(value):
+        raise MedicAuthorizationError(f"{field} contains unsupported characters")
+    return value
+
+
+def load_medic_config(
+    path: str | Path,
+    *,
+    runtime_config: MonitorConfig,
+) -> MedicServiceConfig:
+    source = Path(path).expanduser().resolve()
+    try:
+        raw = json.loads(source.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise MedicAuthorizationError(f"medic config not found: {source}") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MedicAuthorizationError(f"medic config is unreadable: {exc}") from exc
+    config = _object(raw, "medic config")
+    allowed_fields = {
+        "schema_version",
+        "instance_id",
+        "mode",
+        "queue_dir",
+        "poll_interval_seconds",
+        "keys",
+        "allowed_heal_checks",
+    }
+    unknown = sorted(set(config) - allowed_fields)
+    if unknown:
+        raise MedicAuthorizationError(
+            "medic config has unknown fields: " + ", ".join(unknown)
+        )
+    if config.get("schema_version") != 1:
+        raise MedicAuthorizationError("medic config schema_version must be 1")
+    instance_id = _safe_name(config.get("instance_id"), "instance_id")
+    mode = config.get("mode")
+    if mode not in {"diagnose", "heal"}:
+        raise MedicAuthorizationError("medic mode must be diagnose or heal")
+    queue_dir = Path(str(config.get("queue_dir", ""))).expanduser()
+    if not queue_dir.is_absolute():
+        raise MedicAuthorizationError("medic queue_dir must be absolute")
+    queue_dir = queue_dir.resolve()
+    interval = config.get("poll_interval_seconds", 10)
+    if (
+        isinstance(interval, bool)
+        or not isinstance(interval, (int, float))
+        or not 1 <= float(interval) <= 3600
+    ):
+        raise MedicAuthorizationError(
+            "medic poll_interval_seconds must be between 1 and 3600"
+        )
+
+    keys_raw = config.get("keys")
+    if not isinstance(keys_raw, list) or not keys_raw:
+        raise MedicAuthorizationError("medic keys must be a non-empty array")
+    keys: dict[str, AuthorizedKey] = {}
+    public_material: set[bytes] = set()
+    for index, raw_key in enumerate(keys_raw):
+        key_obj = _object(raw_key, f"keys[{index}]")
+        if set(key_obj) != {"key_id", "role", "public_key"}:
+            raise MedicAuthorizationError(
+                f"keys[{index}] must contain key_id, role, and public_key"
+            )
+        key_id = _safe_name(key_obj["key_id"], f"keys[{index}].key_id")
+        if key_id in keys:
+            raise MedicAuthorizationError(f"duplicate medic key_id: {key_id}")
+        role = key_obj["role"]
+        if role not in {"primary", "confirm"}:
+            raise MedicAuthorizationError(
+                f"keys[{index}].role must be primary or confirm"
+            )
+        public_key = load_public_key(key_obj["public_key"])
+        raw_public = public_key.public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        if raw_public in public_material:
+            raise MedicAuthorizationError("medic roles must use distinct public keys")
+        public_material.add(raw_public)
+        keys[key_id] = AuthorizedKey(role=role, public_key=public_key)
+    roles = {key.role for key in keys.values()}
+    if "primary" not in roles:
+        raise MedicAuthorizationError("medic requires a primary public key")
+    if mode == "heal" and "confirm" not in roles:
+        raise MedicAuthorizationError(
+            "medic heal mode requires a distinct confirm public key"
+        )
+
+    allowed_raw = config.get("allowed_heal_checks", [])
+    if not isinstance(allowed_raw, list):
+        raise MedicAuthorizationError("allowed_heal_checks must be an array")
+    allowed = frozenset(
+        _safe_name(value, f"allowed_heal_checks[{index}]")
+        for index, value in enumerate(allowed_raw)
+    )
+    if mode == "diagnose" and allowed:
+        raise MedicAuthorizationError(
+            "diagnose mode cannot declare allowed_heal_checks"
+        )
+    recoverable = {
+        str(check["id"])
+        for check in runtime_config.checks
+        if check.get("enabled", True)
+        and isinstance(check.get("settings", {}).get("recovery"), dict)
+    }
+    unknown_checks = sorted(allowed - recoverable)
+    if unknown_checks:
+        raise MedicAuthorizationError(
+            "medic heal checks are not recoverable in the runtime config: "
+            + ", ".join(unknown_checks)
+        )
+    return MedicServiceConfig(
+        source_path=source,
+        instance_id=instance_id,
+        mode=mode,
+        queue_dir=queue_dir,
+        poll_interval_seconds=float(interval),
+        authorized_keys=keys,
+        allowed_heal_checks=allowed if mode == "heal" else frozenset(),
+    )
+
+
+class MedicService:
+    """Bounded queue processor backed by read-only checks and typed remedies."""
+
+    def __init__(
+        self,
+        runtime_config: MonitorConfig,
+        medic_config: MedicServiceConfig,
+        *,
+        monitor: Monitor | None = None,
+    ):
+        self.runtime_config = runtime_config
+        self.medic_config = medic_config
+        self.monitor = monitor or Monitor(runtime_config)
+        self.queue = MedicQueue(
+            root=medic_config.queue_dir,
+            instance_id=medic_config.instance_id,
+            authorized_keys=medic_config.authorized_keys,
+            allowed_heal_checks=medic_config.allowed_heal_checks,
+            status_callback=self._status,
+            diagnose_callback=self._diagnose,
+            heal_callback=self._heal,
+        )
+
+    def _status(self) -> dict[str, Any]:
+        try:
+            return read_heartbeat(self.runtime_config)
+        except RuntimeError as exc:
+            return {"available": False, "detail": str(exc)}
+
+    def _diagnose(self) -> dict[str, Any]:
+        checks = {}
+        for check in self.runtime_config.checks:
+            if not check.get("enabled", True):
+                continue
+            result = run_check(self.runtime_config, check)
+            checks[result.check_id] = result.as_dict()
+        return {
+            "instance_id": self.medic_config.instance_id,
+            "checks": checks,
+            "healthy": all(
+                result["ok"]
+                for check_id, result in checks.items()
+                if next(
+                    check
+                    for check in self.runtime_config.checks
+                    if check["id"] == check_id
+                ).get("required", True)
+            ),
+        }
+
+    def _heal(self, check_id: str) -> dict[str, Any]:
+        return self.monitor.run_targeted_recovery(check_id).as_dict()
+
+    def process_once(self) -> list[MedicResult]:
+        return self.queue.process_once()
+
+
+def create_medic_service(runtime_config_path: str | Path) -> MedicService | None:
+    """Create the optional service declared by a runtime config."""
+
+    runtime_config = load_config(runtime_config_path)
+    if runtime_config.medic_config_path is None:
+        return None
+    medic_config = load_medic_config(
+        runtime_config.medic_config_path,
+        runtime_config=runtime_config,
+    )
+    return MedicService(runtime_config, medic_config)

--- a/ops/resilience/medic_tools.py
+++ b/ops/resilience/medic_tools.py
@@ -1,0 +1,133 @@
+"""Operator-side key and task tooling for the optional signed medic queue."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from datetime import timedelta
+from pathlib import Path
+
+from .signing import (
+    MedicAuthorizationError,
+    encode_private_key,
+    encode_public_key,
+    generate_keypair,
+    load_private_key,
+    make_task,
+    sign_task,
+)
+
+
+def _write_new(path: Path, value: str, *, mode: int) -> None:
+    path = path.expanduser().resolve()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if path.exists():
+        raise MedicAuthorizationError(f"refusing to overwrite existing file: {path}")
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        os.fchmod(fd, mode)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(value)
+            if not value.endswith("\n"):
+                handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+    finally:
+        if os.path.exists(temp_name):
+            os.unlink(temp_name)
+
+
+def _parse_signer(value: str) -> tuple[str, Path]:
+    key_id, separator, raw_path = value.partition("=")
+    if not separator or not key_id or not raw_path:
+        raise argparse.ArgumentTypeError("signer must be KEY_ID=/path/to/private-key")
+    return key_id, Path(raw_path).expanduser().resolve()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="DevBrain signed medic tooling")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    keygen = commands.add_parser(
+        "keygen",
+        help="generate an off-host Ed25519 signing keypair",
+    )
+    keygen.add_argument("--private", required=True)
+    keygen.add_argument("--public", required=True)
+
+    task = commands.add_parser("task", help="create a signed medic task envelope")
+    task.add_argument("--instance-id", required=True)
+    task.add_argument(
+        "--action",
+        required=True,
+        choices=("status", "diagnose", "heal"),
+    )
+    task.add_argument("--check", help="required only for a heal action")
+    task.add_argument("--ttl-seconds", type=int, default=300)
+    task.add_argument(
+        "--sign",
+        action="append",
+        required=True,
+        type=_parse_signer,
+        metavar="KEY_ID=PRIVATE_KEY_PATH",
+    )
+    task.add_argument("--output", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "keygen":
+            private_raw, _public_raw = generate_keypair()
+            private = load_private_key(private_raw)
+            _write_new(
+                Path(args.private),
+                encode_private_key(private),
+                mode=0o600,
+            )
+            _write_new(
+                Path(args.public),
+                encode_public_key(private.public_key()),
+                mode=0o644,
+            )
+            print(f"private key: {Path(args.private).expanduser().resolve()}")
+            print(f"public key:  {Path(args.public).expanduser().resolve()}")
+            return 0
+
+        if args.action == "heal":
+            if not args.check:
+                raise MedicAuthorizationError("--check is required for heal")
+            action = {"type": "heal", "check": args.check}
+        else:
+            if args.check:
+                raise MedicAuthorizationError("--check is valid only for heal")
+            action = {"type": args.action}
+        task = make_task(
+            instance_id=args.instance_id,
+            action=action,
+            ttl=timedelta(seconds=args.ttl_seconds),
+        )
+        signatures = []
+        for key_id, key_path in args.sign:
+            private = load_private_key(key_path.read_text(encoding="utf-8").strip())
+            signatures.append(sign_task(task, key_id=key_id, private_key=private))
+        envelope = {"task": task, "signatures": signatures}
+        _write_new(
+            Path(args.output),
+            json.dumps(envelope, sort_keys=True, indent=2),
+            mode=0o600,
+        )
+        print(Path(args.output).expanduser().resolve())
+        return 0
+    except (MedicAuthorizationError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/resilience/signing.py
+++ b/ops/resilience/signing.py
@@ -1,0 +1,402 @@
+"""Signing primitives for the optional DevBrain medic queue.
+
+The host stores public keys only.  Every signature covers one canonical task
+body; confirmations are additional signatures over that *same* body.  This
+avoids the common (and dangerous) pattern of trusting unsigned signer metadata
+or comparing only a subset of fields between two independently signed blobs.
+"""
+
+from __future__ import annotations
+
+import base64
+import fcntl
+import json
+import os
+import re
+import tempfile
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+TASK_FIELDS = {
+    "version",
+    "task_id",
+    "instance_id",
+    "issued_at",
+    "expires_at",
+    "nonce",
+    "action",
+}
+SIGNATURE_FIELDS = {"key_id", "signature"}
+SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+DEFAULT_MAX_TTL = timedelta(minutes=15)
+DEFAULT_CLOCK_SKEW = timedelta(seconds=60)
+PUBLIC_KEY_PREFIX = "devbrain-ed25519-public-v1:"
+PRIVATE_KEY_PREFIX = "devbrain-ed25519-private-v1:"
+
+
+class MedicAuthorizationError(ValueError):
+    """Raised when a medic task is malformed or unauthorized."""
+
+
+@dataclass(frozen=True)
+class AuthorizedKey:
+    """One authorized public key and the role it may satisfy."""
+
+    role: str
+    public_key: Ed25519PublicKey
+
+
+@dataclass(frozen=True)
+class VerifiedTask:
+    """A validated task plus the key roles that signed it."""
+
+    task: dict[str, Any]
+    signer_roles: frozenset[str]
+
+
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64decode(value: str, *, field: str) -> bytes:
+    if not isinstance(value, str):
+        raise MedicAuthorizationError(f"{field} must be a string")
+    try:
+        return base64.b64decode(
+            value + ("=" * (-len(value) % 4)),
+            altchars=b"-_",
+            validate=True,
+        )
+    except (ValueError, TypeError) as exc:
+        raise MedicAuthorizationError(f"{field} is not valid base64url") from exc
+
+
+def _parse_time(value: Any, *, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise MedicAuthorizationError(f"{field} must be an RFC3339 string")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise MedicAuthorizationError(f"{field} must be an RFC3339 string") from exc
+    if parsed.tzinfo is None:
+        raise MedicAuthorizationError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def canonical_task_bytes(task: Mapping[str, Any]) -> bytes:
+    """Return the single byte representation every signer must sign."""
+
+    return json.dumps(
+        task,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def generate_keypair() -> tuple[bytes, bytes]:
+    """Generate raw Ed25519 private/public key bytes."""
+
+    private = Ed25519PrivateKey.generate()
+    private_raw = private.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_raw = private.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return private_raw, public_raw
+
+
+def load_private_key(raw: bytes | str) -> Ed25519PrivateKey:
+    """Load raw bytes or a type-tagged Ed25519 private-key string."""
+
+    if isinstance(raw, str):
+        if not raw.startswith(PRIVATE_KEY_PREFIX):
+            raise MedicAuthorizationError(
+                "private key must use the DevBrain private-key encoding"
+            )
+        decoded = _b64decode(
+            raw[len(PRIVATE_KEY_PREFIX) :],
+            field="private key",
+        )
+    else:
+        decoded = raw
+    try:
+        return Ed25519PrivateKey.from_private_bytes(decoded)
+    except ValueError as exc:
+        raise MedicAuthorizationError("invalid Ed25519 private key") from exc
+
+
+def load_public_key(raw: bytes | str) -> Ed25519PublicKey:
+    """Load raw bytes or a type-tagged Ed25519 public-key string."""
+
+    if isinstance(raw, str):
+        if not raw.startswith(PUBLIC_KEY_PREFIX):
+            raise MedicAuthorizationError(
+                "public key must use the DevBrain public-key encoding"
+            )
+        decoded = _b64decode(
+            raw[len(PUBLIC_KEY_PREFIX) :],
+            field="public key",
+        )
+    else:
+        decoded = raw
+    try:
+        return Ed25519PublicKey.from_public_bytes(decoded)
+    except ValueError as exc:
+        raise MedicAuthorizationError("invalid Ed25519 public key") from exc
+
+
+def encode_public_key(key: Ed25519PublicKey) -> str:
+    """Encode a public key for a JSON configuration file."""
+
+    raw = key.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return PUBLIC_KEY_PREFIX + _b64encode(raw)
+
+
+def encode_private_key(key: Ed25519PrivateKey) -> str:
+    """Encode a private key for an operator-owned mode-0600 file."""
+
+    raw = key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return PRIVATE_KEY_PREFIX + _b64encode(raw)
+
+
+def sign_task(
+    task: Mapping[str, Any],
+    *,
+    key_id: str,
+    private_key: Ed25519PrivateKey,
+) -> dict[str, str]:
+    """Create one signature entry for an envelope."""
+
+    if not SAFE_NAME.fullmatch(key_id):
+        raise MedicAuthorizationError("key_id contains unsupported characters")
+    signature = private_key.sign(canonical_task_bytes(task))
+    return {"key_id": key_id, "signature": _b64encode(signature)}
+
+
+def make_task(
+    *,
+    instance_id: str,
+    action: Mapping[str, Any],
+    ttl: timedelta = timedelta(minutes=5),
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a new canonical task body for an off-host signer."""
+
+    if ttl <= timedelta(0) or ttl > DEFAULT_MAX_TTL:
+        raise MedicAuthorizationError(
+            "task ttl must be between 1 second and 15 minutes"
+        )
+    if not SAFE_NAME.fullmatch(instance_id):
+        raise MedicAuthorizationError("instance_id contains unsupported characters")
+    issued = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    return {
+        "version": 1,
+        "task_id": str(uuid.uuid4()),
+        "instance_id": instance_id,
+        "issued_at": issued.isoformat().replace("+00:00", "Z"),
+        "expires_at": (issued + ttl).isoformat().replace("+00:00", "Z"),
+        "nonce": _b64encode(os.urandom(24)),
+        "action": dict(action),
+    }
+
+
+def _validate_action(action: Any) -> tuple[str, set[str]]:
+    if not isinstance(action, dict):
+        raise MedicAuthorizationError("action must be an object")
+    action_type = action.get("type")
+    if action_type in {"status", "diagnose"}:
+        if set(action) != {"type"}:
+            raise MedicAuthorizationError(
+                f"{action_type} action has unsupported fields"
+            )
+        return action_type, {"primary"}
+    if action_type == "heal":
+        if set(action) != {"type", "check"}:
+            raise MedicAuthorizationError("heal action requires only type and check")
+        check = action.get("check")
+        if not isinstance(check, str) or not SAFE_NAME.fullmatch(check):
+            raise MedicAuthorizationError("heal check has an invalid name")
+        return action_type, {"primary", "confirm"}
+    raise MedicAuthorizationError("unsupported medic action type")
+
+
+def verify_envelope(
+    envelope: Mapping[str, Any],
+    *,
+    authorized_keys: Mapping[str, AuthorizedKey],
+    instance_id: str,
+    now: datetime | None = None,
+    max_ttl: timedelta = DEFAULT_MAX_TTL,
+    clock_skew: timedelta = DEFAULT_CLOCK_SKEW,
+) -> VerifiedTask:
+    """Validate structure, lifetime, instance binding, and every signature."""
+
+    if not isinstance(envelope, dict) or set(envelope) != {"task", "signatures"}:
+        raise MedicAuthorizationError("envelope must contain only task and signatures")
+    task = envelope.get("task")
+    signatures = envelope.get("signatures")
+    if not isinstance(task, dict) or set(task) != TASK_FIELDS:
+        raise MedicAuthorizationError("task fields do not match the version 1 schema")
+    if task.get("version") != 1:
+        raise MedicAuthorizationError("unsupported task version")
+    for field in ("task_id", "instance_id", "nonce"):
+        value = task.get(field)
+        if not isinstance(value, str) or not value:
+            raise MedicAuthorizationError(f"{field} must be a non-empty string")
+    try:
+        uuid.UUID(task["task_id"])
+    except (ValueError, AttributeError) as exc:
+        raise MedicAuthorizationError("task_id must be a UUID") from exc
+    if task["instance_id"] != instance_id:
+        raise MedicAuthorizationError("task targets a different instance")
+    if not SAFE_NAME.fullmatch(task["instance_id"]):
+        raise MedicAuthorizationError("instance_id contains unsupported characters")
+    nonce = _b64decode(task["nonce"], field="nonce")
+    if len(nonce) < 16:
+        raise MedicAuthorizationError("nonce must contain at least 128 bits")
+
+    issued = _parse_time(task.get("issued_at"), field="issued_at")
+    expires = _parse_time(task.get("expires_at"), field="expires_at")
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    if expires <= issued:
+        raise MedicAuthorizationError("expires_at must be after issued_at")
+    if expires - issued > max_ttl:
+        raise MedicAuthorizationError("task lifetime exceeds the configured maximum")
+    if issued > current + clock_skew:
+        raise MedicAuthorizationError("task was issued too far in the future")
+    if current >= expires:
+        raise MedicAuthorizationError("task has expired")
+
+    _action_type, required_roles = _validate_action(task.get("action"))
+    if not isinstance(signatures, list) or not signatures:
+        raise MedicAuthorizationError("signatures must be a non-empty list")
+
+    signed_bytes = canonical_task_bytes(task)
+    signer_roles: set[str] = set()
+    signer_keys: set[bytes] = set()
+    seen_key_ids: set[str] = set()
+    for entry in signatures:
+        if not isinstance(entry, dict) or set(entry) != SIGNATURE_FIELDS:
+            raise MedicAuthorizationError("signature entry fields are invalid")
+        key_id = entry.get("key_id")
+        if not isinstance(key_id, str) or not SAFE_NAME.fullmatch(key_id):
+            raise MedicAuthorizationError("signature key_id is invalid")
+        if key_id in seen_key_ids:
+            raise MedicAuthorizationError("duplicate signature key_id")
+        seen_key_ids.add(key_id)
+        authorized = authorized_keys.get(key_id)
+        if authorized is None:
+            raise MedicAuthorizationError(f"unknown signing key: {key_id}")
+        signature = _b64decode(entry.get("signature"), field="signature")
+        try:
+            authorized.public_key.verify(signature, signed_bytes)
+        except InvalidSignature as exc:
+            raise MedicAuthorizationError(
+                f"invalid signature for key: {key_id}"
+            ) from exc
+        raw_public = authorized.public_key.public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        if raw_public in signer_keys:
+            raise MedicAuthorizationError(
+                "one public key cannot satisfy multiple roles"
+            )
+        signer_keys.add(raw_public)
+        signer_roles.add(authorized.role)
+
+    missing = required_roles - signer_roles
+    if missing:
+        raise MedicAuthorizationError(
+            "missing required signature role(s): " + ", ".join(sorted(missing))
+        )
+    return VerifiedTask(task=dict(task), signer_roles=frozenset(signer_roles))
+
+
+class ReplayLedger:
+    """Small persistent nonce ledger with atomic replace semantics."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path).expanduser().resolve()
+
+    def _load(self) -> dict[str, str]:
+        if not self.path.exists():
+            return {}
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise MedicAuthorizationError("replay ledger is unreadable") from exc
+        if not isinstance(data, dict):
+            raise MedicAuthorizationError("replay ledger has an invalid format")
+        return {str(key): str(value) for key, value in data.items()}
+
+    def claim(
+        self,
+        nonce: str,
+        *,
+        expires_at: str,
+        now: datetime | None = None,
+    ) -> None:
+        """Persist a nonce before execution; raise when it was already claimed."""
+
+        self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        with lock_path.open("a+", encoding="utf-8") as lock:
+            os.fchmod(lock.fileno(), 0o600)
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+            ledger = self._load()
+            retained: dict[str, str] = {}
+            for key, expiry in ledger.items():
+                try:
+                    if _parse_time(expiry, field="ledger expiry") > current:
+                        retained[key] = expiry
+                except MedicAuthorizationError as exc:
+                    raise MedicAuthorizationError(
+                        "replay ledger contains an invalid expiry"
+                    ) from exc
+            if nonce in retained:
+                raise MedicAuthorizationError("task nonce has already been used")
+            retained[nonce] = expires_at
+            fd, temp_name = tempfile.mkstemp(
+                prefix=f".{self.path.name}.",
+                dir=str(self.path.parent),
+            )
+            try:
+                os.fchmod(fd, 0o600)
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    json.dump(retained, handle, sort_keys=True, separators=(",", ":"))
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(temp_name, self.path)
+                directory_fd = os.open(self.path.parent, os.O_RDONLY)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+            finally:
+                if os.path.exists(temp_name):
+                    os.unlink(temp_name)

--- a/ops/resilience/templates/linux-systemd-user.service.template
+++ b/ops/resilience/templates/linux-systemd-user.service.template
@@ -1,0 +1,20 @@
+[Unit]
+Description=DevBrain resilience watchdog
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=@DEVBRAIN_HOME@
+ExecStart=@PYTHON@ -m ops.resilience --config @CONFIG_PATH@ watch
+Environment=@DEVBRAIN_ENV@
+Environment=@HOME_ENV@
+Environment=@PATH_ENV@
+UMask=0077
+Restart=always
+RestartSec=30
+StandardOutput=@STDOUT_TARGET@
+StandardError=@STDERR_TARGET@
+
+[Install]
+WantedBy=default.target

--- a/ops/resilience/templates/macos-launchagent.plist.template
+++ b/ops/resilience/templates/macos-launchagent.plist.template
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>@LABEL@</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>@PYTHON@</string>
+        <string>-m</string>
+        <string>ops.resilience</string>
+        <string>--config</string>
+        <string>@CONFIG_PATH@</string>
+        <string>watch</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>@DEVBRAIN_HOME@</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>DEVBRAIN_HOME</key>
+        <string>@DEVBRAIN_HOME@</string>
+        <key>HOME</key>
+        <string>@HOME@</string>
+        <key>PATH</key>
+        <string>@PATH@</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>Umask</key>
+    <integer>63</integer>
+
+    <key>StandardOutPath</key>
+    <string>@STDOUT_PATH@</string>
+    <key>StandardErrorPath</key>
+    <string>@STDERR_PATH@</string>
+</dict>
+</plist>

--- a/ops/resilience/templates/macos-launchdaemon.plist.template
+++ b/ops/resilience/templates/macos-launchdaemon.plist.template
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>@LABEL@</string>
+
+    <key>UserName</key>
+    <string>@RUN_AS_USER@</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>@PYTHON@</string>
+        <string>-m</string>
+        <string>ops.resilience</string>
+        <string>--config</string>
+        <string>@CONFIG_PATH@</string>
+        <string>watch</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>@DEVBRAIN_HOME@</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>DEVBRAIN_HOME</key>
+        <string>@DEVBRAIN_HOME@</string>
+        <key>HOME</key>
+        <string>@HOME@</string>
+        <key>PATH</key>
+        <string>@PATH@</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>Umask</key>
+    <integer>63</integer>
+
+    <key>StandardOutPath</key>
+    <string>@STDOUT_PATH@</string>
+    <key>StandardErrorPath</key>
+    <string>@STDERR_PATH@</string>
+</dict>
+</plist>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pyyaml>=6.0
 textual>=0.80
 google-auth>=2.0
 google-api-python-client>=2.0
+cryptography>=42.0
 # Anthropic SDK used by cognify_extract + cognify_edges (LLM-cost passes).
 # Cognify's code path degrades gracefully on ImportError (logs a warning and
 # skips the LLM call), so the package is technically optional for non-LLM

--- a/scripts/install-resilience.sh
+++ b/scripts/install-resilience.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Install, render, dry-run, or uninstall the DevBrain resilience service.
+#
+# The Python module owns validation and service-manager operations. Unknown
+# flags are intentionally rejected by argparse; this wrapper does not silently
+# discard installer options.
+#
+# Examples:
+#   bash scripts/install-resilience.sh --profile workstation
+#   bash scripts/install-resilience.sh --profile studio --dry-run
+#   bash scripts/install-resilience.sh --with-heartbeat \
+#       --heartbeat-url https://health.example.invalid/ping
+#   bash scripts/install-resilience.sh --restart
+#   bash scripts/install-resilience.sh --uninstall --yes
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEVBRAIN_HOME="${DEVBRAIN_HOME:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+if [[ -n "${DEVBRAIN_PYTHON:-}" ]]; then
+    PYTHON="$DEVBRAIN_PYTHON"
+elif [[ -x "$DEVBRAIN_HOME/.venv/bin/python" ]]; then
+    PYTHON="$DEVBRAIN_HOME/.venv/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+    PYTHON="$(command -v python3)"
+else
+    echo "Error: Python 3 is required (set DEVBRAIN_PYTHON to its path)." >&2
+    exit 1
+fi
+
+export DEVBRAIN_HOME
+cd "$DEVBRAIN_HOME"
+exec "$PYTHON" -m ops.resilience.install "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,6 +12,8 @@
 #   ./scripts/install.sh              # Interactive (prompts for optional steps)
 #   ./scripts/install.sh --yes        # Accept all defaults (non-interactive)
 #   ./scripts/install.sh --no-pkrelay # Skip PKRelay prompt
+#   ./scripts/install.sh --profile=studio
+#   ./scripts/install.sh --with-resilience
 #
 # Requirements: macOS (Apple Silicon or Intel) or Linux (Debian/Ubuntu).
 # Other Linux distros may need manual dep installation — see INSTALL.md.
@@ -59,15 +61,305 @@ AUTO_YES=false
 SKIP_PKRELAY=false
 SKIP_SETUP=false
 SKIP_SHIMS=false
+DEPLOYMENT_PROFILE="workstation"
+DEPLOYMENT_PROFILE_EXPLICIT=false
+CONTAINER_RUNTIME=""
+CONTAINER_RUNTIME_EXPLICIT=false
+DOCKER_CONTEXT_NAME=""
+INSTALL_TARGET_PATH="$HOME/.devbrain/install-target.json"
+RECORDED_DEPLOYMENT_PROFILE=""
+RECORDED_CONTAINER_RUNTIME=""
+RECORDED_DOCKER_CONTEXT=""
+WITH_RESILIENCE=false
+NO_RESILIENCE=false
+WITH_HEARTBEAT=false
+WITH_TUNNEL_CHECK=false
+WITH_AGENT_BUS_CHECK=false
+WITH_BACKUP_CHECK=false
+BACKUP_PATH=""
+WITH_MEDIC=""
+MEDIC_INSTANCE_ID=""
+MEDIC_PRIMARY_PUBLIC_KEY=""
+MEDIC_CONFIRM_PUBLIC_KEY=""
+MEDIC_ALLOW_CHECKS=()
 
-for arg in "$@"; do
-    case "$arg" in
-        --yes|-y) AUTO_YES=true ;;
-        --no-pkrelay) SKIP_PKRELAY=true ;;
-        --no-setup) SKIP_SETUP=true ;;
-        --no-shims) SKIP_SHIMS=true ;;
+print_usage() {
+    cat <<'EOF'
+Usage: ./scripts/install.sh [options]
+
+Core options:
+  --yes, -y                         Accept existing installer defaults
+  --no-pkrelay                      Skip the PKRelay prompt
+  --no-setup                        Skip the interactive setup wizard
+  --no-shims                        Skip global command shims
+
+Deployment options:
+  --profile=workstation|studio      Workstation is the default; studio enables
+                                    the local resilience service by default
+  --container-runtime=RUNTIME       docker-desktop, docker-engine, colima,
+                                    or orbstack
+  --with-resilience                 Install the local self-healing service
+  --no-resilience                   Do not install it (overrides profile default)
+  --with-heartbeat                  Add an external heartbeat check; reads
+                                    DEVBRAIN_HEARTBEAT_URL from env or .env
+  --with-tunnel-check               Monitor a tunnel service; reads
+                                    DEVBRAIN_TUNNEL_LABEL from env or .env
+  --with-agent-bus-check            Monitor agent-bus; reads its health URL
+                                    from env or .env
+  --with-backup-check               Monitor output from an existing backup job
+  --backup-path=PATH                Backup file/directory to monitor; may also
+                                    be set as DEVBRAIN_BACKUP_PATH
+  --with-medic=diagnose|heal        Enable the signed local medic queue
+  --medic-primary-public-key=PATH   Off-host primary public key file
+  --medic-confirm-public-key=PATH   Distinct confirm public key (heal only)
+  --medic-allow-check=CHECK         Named recovery a heal task may request;
+                                    repeat for additional checks
+  --medic-instance-id=ID            Stable target name (defaults to hostname)
+
+Remote checks are optional. Resilience works locally without a VPS.
+Medic private signing keys must remain off the DevBrain host.
+EOF
+}
+
+# Parse inside a function so `shift` consumes only the function's positional
+# arguments. The script-level "$@" remains intact for bootstrap_clone, which
+# must forward every flag to the newly cloned installer.
+parse_install_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --yes|-y) AUTO_YES=true ;;
+            --no-pkrelay) SKIP_PKRELAY=true ;;
+            --no-setup) SKIP_SETUP=true ;;
+            --no-shims) SKIP_SHIMS=true ;;
+            --profile=*)
+                DEPLOYMENT_PROFILE="${1#*=}"
+                DEPLOYMENT_PROFILE_EXPLICIT=true
+                ;;
+            --profile)
+                shift
+                [[ $# -gt 0 ]] || { echo "Error: --profile requires a value" >&2; exit 2; }
+                DEPLOYMENT_PROFILE="$1"
+                DEPLOYMENT_PROFILE_EXPLICIT=true
+                ;;
+            --container-runtime=*)
+                CONTAINER_RUNTIME="${1#*=}"
+                CONTAINER_RUNTIME_EXPLICIT=true
+                ;;
+            --container-runtime)
+                shift
+                [[ $# -gt 0 ]] || { echo "Error: --container-runtime requires a value" >&2; exit 2; }
+                CONTAINER_RUNTIME="$1"
+                CONTAINER_RUNTIME_EXPLICIT=true
+                ;;
+            --with-resilience) WITH_RESILIENCE=true ;;
+            --no-resilience) NO_RESILIENCE=true ;;
+            --with-heartbeat) WITH_HEARTBEAT=true ;;
+            --with-tunnel-check) WITH_TUNNEL_CHECK=true ;;
+            --with-agent-bus-check) WITH_AGENT_BUS_CHECK=true ;;
+            --with-backup-check) WITH_BACKUP_CHECK=true ;;
+            --backup-path=*) BACKUP_PATH="${1#*=}" ;;
+            --backup-path)
+                shift
+                [[ $# -gt 0 ]] || { echo "Error: --backup-path requires a path" >&2; exit 2; }
+                BACKUP_PATH="$1"
+                ;;
+            --with-medic=*) WITH_MEDIC="${1#*=}" ;;
+            --with-medic)
+                shift
+                [[ $# -gt 0 ]] || { echo "Error: --with-medic requires diagnose or heal" >&2; exit 2; }
+                WITH_MEDIC="$1"
+                ;;
+            --medic-instance-id=*) MEDIC_INSTANCE_ID="${1#*=}" ;;
+            --medic-instance-id)
+                shift
+                [[ $# -gt 0 ]] || { echo "Error: --medic-instance-id requires a value" >&2; exit 2; }
+                MEDIC_INSTANCE_ID="$1"
+                ;;
+            --medic-primary-public-key=*) MEDIC_PRIMARY_PUBLIC_KEY="${1#*=}" ;;
+            --medic-primary-public-key)
+                shift
+                [[ $# -gt 0 ]] || { echo "Error: --medic-primary-public-key requires a path" >&2; exit 2; }
+                MEDIC_PRIMARY_PUBLIC_KEY="$1"
+                ;;
+            --medic-confirm-public-key=*) MEDIC_CONFIRM_PUBLIC_KEY="${1#*=}" ;;
+            --medic-confirm-public-key)
+                shift
+                [[ $# -gt 0 ]] || { echo "Error: --medic-confirm-public-key requires a path" >&2; exit 2; }
+                MEDIC_CONFIRM_PUBLIC_KEY="$1"
+                ;;
+            --medic-allow-check=*) MEDIC_ALLOW_CHECKS+=("${1#*=}") ;;
+            --medic-allow-check)
+                shift
+                [[ $# -gt 0 ]] || { echo "Error: --medic-allow-check requires a check ID" >&2; exit 2; }
+                MEDIC_ALLOW_CHECKS+=("$1")
+                ;;
+            --help|-h)
+                print_usage
+                exit 0
+                ;;
+            *)
+                echo "Error: unknown installer option: $1" >&2
+                echo "Run ./scripts/install.sh --help for supported options." >&2
+                exit 2
+                ;;
+        esac
+        shift
+    done
+}
+parse_install_args "$@"
+
+load_existing_install_target() {
+    if [[ -L "$INSTALL_TARGET_PATH" ]] || {
+        [[ -e "$INSTALL_TARGET_PATH" ]] && [[ ! -f "$INSTALL_TARGET_PATH" ]]
+    }; then
+        echo "Error: install target metadata is not a regular file: $INSTALL_TARGET_PATH" >&2
+        exit 1
+    fi
+    [[ -f "$INSTALL_TARGET_PATH" ]] || return 0
+
+    local metadata_python="$DEVBRAIN_HOME/.venv/bin/python"
+    if [[ ! -x "$metadata_python" ]]; then
+        metadata_python="$(command -v python3 2>/dev/null || true)"
+    fi
+    if [[ -z "$metadata_python" ]]; then
+        echo "Error: Python is required to validate $INSTALL_TARGET_PATH" >&2
+        exit 1
+    fi
+
+    local recorded
+    if ! recorded="$("$metadata_python" - "$INSTALL_TARGET_PATH" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1]).expanduser().resolve()
+try:
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"install target metadata is unreadable: {exc}") from exc
+expected = {
+    "schema_version",
+    "generated_by",
+    "profile",
+    "container_runtime",
+    "docker_context",
+}
+if not isinstance(metadata, dict) or set(metadata) != expected:
+    raise SystemExit("install target metadata fields are invalid")
+if (
+    metadata.get("schema_version") != 2
+    or metadata.get("generated_by") != "devbrain-installer"
+):
+    raise SystemExit("install target metadata identity is invalid")
+profile = metadata.get("profile")
+runtime = metadata.get("container_runtime")
+context = metadata.get("docker_context")
+if profile not in {"workstation", "studio"}:
+    raise SystemExit("install target metadata has an invalid profile")
+if runtime not in {"colima", "docker-desktop", "docker-engine", "orbstack"}:
+    raise SystemExit("install target metadata has an invalid runtime")
+if not isinstance(context, str) or not re.fullmatch(
+    r"[A-Za-z0-9][-A-Za-z0-9._+]*", context
+):
+    raise SystemExit("install target metadata has an invalid Docker context")
+sys.stdout.write(f"{profile}\t{runtime}\t{context}")
+PY
+    )"; then
+        echo "Error: refusing to overwrite invalid install target metadata" >&2
+        exit 1
+    fi
+    IFS=$'\t' read -r RECORDED_DEPLOYMENT_PROFILE \
+        RECORDED_CONTAINER_RUNTIME RECORDED_DOCKER_CONTEXT <<< "$recorded"
+}
+load_existing_install_target
+
+if [[ -n "$RECORDED_DEPLOYMENT_PROFILE" ]] \
+   && ! $DEPLOYMENT_PROFILE_EXPLICIT; then
+    DEPLOYMENT_PROFILE="$RECORDED_DEPLOYMENT_PROFILE"
+fi
+
+case "$DEPLOYMENT_PROFILE" in
+    workstation|studio) ;;
+    *)
+        echo "Error: --profile must be workstation or studio" >&2
+        exit 2
+        ;;
+esac
+
+if [[ -n "$RECORDED_CONTAINER_RUNTIME" ]]; then
+    if $CONTAINER_RUNTIME_EXPLICIT \
+       && [[ "$CONTAINER_RUNTIME" != "$RECORDED_CONTAINER_RUNTIME" ]]; then
+        echo "Error: this install is recorded on runtime '$RECORDED_CONTAINER_RUNTIME'." >&2
+        echo "Refusing to switch to '$CONTAINER_RUNTIME' without an explicit database migration." >&2
+        exit 2
+    fi
+    CONTAINER_RUNTIME="$RECORDED_CONTAINER_RUNTIME"
+    DOCKER_CONTEXT_NAME="$RECORDED_DOCKER_CONTEXT"
+elif [[ -z "$CONTAINER_RUNTIME" ]]; then
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        CONTAINER_RUNTIME="docker-engine"
+    elif [[ "$DEPLOYMENT_PROFILE" == "studio" ]]; then
+        CONTAINER_RUNTIME="colima"
+    else
+        CONTAINER_RUNTIME="docker-desktop"
+    fi
+fi
+case "$CONTAINER_RUNTIME" in
+    colima|docker-desktop|docker-engine|orbstack) ;;
+    *)
+        echo "Error: --container-runtime must be docker-desktop, docker-engine, colima, or orbstack" >&2
+        exit 2
+        ;;
+esac
+if [[ -z "$DOCKER_CONTEXT_NAME" ]]; then
+    case "$CONTAINER_RUNTIME" in
+        colima) DOCKER_CONTEXT_NAME="colima" ;;
+        docker-desktop) DOCKER_CONTEXT_NAME="desktop-linux" ;;
+        docker-engine) DOCKER_CONTEXT_NAME="default" ;;
+        orbstack) DOCKER_CONTEXT_NAME="orbstack" ;;
     esac
-done
+fi
+
+if $WITH_RESILIENCE && $NO_RESILIENCE; then
+    echo "Error: --with-resilience and --no-resilience cannot be used together" >&2
+    exit 2
+fi
+case "$WITH_MEDIC" in
+    ""|diagnose|heal) ;;
+    *)
+        echo "Error: --with-medic must be diagnose or heal" >&2
+        exit 2
+        ;;
+esac
+if [[ -z "$WITH_MEDIC" ]] && {
+    [[ -n "$MEDIC_INSTANCE_ID" ]] ||
+    [[ -n "$MEDIC_PRIMARY_PUBLIC_KEY" ]] ||
+    [[ -n "$MEDIC_CONFIRM_PUBLIC_KEY" ]] ||
+    [[ ${#MEDIC_ALLOW_CHECKS[@]} -gt 0 ]]
+}; then
+    echo "Error: medic options require --with-medic=diagnose|heal" >&2
+    exit 2
+fi
+if ! $WITH_BACKUP_CHECK && [[ -n "$BACKUP_PATH" ]]; then
+    echo "Error: --backup-path requires --with-backup-check" >&2
+    exit 2
+fi
+if $NO_RESILIENCE && {
+    $WITH_HEARTBEAT ||
+    $WITH_TUNNEL_CHECK ||
+    $WITH_AGENT_BUS_CHECK ||
+    $WITH_BACKUP_CHECK ||
+    [[ -n "$WITH_MEDIC" ]]
+}; then
+    echo "Error: resilience options cannot be combined with --no-resilience" >&2
+    exit 2
+fi
+# Selecting any optional check is also an explicit request for the resilience
+# service. This makes `--with-heartbeat` useful on a workstation under --yes.
+if $WITH_HEARTBEAT || $WITH_TUNNEL_CHECK || $WITH_AGENT_BUS_CHECK || $WITH_BACKUP_CHECK || [[ -n "$WITH_MEDIC" ]]; then
+    WITH_RESILIENCE=true
+fi
 
 # ─── Formatting ─────────────────────────────────────────────────────────────
 
@@ -697,33 +989,42 @@ install_docker() {
     desc "Runs PostgreSQL + pgvector in a container. DevBrain stores all"
     desc "memory, sessions, and factory state in this database."
 
-    if command -v docker &>/dev/null; then
-        skip "Docker $(docker --version 2>/dev/null | awk '{print $3}' | tr -d ',')"
-        # Even if Docker is already installed, kick the daemon if it's
-        # not running so it's ready by the Postgres step.
-        if [[ "$OS" == "macos" ]] && ! docker info &>/dev/null 2>&1; then
-            _launch_docker_in_background
-        fi
-    elif [[ "$OS" == "macos" ]]; then
-        desc "(Alternatives: Colima or OrbStack — see INSTALL.md)"
-        if _run "Installing Docker Desktop via Homebrew" brew install --cask docker-desktop; then
-            ok "Docker Desktop installed"
+    if [[ "$OS" == "macos" ]]; then
+        # A Docker CLI installed for Colima is not evidence that Docker
+        # Desktop exists. The chosen backend must be installed independently
+        # so another running context cannot make this selection look healthy.
+        if [[ -d /Applications/Docker.app ]]; then
+            skip "Docker Desktop"
         else
-            warn "Homebrew cask install failed."
-            warn "Most common cause on Sequoia/Tahoe: the terminal lacks"
-            warn "App Management permission, so brew can't set xattrs on"
-            warn "files inside /Applications/Docker.app."
-            info "Falling back to Docker's own DMG installer..."
-            if _install_docker_desktop_from_dmg; then
-                ok "Docker Desktop installed via DMG"
+            desc "(Alternatives: Colima or OrbStack — see INSTALL.md)"
+            if _run "Installing Docker Desktop via Homebrew" brew install --cask docker-desktop; then
+                ok "Docker Desktop installed"
             else
-                fail "Docker Desktop install failed both ways."
-                fail "Manual install: https://www.docker.com/products/docker-desktop"
-                fail "Then re-run this installer — it will detect Docker and continue."
-                return 1
+                warn "Homebrew cask install failed."
+                warn "Most common cause on Sequoia/Tahoe: the terminal lacks"
+                warn "App Management permission, so brew can't set xattrs on"
+                warn "files inside /Applications/Docker.app."
+                info "Falling back to Docker's own DMG installer..."
+                if _install_docker_desktop_from_dmg; then
+                    ok "Docker Desktop installed via DMG"
+                else
+                    fail "Docker Desktop install failed both ways."
+                    fail "Manual install: https://www.docker.com/products/docker-desktop"
+                    fail "Then re-run this installer — it will detect Docker and continue."
+                    return 1
+                fi
             fi
         fi
-        _launch_docker_in_background
+        if ! command -v docker &>/dev/null; then
+            fail "Docker Desktop is installed, but the Docker CLI is not in PATH."
+            fail "Open Docker Desktop once, then re-run the installer."
+            return 1
+        fi
+        if ! docker --context "$DOCKER_CONTEXT_NAME" info &>/dev/null 2>&1; then
+            _launch_docker_in_background
+        fi
+    elif command -v docker &>/dev/null; then
+        skip "Docker $(docker --version 2>/dev/null | awk '{print $3}' | tr -d ',')"
     else
         info "Installing Docker Engine..."
         curl -fsSL https://get.docker.com | sh
@@ -734,6 +1035,96 @@ install_docker() {
             sudo systemctl start docker 2>/dev/null || true
         fi
     fi
+}
+
+ensure_docker_compose_plugin() {
+    if docker compose version &>/dev/null 2>&1; then
+        return 0
+    fi
+
+    local plugin_source
+    plugin_source="$(command -v docker-compose 2>/dev/null || true)"
+    if [[ -z "$plugin_source" ]]; then
+        fail "Docker Compose plugin is unavailable after installation."
+        return 1
+    fi
+
+    local plugin_dir="$HOME/.docker/cli-plugins"
+    local plugin_target="$plugin_dir/docker-compose"
+    mkdir -p "$plugin_dir"
+    chmod 700 "$plugin_dir"
+    if [[ ! -e "$plugin_target" && ! -L "$plugin_target" ]]; then
+        ln -s "$plugin_source" "$plugin_target"
+    fi
+    if ! docker compose version &>/dev/null 2>&1; then
+        fail "Docker Compose plugin is not discoverable at $plugin_target."
+        fail "Resolve the existing plugin path, then re-run the installer."
+        return 1
+    fi
+}
+
+install_colima() {
+    step "Container runtime (Colima)"
+    desc "Colima provides a lightweight Docker-compatible VM without"
+    desc "requiring Docker Desktop. It is the default for studio installs."
+
+    if [[ "$OS" != "macos" ]]; then
+        fail "Colima installation is supported by this installer only on macOS."
+        fail "Use --container-runtime=docker-engine on Linux."
+        return 1
+    fi
+
+    local packages=""
+    command -v colima &>/dev/null || packages+=" colima"
+    command -v docker &>/dev/null || packages+=" docker"
+    if ! docker compose version &>/dev/null 2>&1; then
+        packages+=" docker-compose"
+    fi
+    if [[ -n "$packages" ]]; then
+        # shellcheck disable=SC2086
+        _run "Installing Colima and Docker CLI via Homebrew" brew install $packages
+        ok "Colima container runtime installed"
+    else
+        skip "Colima and Docker CLI"
+    fi
+    ensure_docker_compose_plugin
+
+    if ! colima status &>/dev/null 2>&1; then
+        info "Starting Colima..."
+        _run "Starting Colima VM" colima start
+    fi
+}
+
+install_orbstack() {
+    step "Container runtime (OrbStack)"
+    desc "OrbStack provides a Docker-compatible macOS runtime. A VPS is"
+    desc "not required; it runs the DevBrain database entirely on this Mac."
+
+    if [[ "$OS" != "macos" ]]; then
+        fail "OrbStack is available only on macOS."
+        fail "Use --container-runtime=docker-engine on Linux."
+        return 1
+    fi
+
+    if [[ -d /Applications/OrbStack.app ]] || command -v orb &>/dev/null; then
+        skip "OrbStack"
+    else
+        _run "Installing OrbStack via Homebrew" brew install --cask orbstack
+        ok "OrbStack installed"
+    fi
+
+    if ! docker --context "$DOCKER_CONTEXT_NAME" info &>/dev/null 2>&1; then
+        info "Launching OrbStack..."
+        open -a OrbStack 2>/dev/null || true
+    fi
+}
+
+install_container_runtime() {
+    case "$CONTAINER_RUNTIME" in
+        docker-desktop|docker-engine) install_docker ;;
+        colima) install_colima ;;
+        orbstack) install_orbstack ;;
+    esac
 }
 
 install_ollama() {
@@ -1135,6 +1526,7 @@ setup_config() {
     else
         skip ".env already exists"
     fi
+    chmod 600 "$DEVBRAIN_HOME/.env"
 
     if [[ ! -f "$DEVBRAIN_HOME/config/devbrain.yaml" ]]; then
         cp "$DEVBRAIN_HOME/config/devbrain.yaml.example" "$DEVBRAIN_HOME/config/devbrain.yaml"
@@ -1194,12 +1586,13 @@ setup_venvs() {
 }
 
 _wait_for_docker_daemon() {
-    # Poll `docker info` until the daemon responds, or timeout. Prints
+    # Poll the selected Docker context until its daemon responds. Prints
     # a progress dot per second so the user knows we're still alive.
     local max_wait="${1:-60}"
+    local context="${2:-$DOCKER_CONTEXT_NAME}"
     local waited=0
     echo -n "  Waiting for Docker daemon"
-    while ! docker info &>/dev/null 2>&1; do
+    while ! docker --context "$context" info &>/dev/null 2>&1; do
         sleep 1
         waited=$((waited + 1))
         echo -n "."
@@ -1222,8 +1615,8 @@ ensure_docker_ready() {
     desc "DevBrain's database runs in a Docker container. Before we can"
     desc "start it, the Docker daemon needs to be fully running."
 
-    if docker info &>/dev/null 2>&1; then
-        ok "Docker daemon is already running"
+    if docker --context "$DOCKER_CONTEXT_NAME" info &>/dev/null 2>&1; then
+        ok "Docker context '$DOCKER_CONTEXT_NAME' is already running"
         return 0
     fi
 
@@ -1255,8 +1648,8 @@ ensure_docker_ready() {
         fi
 
         info "Verifying Docker daemon..."
-        if _wait_for_docker_daemon 20; then
-            ok "Docker daemon responding"
+        if _wait_for_docker_daemon 20 "$DOCKER_CONTEXT_NAME"; then
+            ok "Docker context '$DOCKER_CONTEXT_NAME' is responding"
             return 0
         fi
 
@@ -1267,6 +1660,67 @@ ensure_docker_ready() {
         fi
         warn "Daemon still not responding. Check Docker Desktop."
     done
+}
+
+ensure_container_runtime_ready() {
+    if [[ "$CONTAINER_RUNTIME" == "docker-desktop" || "$CONTAINER_RUNTIME" == "docker-engine" ]]; then
+        ensure_docker_ready
+        export DOCKER_CONTEXT="$DOCKER_CONTEXT_NAME"
+        return
+    fi
+
+    step "Container runtime check"
+    desc "DevBrain's database uses the Docker-compatible API exposed by"
+    desc "$CONTAINER_RUNTIME. The runtime must be ready before DB startup."
+
+    if docker --context "$DOCKER_CONTEXT_NAME" info &>/dev/null 2>&1; then
+        ok "$CONTAINER_RUNTIME context '$DOCKER_CONTEXT_NAME' is already responding"
+        export DOCKER_CONTEXT="$DOCKER_CONTEXT_NAME"
+        return 0
+    fi
+
+    case "$CONTAINER_RUNTIME" in
+        colima)
+            info "Starting Colima..."
+            colima start
+            ;;
+        orbstack)
+            info "Launching OrbStack..."
+            open -a OrbStack 2>/dev/null || true
+            ;;
+    esac
+
+    info "Waiting for the Docker-compatible daemon..."
+    if _wait_for_docker_daemon 120 "$DOCKER_CONTEXT_NAME"; then
+        export DOCKER_CONTEXT="$DOCKER_CONTEXT_NAME"
+        ok "$CONTAINER_RUNTIME context '$DOCKER_CONTEXT_NAME' is responding"
+        return 0
+    fi
+
+    fail "$CONTAINER_RUNTIME did not become ready."
+    fail "Start it manually, verify 'docker --context $DOCKER_CONTEXT_NAME info', then re-run install-devbrain."
+    return 1
+}
+
+record_install_target() {
+    local target_dir
+    local temporary
+    target_dir="$(dirname "$INSTALL_TARGET_PATH")"
+    mkdir -p "$target_dir"
+    chmod 700 "$target_dir"
+    temporary="$(mktemp "$target_dir/.install-target.XXXXXX")"
+    chmod 600 "$temporary"
+    printf '%s\n' \
+        '{' \
+        '  "schema_version": 2,' \
+        '  "generated_by": "devbrain-installer",' \
+        "  \"profile\": \"$DEPLOYMENT_PROFILE\"," \
+        "  \"container_runtime\": \"$CONTAINER_RUNTIME\"," \
+        "  \"docker_context\": \"$DOCKER_CONTEXT_NAME\"" \
+        '}' >"$temporary"
+    mv "$temporary" "$INSTALL_TARGET_PATH"
+    chmod 600 "$INSTALL_TARGET_PATH"
+    ok "Recorded container target at $INSTALL_TARGET_PATH"
 }
 
 start_postgres() {
@@ -1469,6 +1923,104 @@ install_launchd() {
     else
         info "Skipped — run scripts/install-ingest-service.sh later if you want it."
     fi
+}
+
+# ─── Optional: local resilience / self-healing ─────────────────────────────
+
+install_resilience() {
+    step "Resilience service (optional self-healing)"
+    desc "Monitors the local container runtime, PostgreSQL, Ollama, ingest,"
+    desc "and disk space, then applies bounded recovery actions."
+    desc "It works entirely on this machine; a VPS is not required."
+
+    local enable=false
+    if $NO_RESILIENCE; then
+        enable=false
+    elif $WITH_RESILIENCE; then
+        enable=true
+    elif [[ "$DEPLOYMENT_PROFILE" == "studio" ]]; then
+        enable=true
+    elif $AUTO_YES; then
+        # Preserve workstation --yes behavior: optional resilience is not
+        # silently installed unless the user selected --with-resilience or
+        # one of its optional checks.
+        enable=false
+    elif ask_no "Install the local resilience service?"; then
+        enable=true
+    fi
+
+    if ! $enable; then
+        if $NO_RESILIENCE; then
+            info "Skipped (--no-resilience)"
+        else
+            info "Skipped. Add later with 'devbrain setup resilience'."
+        fi
+        return 0
+    fi
+
+    if [[ -n "$WITH_MEDIC" ]]; then
+        MEDIC_PRIMARY_PUBLIC_KEY="${MEDIC_PRIMARY_PUBLIC_KEY:-${DEVBRAIN_MEDIC_PRIMARY_PUBLIC_KEY_FILE:-}}"
+        if [[ "$WITH_MEDIC" == "heal" ]]; then
+            MEDIC_CONFIRM_PUBLIC_KEY="${MEDIC_CONFIRM_PUBLIC_KEY:-${DEVBRAIN_MEDIC_CONFIRM_PUBLIC_KEY_FILE:-}}"
+            if [[ ${#MEDIC_ALLOW_CHECKS[@]} -eq 0 ]]; then
+                fail "Medic heal mode requires at least one --medic-allow-check."
+                return 1
+            fi
+        fi
+    fi
+
+    local resilience_args=(
+        --profile "$DEPLOYMENT_PROFILE"
+        --container-runtime "$CONTAINER_RUNTIME"
+        --docker-context "$DOCKER_CONTEXT_NAME"
+    )
+    if $WITH_HEARTBEAT; then
+        resilience_args+=(--with-heartbeat)
+        if [[ -n "${DEVBRAIN_HEARTBEAT_URL:-}" ]]; then
+            resilience_args+=(--heartbeat-url "$DEVBRAIN_HEARTBEAT_URL")
+        fi
+    fi
+    if $WITH_TUNNEL_CHECK; then
+        resilience_args+=(--with-tunnel-check)
+        if [[ -n "${DEVBRAIN_TUNNEL_LABEL:-}" ]]; then
+            resilience_args+=(--tunnel-label "$DEVBRAIN_TUNNEL_LABEL")
+        fi
+    fi
+    if $WITH_AGENT_BUS_CHECK; then
+        resilience_args+=(--with-agent-bus-check)
+        if [[ -n "${DEVBRAIN_AGENT_BUS_HEALTH_URL:-}" ]]; then
+            resilience_args+=(--agent-bus-url "$DEVBRAIN_AGENT_BUS_HEALTH_URL")
+        fi
+    fi
+    if $WITH_BACKUP_CHECK; then
+        resilience_args+=(--with-backup-check)
+        if [[ -n "$BACKUP_PATH" ]]; then
+            resilience_args+=(--backup-path "$BACKUP_PATH")
+        fi
+    fi
+    if [[ -n "$WITH_MEDIC" ]]; then
+        resilience_args+=(--with-medic "$WITH_MEDIC")
+        if [[ -n "$MEDIC_PRIMARY_PUBLIC_KEY" ]]; then
+            resilience_args+=(--medic-primary-public-key "$MEDIC_PRIMARY_PUBLIC_KEY")
+        fi
+        if [[ -n "$MEDIC_INSTANCE_ID" ]]; then
+            resilience_args+=(--medic-instance-id "$MEDIC_INSTANCE_ID")
+        fi
+        if [[ "$WITH_MEDIC" == "heal" ]]; then
+            if [[ -n "$MEDIC_CONFIRM_PUBLIC_KEY" ]]; then
+                resilience_args+=(--medic-confirm-public-key "$MEDIC_CONFIRM_PUBLIC_KEY")
+            fi
+            local medic_check
+            for medic_check in "${MEDIC_ALLOW_CHECKS[@]}"; do
+                resilience_args+=(--medic-allow-check "$medic_check")
+            done
+        fi
+    fi
+
+    info "Installing $DEPLOYMENT_PROFILE resilience with $CONTAINER_RUNTIME recovery..."
+    DEVBRAIN_PYTHON="$DEVBRAIN_HOME/.venv/bin/python" \
+        bash "$DEVBRAIN_HOME/scripts/install-resilience.sh" "${resilience_args[@]}"
+    ok "Resilience service installed"
 }
 
 # ─── Optional: PKRelay ──────────────────────────────────────────────────────
@@ -1759,13 +2311,15 @@ main() {
     detect_os
     info "Detected: $OS ($ARCH)"
     info "DevBrain home: $DEVBRAIN_HOME"
+    info "Deployment profile: $DEPLOYMENT_PROFILE"
+    info "Container runtime: $CONTAINER_RUNTIME"
     echo ""
 
     # Prime sudo once up front so every downstream step (Homebrew bootstrap,
     # `brew install --cask docker` moving Docker.app into /Applications,
     # Linux apt-get, etc.) finds a cached credential. Prevents the sudo
     # Password: prompt from colliding with the quiet-mode spinner later.
-    _prime_sudo "DevBrain install needs sudo for a few system-level steps (Homebrew, Docker Desktop)."
+    _prime_sudo "DevBrain install needs sudo for a few system-level steps (Homebrew and system services)."
 
     # Phase 1: Foundation dependencies
     if [[ "$OS" == "macos" ]]; then
@@ -1781,11 +2335,11 @@ main() {
     install_gh
     install_psql
 
-    # Phase 3: Docker — install, then explicitly wait for user to complete
-    # Docker Desktop setup (license agreement). This is the main interactive
-    # checkpoint; everything after this phase runs unattended.
-    install_docker
-    ensure_docker_ready
+    # Phase 3: chosen Docker-compatible runtime. Workstations retain the
+    # Docker Desktop default; studio installs default to lightweight Colima.
+    install_container_runtime
+    ensure_container_runtime_ready
+    record_install_target
 
     # Phase 4: DB startup — now that Docker is confirmed running
     setup_config
@@ -1799,6 +2353,7 @@ main() {
     pull_models
     build_mcp
     install_launchd
+    install_resilience
 
     # Phase 6: AI CLIs (interactive prompts) + optional companions + finalization
     install_ai_clis

--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -8,11 +8,12 @@
 # without a fresh machine.
 #
 # Default: removes DevBrain repo + shims + Postgres data.
-# With --full: also removes Ollama models, Homebrew, and CLT (full reset).
+# With --full: also removes Docker Desktop, Ollama models, Homebrew, and CLT.
+# Colima/OrbStack VM and application data are not removed wholesale.
 #
 # Usage (sync to target machine and run):
 #   bash reinstall.sh             # quick reset (preserves Homebrew/Ollama/CLT)
-#   bash reinstall.sh --full      # nuclear reset
+#   bash reinstall.sh --full      # extended toolchain reset
 #   bash reinstall.sh --yes       # skip confirmation prompt
 #
 # Or directly from GitHub:
@@ -23,6 +24,12 @@ set -euo pipefail
 
 DEVBRAIN_HOME="${DEVBRAIN_HOME:-$HOME/devbrain}"
 PKRELAY_HOME="${PKRELAY_HOME:-$HOME/pkrelay}"
+RESILIENCE_MANIFEST="$HOME/.devbrain/resilience/install-manifest.json"
+INSTALL_TARGET_PATH="$HOME/.devbrain/install-target.json"
+TARGET_CONTAINER_RUNTIME=""
+TARGET_DOCKER_CONTEXT=""
+EXPLICIT_CONTAINER_RUNTIME=""
+EXPLICIT_DOCKER_CONTEXT=""
 
 # Anchor CWD to $HOME so that when DEVBRAIN_HOME gets deleted mid-script,
 # subshells (e.g., spawned by the Homebrew uninstaller) don't spam
@@ -34,12 +41,77 @@ cd "$HOME"
 FULL_RESET=false
 AUTO_YES=false
 
-for arg in "$@"; do
-    case "$arg" in
-        --full) FULL_RESET=true ;;
-        --yes|-y) AUTO_YES=true ;;
+print_usage() {
+    cat <<'EOF'
+Usage: bash scripts/reinstall.sh [options]
+
+  --full                           Also reset the documented toolchain items
+  --yes, -y                        Skip the confirmation prompt
+  --container-runtime=RUNTIME      Required with --docker-context when an
+                                   older install has no target metadata
+  --docker-context=CONTEXT         Exact Docker context containing DevBrain
+  --help, -h                       Show this help
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --full) FULL_RESET=true ;;
+            --yes|-y) AUTO_YES=true ;;
+            --container-runtime=*)
+                EXPLICIT_CONTAINER_RUNTIME="${1#*=}"
+                ;;
+            --container-runtime)
+                shift
+                [[ $# -gt 0 ]] || {
+                    echo "Error: --container-runtime requires a value" >&2
+                    exit 2
+                }
+                EXPLICIT_CONTAINER_RUNTIME="$1"
+                ;;
+            --docker-context=*)
+                EXPLICIT_DOCKER_CONTEXT="${1#*=}"
+                ;;
+            --docker-context)
+                shift
+                [[ $# -gt 0 ]] || {
+                    echo "Error: --docker-context requires a value" >&2
+                    exit 2
+                }
+                EXPLICIT_DOCKER_CONTEXT="$1"
+                ;;
+            --help|-h)
+                print_usage
+                exit 0
+                ;;
+            *)
+                echo "Error: unknown reinstall option: $1" >&2
+                exit 2
+                ;;
+        esac
+        shift
+    done
+}
+parse_args "$@"
+
+if [[ -n "$EXPLICIT_CONTAINER_RUNTIME" || -n "$EXPLICIT_DOCKER_CONTEXT" ]]; then
+    if [[ -z "$EXPLICIT_CONTAINER_RUNTIME" || -z "$EXPLICIT_DOCKER_CONTEXT" ]]; then
+        echo "Error: --container-runtime and --docker-context must be used together" >&2
+        exit 2
+    fi
+    case "$EXPLICIT_CONTAINER_RUNTIME" in
+        colima|docker-desktop|docker-engine|orbstack) ;;
+        *)
+            echo "Error: unsupported --container-runtime" >&2
+            exit 2
+            ;;
     esac
-done
+    if [[ ! "$EXPLICIT_DOCKER_CONTEXT" =~ ^[A-Za-z0-9][-A-Za-z0-9._+]*$ ]]; then
+        echo "Error: --docker-context contains unsupported characters" >&2
+        exit 2
+    fi
+fi
 
 # ─── Colors ─────────────────────────────────────────────────────────────────
 
@@ -68,6 +140,190 @@ ask_yn() {
     [[ "$answer" =~ ^[Yy] ]]
 }
 
+_capture_container_target() {
+    if [[ -L "$INSTALL_TARGET_PATH" ]] || {
+        [[ -e "$INSTALL_TARGET_PATH" ]] && [[ ! -f "$INSTALL_TARGET_PATH" ]]
+    }; then
+        warn "Install target metadata is not a regular file:"
+        warn "  $INSTALL_TARGET_PATH"
+        return 1
+    fi
+    if [[ ! -f "$RESILIENCE_MANIFEST" && ! -f "$INSTALL_TARGET_PATH" ]]; then
+        if [[ -n "$EXPLICIT_CONTAINER_RUNTIME" ]]; then
+            TARGET_CONTAINER_RUNTIME="$EXPLICIT_CONTAINER_RUNTIME"
+            TARGET_DOCKER_CONTEXT="$EXPLICIT_DOCKER_CONTEXT"
+            return 0
+        fi
+        warn "No recorded DevBrain Docker target was found."
+        warn "For an older install, retry with both:"
+        warn "  --container-runtime=RUNTIME --docker-context=CONTEXT"
+        return 1
+    fi
+
+    local manifest_python="$DEVBRAIN_HOME/.venv/bin/python"
+    if [[ ! -x "$manifest_python" ]]; then
+        manifest_python="$(command -v python3 2>/dev/null || true)"
+    fi
+    if [[ -z "$manifest_python" ]]; then
+        warn "Python is required to validate DevBrain container metadata."
+        return 1
+    fi
+
+    local manifest_target
+    if ! manifest_target="$(
+        PYTHONPATH="$DEVBRAIN_HOME${PYTHONPATH:+:$PYTHONPATH}" \
+            "$manifest_python" - "$RESILIENCE_MANIFEST" \
+            "$INSTALL_TARGET_PATH" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1]).expanduser().resolve()
+target_path = Path(sys.argv[2]).expanduser().resolve()
+
+resilience_metadata = None
+if manifest_path.is_file():
+    from ops.resilience.install import _load_manifest
+
+    resilience_metadata = _load_manifest(manifest_path)
+    if resilience_metadata is None:
+        raise SystemExit(
+            "resilience manifest disappeared while it was being read"
+        )
+
+install_metadata = None
+if target_path.is_file():
+    try:
+        install_metadata = json.loads(target_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"install target metadata is unreadable: {exc}") from exc
+    expected = {
+        "schema_version",
+        "generated_by",
+        "profile",
+        "container_runtime",
+        "docker_context",
+    }
+    if not isinstance(install_metadata, dict) or set(install_metadata) != expected:
+        raise SystemExit("install target metadata fields are invalid")
+    if (
+        install_metadata.get("schema_version") != 2
+        or install_metadata.get("generated_by") != "devbrain-installer"
+    ):
+        raise SystemExit("install target metadata identity is invalid")
+    if install_metadata.get("profile") not in {"workstation", "studio"}:
+        raise SystemExit("install target metadata profile is invalid")
+if resilience_metadata is None and install_metadata is None:
+    raise SystemExit(
+        "container target metadata disappeared while it was being read"
+    )
+
+if resilience_metadata is not None and install_metadata is not None:
+    resilience_target = (
+        resilience_metadata.get("container_runtime"),
+        resilience_metadata.get("docker_context"),
+    )
+    install_target = (
+        install_metadata.get("container_runtime"),
+        install_metadata.get("docker_context"),
+    )
+    if resilience_target != install_target:
+        raise SystemExit(
+            "resilience and install target metadata disagree; "
+            "refusing destructive cleanup"
+        )
+
+metadata = install_metadata or resilience_metadata
+runtime = metadata.get("container_runtime")
+context = metadata.get("docker_context")
+if runtime not in {"colima", "docker-desktop", "docker-engine", "orbstack"}:
+    raise SystemExit("container metadata has an invalid runtime")
+if not isinstance(context, str) or not re.fullmatch(
+    r"[A-Za-z0-9][-A-Za-z0-9._+]*", context
+):
+    raise SystemExit("container metadata has an invalid Docker context")
+
+sys.stdout.write(f"{runtime}\t{context}")
+PY
+    )"; then
+        warn "Could not validate the recorded container target."
+        return 1
+    fi
+
+    IFS=$'\t' read -r TARGET_CONTAINER_RUNTIME \
+        TARGET_DOCKER_CONTEXT <<< "$manifest_target"
+    if [[ -z "$TARGET_CONTAINER_RUNTIME" || -z "$TARGET_DOCKER_CONTEXT" ]]; then
+        warn "Validated metadata did not identify its container target."
+        return 1
+    fi
+    if [[ -n "$EXPLICIT_CONTAINER_RUNTIME" ]] && {
+        [[ "$EXPLICIT_CONTAINER_RUNTIME" != "$TARGET_CONTAINER_RUNTIME" ]] ||
+        [[ "$EXPLICIT_DOCKER_CONTEXT" != "$TARGET_DOCKER_CONTEXT" ]]
+    }; then
+        warn "Explicit container target disagrees with recorded metadata."
+        warn "Refusing destructive cleanup; repair the metadata first."
+        return 1
+    fi
+}
+
+docker_for_devbrain() {
+    if [[ -n "$TARGET_DOCKER_CONTEXT" ]]; then
+        command docker --context "$TARGET_DOCKER_CONTEXT" "$@"
+    else
+        command docker "$@"
+    fi
+}
+
+_prepare_selected_container_runtime() {
+    [[ -n "$TARGET_DOCKER_CONTEXT" ]] || return 0
+    if ! command -v docker >/dev/null 2>&1; then
+        warn "Docker CLI is unavailable; cannot clean context '$TARGET_DOCKER_CONTEXT'."
+        return 1
+    fi
+    if docker_for_devbrain info >/dev/null 2>&1; then
+        return 0
+    fi
+
+    case "$TARGET_CONTAINER_RUNTIME" in
+        colima)
+            if ! command -v colima >/dev/null 2>&1; then
+                warn "Colima is unavailable; cannot start the selected Docker context."
+                return 1
+            fi
+            info "Starting Colima so its DevBrain data can be removed..."
+            colima start
+            ;;
+        docker-desktop)
+            info "Launching Docker Desktop so its DevBrain data can be removed..."
+            open -a Docker >/dev/null 2>&1 || true
+            ;;
+        orbstack)
+            info "Launching OrbStack so its DevBrain data can be removed..."
+            open -a OrbStack >/dev/null 2>&1 || true
+            ;;
+        docker-engine)
+            info "Starting Docker Engine so its DevBrain data can be removed..."
+            if command -v systemctl >/dev/null 2>&1; then
+                sudo systemctl start docker
+            elif command -v service >/dev/null 2>&1; then
+                sudo service docker start
+            fi
+            ;;
+    esac
+
+    local attempt=0
+    while (( attempt < 30 )); do
+        attempt=$((attempt + 1))
+        if docker_for_devbrain info >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    warn "Docker context '$TARGET_DOCKER_CONTEXT' did not become ready."
+    return 1
+}
+
 # ─── Banner & confirmation ──────────────────────────────────────────────────
 
 echo ""
@@ -82,13 +338,19 @@ echo -e "  ${RED}✗${RESET} /opt/homebrew/bin/devbrain  /opt/homebrew/bin/insta
 echo -e "  ${RED}✗${RESET} /usr/local/bin/devbrain  /usr/local/bin/install-devbrain (if present)"
 echo -e "  ${RED}✗${RESET} devbrain-db Docker container + volume (loses all DevBrain DB data)"
 echo -e "  ${RED}✗${RESET} ~/Library/LaunchAgents/com.devbrain.ingest.plist (launchd service)"
+echo -e "  ${RED}✗${RESET} $INSTALL_TARGET_PATH (recorded Docker target)"
+if [[ -f "$RESILIENCE_MANIFEST" ]]; then
+    echo -e "  ${RED}✗${RESET} Resilience service + files recorded in $RESILIENCE_MANIFEST"
+fi
 
 if $FULL_RESET; then
     echo ""
     echo -e "${YELLOW}--full flag set — also removing:${RESET}"
+    echo -e "  ${RED}✗${RESET} Docker Desktop application and data (if installed)"
     echo -e "  ${RED}✗${RESET} Ollama models (snowflake-arctic-embed2, qwen2.5:7b — ~10GB to redownload)"
     echo -e "  ${RED}✗${RESET} Homebrew itself (will be reinstalled fresh)"
     echo -e "  ${RED}✗${RESET} Xcode Command Line Tools (will be reinstalled fresh, slow)"
+    echo -e "  ${GREEN}✓${RESET} Colima/OrbStack VM disks are not wiped"
 fi
 
 echo ""
@@ -109,6 +371,37 @@ fi
 echo ""
 echo -e "${BOLD}[1] Stopping running services${RESET}"
 
+if [[ -d "$DEVBRAIN_HOME" || -f "$RESILIENCE_MANIFEST" \
+      || -f "$INSTALL_TARGET_PATH" || -n "$EXPLICIT_CONTAINER_RUNTIME" ]]; then
+    if ! _capture_container_target; then
+        warn "Refusing to delete DevBrain without its exact Docker target."
+        exit 1
+    fi
+    info "Using Docker context '$TARGET_DOCKER_CONTEXT' ($TARGET_CONTAINER_RUNTIME)."
+    if ! _prepare_selected_container_runtime; then
+        warn "Refusing to continue while DevBrain database cleanup is unavailable."
+        exit 1
+    fi
+fi
+
+if [[ -f "$RESILIENCE_MANIFEST" ]]; then
+    if [[ ! -f "$DEVBRAIN_HOME/scripts/install-resilience.sh" ]]; then
+        warn "Resilience is installed, but its manifest-aware uninstaller is missing:"
+        warn "  $DEVBRAIN_HOME/scripts/install-resilience.sh"
+        warn "Refusing to delete the repo and leave an unmanaged background service."
+        exit 1
+    fi
+    info "Uninstalling manifest-owned resilience service and files..."
+    if bash "$DEVBRAIN_HOME/scripts/install-resilience.sh" --uninstall --yes; then
+        ok "Resilience service uninstalled"
+    else
+        warn "Resilience uninstall failed. Resolve it before deleting DevBrain."
+        exit 1
+    fi
+else
+    skip "No resilience install manifest found"
+fi
+
 if launchctl list 2>/dev/null | grep -q com.devbrain.ingest; then
     info "Unloading launchd ingest service..."
     launchctl unload ~/Library/LaunchAgents/com.devbrain.ingest.plist 2>/dev/null || true
@@ -117,18 +410,195 @@ else
     skip "No launchd ingest service running"
 fi
 
-if docker ps 2>/dev/null | grep -q devbrain-db; then
-    info "Stopping devbrain-db container..."
-    if [[ -f "$DEVBRAIN_HOME/docker-compose.yml" ]]; then
-        (cd "$DEVBRAIN_HOME" && docker compose down -v 2>/dev/null) || docker stop devbrain-db
-    else
-        docker stop devbrain-db 2>/dev/null || true
+if [[ -n "$TARGET_DOCKER_CONTEXT" ]]; then
+    if ! command -v docker >/dev/null 2>&1; then
+        warn "Docker CLI disappeared before DevBrain data cleanup."
+        exit 1
     fi
-    docker rm devbrain-db 2>/dev/null || true
-    docker volume rm devbrain_devbrain-pgdata 2>/dev/null || true
-    ok "Container + volume removed"
+    if ! docker_for_devbrain info >/dev/null 2>&1; then
+        warn "Selected Docker context '$TARGET_DOCKER_CONTEXT' became unavailable."
+        exit 1
+    fi
+    devbrain_volumes=(
+        devbrain_devbrain-pgdata
+        devbrain_devbrain-wal-archive
+        devbrain-pgdata
+        devbrain-wal-archive
+    )
+
+    _inventory_contains() {
+        local needle="$1"
+        local inventory="$2"
+        local item
+        while IFS= read -r item; do
+            [[ "$item" == "$needle" ]] && return 0
+        done <<< "$inventory"
+        return 1
+    }
+
+    _append_devbrain_volume() {
+        local candidate="$1"
+        local existing
+        for existing in "${devbrain_volumes[@]}"; do
+            [[ "$existing" == "$candidate" ]] && return 0
+        done
+        devbrain_volumes+=("$candidate")
+    }
+
+    container_present=false
+    volume_present=false
+    container_inventory=""
+    volume_inventory=""
+    if ! container_inventory="$(
+        docker_for_devbrain container ls -a --format '{{.Names}}'
+    )"; then
+        warn "Could not inventory containers in the selected Docker context."
+        exit 1
+    fi
+    if ! volume_inventory="$(docker_for_devbrain volume ls -q)"; then
+        warn "Could not inventory volumes in the selected Docker context."
+        exit 1
+    fi
+
+    mounted_volumes=""
+    if _inventory_contains "devbrain-db" "$container_inventory"; then
+        container_present=true
+        if ! mounted_volumes="$(
+            docker_for_devbrain container inspect \
+            --format '{{range .Mounts}}{{if eq .Type "volume"}}{{println .Name}}{{end}}{{end}}' \
+            devbrain-db 2>/dev/null
+        )"; then
+            warn "Could not inspect the confirmed devbrain-db container."
+            exit 1
+        fi
+        while IFS= read -r volume; do
+            [[ -n "$volume" ]] || continue
+            if [[ ! "$volume" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]]; then
+                warn "Container reported an unsafe volume name; refusing cleanup."
+                exit 1
+            fi
+            _append_devbrain_volume "$volume"
+        done <<< "$mounted_volumes"
+    fi
+    for volume in "${devbrain_volumes[@]}"; do
+        if _inventory_contains "$volume" "$volume_inventory"; then
+            volume_present=true
+        fi
+    done
+    labeled_candidates=""
+    for logical_volume in devbrain-pgdata devbrain-wal-archive; do
+        labeled=""
+        if ! labeled="$(
+            docker_for_devbrain volume ls -q \
+                --filter "label=com.docker.compose.volume=$logical_volume"
+        )"; then
+            warn "Could not inspect labeled Compose volumes."
+            exit 1
+        fi
+        if [[ -n "$labeled" ]]; then
+            labeled_candidates+="${labeled_candidates:+$'\n'}$labeled"
+            volume_present=true
+        fi
+    done
+    labeled_services=""
+    if ! labeled_services="$(
+        docker_for_devbrain container ls -a -q \
+            --filter label=com.docker.compose.service=devbrain-db
+    )"; then
+        warn "Could not inspect labeled Compose services."
+        exit 1
+    fi
+
+    if $container_present || $volume_present || \
+       [[ -n "$labeled_candidates" || -n "$labeled_services" ]]; then
+        info "Removing devbrain-db container and volume..."
+        if $container_present; then
+            if ! docker_for_devbrain container rm -f -v \
+                devbrain-db >/dev/null 2>&1; then
+                warn "Could not remove the confirmed devbrain-db container."
+                exit 1
+            fi
+        fi
+
+        if ! volume_inventory="$(docker_for_devbrain volume ls -q)"; then
+            warn "Could not refresh the Docker volume inventory."
+            exit 1
+        fi
+        for volume in "${devbrain_volumes[@]}"; do
+            if _inventory_contains "$volume" "$volume_inventory"; then
+                if ! docker_for_devbrain volume rm "$volume" >/dev/null 2>&1; then
+                    warn "Could not remove confirmed DevBrain volume '$volume'."
+                    exit 1
+                fi
+            fi
+        done
+
+        if ! container_inventory="$(
+            docker_for_devbrain container ls -a --format '{{.Names}}'
+        )"; then
+            warn "Could not verify the post-cleanup container inventory."
+            exit 1
+        fi
+        if ! volume_inventory="$(docker_for_devbrain volume ls -q)"; then
+            warn "Could not verify the post-cleanup volume inventory."
+            exit 1
+        fi
+
+        cleanup_incomplete=false
+        if _inventory_contains "devbrain-db" "$container_inventory"; then
+            cleanup_incomplete=true
+        fi
+        for volume in "${devbrain_volumes[@]}"; do
+            if _inventory_contains "$volume" "$volume_inventory"; then
+                cleanup_incomplete=true
+            fi
+        done
+        leftover_services=""
+        if ! leftover_services="$(
+            docker_for_devbrain container ls -a -q \
+                --filter label=com.docker.compose.service=devbrain-db
+        )"; then
+            warn "Could not verify Compose service cleanup."
+            exit 1
+        fi
+        leftover_volumes=""
+        for logical_volume in devbrain-pgdata devbrain-wal-archive; do
+            labeled=""
+            if ! labeled="$(
+                docker_for_devbrain volume ls -q \
+                    --filter "label=com.docker.compose.volume=$logical_volume"
+            )"; then
+                warn "Could not verify Compose volume cleanup."
+                exit 1
+            fi
+            if [[ -n "$labeled" ]]; then
+                leftover_volumes+="${leftover_volumes:+$'\n'}$labeled"
+            fi
+        done
+        if [[ -n "$leftover_services" || -n "$leftover_volumes" ]]; then
+            cleanup_incomplete=true
+        fi
+        if $cleanup_incomplete; then
+            warn "DevBrain container data remains in Docker context '$TARGET_DOCKER_CONTEXT'."
+            if [[ -n "$leftover_volumes" ]]; then
+                warn "Labeled volumes still present:"
+                while IFS= read -r volume; do
+                    [[ -n "$volume" ]] && warn "  $volume"
+                done <<< "$leftover_volumes"
+            fi
+            exit 1
+        fi
+        ok "Container + volume removed"
+    else
+        skip "No devbrain-db container or volume found"
+    fi
 else
-    skip "No devbrain-db container running"
+    skip "Docker daemon unavailable; no recorded DevBrain context to clean"
+fi
+
+if [[ -f "$INSTALL_TARGET_PATH" ]]; then
+    rm -f "$INSTALL_TARGET_PATH"
+    ok "Removed recorded container target"
 fi
 
 # ─── Step 2: Remove shims ──────────────────────────────────────────────────
@@ -376,6 +846,7 @@ verify_failures=0
 
 _check_removed "DevBrain repo" "$DEVBRAIN_HOME" || ((verify_failures++))
 _check_removed "launchd plist" "$HOME/Library/LaunchAgents/com.devbrain.ingest.plist" || ((verify_failures++))
+_check_removed "container target metadata" "$INSTALL_TARGET_PATH" || ((verify_failures++))
 
 if $FULL_RESET; then
     _check_removed "Docker.app" "/Applications/Docker.app" || ((verify_failures++))


### PR DESCRIPTION
## What and why

Productizes the BrightBrain-style host resilience layer in DevBrain so Studio deployments can self-heal locally without requiring a VPS. Remote operations remain separate, explicit options for teams that have a VPS or operator host.

- adds workstation and always-on Studio resilience profiles
- adds bounded typed health checks/recovery for Docker, Postgres, Ollama, ingest, disk, and optional backup freshness
- makes heartbeat, tunnel monitoring, agent-bus health, and signed medic independently opt-in
- adds signed diagnose/heal tasks with Ed25519 roles, dual authorization for heal, expiry/nonce/replay checks, allowlisted typed actions, audit logs, lifecycle locking, and no inbound listener or arbitrary shell execution
- adds launchd/systemd installers, exact manifests, status/run-once CLI commands, setup wizard integration, upgrade/restart support, and operator documentation
- persists the exact Docker runtime/context across installer reruns; upgrade and reinstall fail closed on ambiguity, transport errors, conflicting metadata, or incomplete cleanup
- keeps workstation resilience opt-in; Studio defaults to local resilience on Colima; no VPS is required

## Safety and compatibility

- recovery uses typed argument vectors only
- failure thresholds, cooldowns, and maximum attempt budgets bound all healing
- installer/uninstaller paths are manifest-owned and validated
- medic consumers and lifecycle changes share locks; policy changes quarantine pending tasks
- reinstall removes only the exact DevBrain container and volumes proven by successful inventory or by its mount list
- legacy Docker Desktop aliases are deduplicated by full container ID; distinct or unprobeable backends are rejected

## Validation

- 100 focused resilience tests passed
- 309-test no-database installer/CLI regression suite passed
- ingest suite: 8 passed, 1 skipped
- Bash 3.2 syntax passed
- ShellCheck passed on changed shell surfaces
- Ruff and Python compilation passed
- independent installer, lifecycle-hardening, reinstall, and Docker-context reviews report no remaining blockers

## Remaining rollout gate

Draft pending a live Nooma Mac Studio fire drill and wiring of the SOHO heartbeat/tunnel credentials. The local-only installation path is complete and does not depend on those credentials.